### PR TITLE
Fixed compile-time error for stk BulkData constructor (extra argument)

### DIFF
--- a/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
@@ -180,7 +180,7 @@ void GenericSTKMeshStruct::SetupFieldData(
                                auto_aura_option,
                                //worksetSize, // capability currently removed from STK_Mesh
                                false, // add_fmwk_data
-                               NULL, // ConnectivityMap
+                               //NULL, // ConnectivityMap
                                NULL, // FieldDataManager
                                worksetSize));
   }

--- a/src/disc/stk/Albany_SideSetSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_SideSetSTKMeshStruct.cpp
@@ -102,7 +102,7 @@ SideSetSTKMeshStruct::SideSetSTKMeshStruct (const MeshSpecsStruct& inputMeshSpec
   const Teuchos::MpiComm<int>* mpiComm = dynamic_cast<const Teuchos::MpiComm<int>* > (commT.get());
   bulkData = Teuchos::rcp(new stk::mesh::BulkData(*metaData, *mpiComm->getRawMpiComm(),
                                                    stk::mesh::BulkData::NO_AUTO_AURA,
-                                                   false, NULL, NULL, worksetSize));
+                                                   false, /*NULL,*/ NULL, worksetSize));
 }
 
 SideSetSTKMeshStruct::~SideSetSTKMeshStruct()


### PR DESCRIPTION
Changes to `stk::mesh::BulkData` constructor left an extra argument in the Albany code.  Aeras and DemoPDEs enabled.  Ctest results:


```
94% tests passed, 8 tests failed out of 141

Label Time Summary:
Aeras          = 921.10 sec*proc (26 tests)
Analysis       = 141.95 sec*proc (5 tests)
Basic          = 559.37 sec*proc (78 tests)
Demo           = 1189.46 sec*proc (30 tests)
Epetra         = 554.07 sec*proc (54 tests)
Forward        = 2534.42 sec*proc (133 tests)
ROL            = 140.36 sec*proc (3 tests)
RegressFail    = 142.29 sec*proc (3 tests)
Rythmos        =  33.32 sec*proc (3 tests)
SCOREC         =   6.45 sec*proc (4 tests)
Serial         = 246.59 sec*proc (10 tests)
Tempus         =  25.19 sec*proc (2 tests)
Tpetra         = 2122.30 sec*proc (84 tests)

Total Test time (real) = 2712.94 sec

The following tests FAILED:
	 20 - SteadyHeatConstrainedOpt2D_Conductivity_Dist_Param_Restart_Tpetra (Failed)
	 22 - SteadyHeatConstrainedOpt2D_Conductivity_Dist_Param_Restart_Epetra (Failed)
	 68 - Ioss2D_SerialInput_Epetra (Failed)
	 69 - Ioss2D_SerialInput_Tpetra (Failed)
	 94 - LinComprNS_3DUnsteadyNS (Failed)
	103 - CahnHillElast2D_Rythmos_Epetra (Failed)
	104 - CahnHillElast2D_Rythmos_Tpetra (Failed)
	105 - CahnHillElast2D_Tempus (Failed)
```