### PR TITLE
changes for phalanx mdfield refactor

### DIFF
--- a/src/PHAL_Dimension.cpp
+++ b/src/PHAL_Dimension.cpp
@@ -8,52 +8,22 @@
 
 #include "PHAL_Dimension.hpp"
 
-const char * Dim::name() const
-{ static const char n[] = "Dim" ; return n ; }
-const Dim & Dim::tag()
-{ static const Dim myself ; return myself ; }
+const char * DIM::name() const
+{ static const char n[] = "DIM" ; return n ; }
+const DIM & DIM::tag()
+{ static const DIM myself ; return myself ; }
 
-const char * VecDim::name() const
-{ static const char n[] = "VecDim" ; return n ; }
-const VecDim & VecDim::tag()
-{ static const VecDim myself ; return myself ; }
+const char * QP::name() const
+{ static const char n[] = "QP" ; return n ; }
+const QP & QP::tag()
+{ static const QP myself ; return myself ; }
 
-const char * LayerDim::name() const
-{ static const char n[] = "LayerDim" ; return n ; }
-const LayerDim & LayerDim::tag()
-{ static const LayerDim myself ; return myself ; }
+const char * NODE::name() const
+{ static const char n[] = "NODE" ; return n ; }
+const NODE & NODE::tag()
+{ static const NODE myself ; return myself ; }
 
-const char * QuadPoint::name() const
-{ static const char n[] = "QuadPoint" ; return n ; }
-const QuadPoint & QuadPoint::tag()
-{ static const QuadPoint myself ; return myself ; }
-
-const char * Node::name() const
-{ static const char n[] = "Node" ; return n ; }
-const Node & Node::tag()
-{ static const Node myself ; return myself ; }
-
-const char * Vertex::name() const
-{ static const char n[] = "Vertex" ; return n ; }
-const Vertex & Vertex::tag()
-{ static const Vertex myself ; return myself ; }
-
-const char * Point::name() const
-{ static const char n[] = "Point" ; return n ; }
-const Point & Point::tag()
-{ static const Point myself ; return myself ; }
-
-const char * Cell::name() const
-{ static const char n[] = "Cell" ; return n ; }
-const Cell & Cell::tag()
-{ static const Cell myself ; return myself ; }
-
-const char * Side::name() const
-{ static const char n[] = "Side" ; return n; }
-const Side & Side::tag()
-{static const Side myself ; return myself; }
-
-const char * Dummy::name() const
-{ static const char n[] = "Dummy" ; return n ; }
-const Dummy & Dummy::tag()
-{ static const Dummy myself ; return myself ; }
+const char * CELL::name() const
+{ static const char n[] = "CELL" ; return n ; }
+const CELL & CELL::tag()
+{ static const CELL myself ; return myself ; }

--- a/src/PHAL_Dimension.hpp
+++ b/src/PHAL_Dimension.hpp
@@ -10,64 +10,54 @@
 #define PHAL_DIMENSION_HPP
 
 #include "Shards_Array.hpp"
+#include "Phalanx_ExtentTraits.hpp"
 
-struct Dim : public shards::ArrayDimTag {
-  Dim(){};
+struct Dim {};
+struct VecDim {};
+struct LayerDim {};
+struct QuadPoint {};
+struct Node {};
+struct Vertex {};
+struct Point {};
+struct Cell {};
+struct Side {};
+struct Dummy {};
+
+namespace PHX {
+  template<> struct is_extent<Dim> : std::true_type {};
+  template<> struct is_extent<VecDim> : std::true_type {};
+  template<> struct is_extent<LayerDim> : std::true_type {};
+  template<> struct is_extent<QuadPoint> : std::true_type {};
+  template<> struct is_extent<Node> : std::true_type {};
+  template<> struct is_extent<Vertex> : std::true_type {};
+  template<> struct is_extent<Point> : std::true_type {};
+  template<> struct is_extent<Cell> : std::true_type {};
+  template<> struct is_extent<Side> : std::true_type {};
+  template<> struct is_extent<Dummy> : std::true_type {};
+}
+
+struct DIM : public shards::ArrayDimTag {
+  DIM(){};
   const char * name() const ;
-  static const Dim& tag();
+  static const DIM& tag();
 };
 
-struct VecDim : public shards::ArrayDimTag {
-  VecDim(){};
+struct QP : public shards::ArrayDimTag {
+  QP(){};
   const char * name() const ;
-  static const VecDim& tag();
+  static const QP& tag();
 };
 
-struct LayerDim : public shards::ArrayDimTag {
-  LayerDim(){};
+struct NODE : public shards::ArrayDimTag {
+  NODE(){};
   const char * name() const ;
-  static const LayerDim& tag();
+  static const NODE& tag();
 };
 
-struct QuadPoint : public shards::ArrayDimTag {
-  QuadPoint(){};
+struct CELL : public shards::ArrayDimTag {
+  CELL(){};
   const char * name() const ;
-  static const QuadPoint& tag();
+  static const CELL& tag();
 };
 
-struct Node : public shards::ArrayDimTag {
-  Node(){};
-  const char * name() const ;
-  static const Node& tag();
-};
-
-struct Vertex : public shards::ArrayDimTag {
-  Vertex(){};
-  const char * name() const ;
-  static const Vertex& tag();
-};
-
-struct Point : public shards::ArrayDimTag {
-  Point(){};
-  const char * name() const ;
-  static const Point& tag();
-};
-
-struct Cell : public shards::ArrayDimTag {
-  Cell(){};
-  const char * name() const ;
-  static const Cell& tag();
-};
-
-struct Side : public shards::ArrayDimTag {
-  Side(){};
-  const char * name() const;
-  static const Side& tag();
-};
-
-struct Dummy : public shards::ArrayDimTag {
-  Dummy(){};
-  const char * name() const ;
-  static const Dummy& tag();
-};
 #endif

--- a/src/adapt/AAdapt_RC_Manager.cpp
+++ b/src/adapt/AAdapt_RC_Manager.cpp
@@ -959,7 +959,7 @@ void testProjector (
     new Layout(workset.numCells, coord_qp.dimension(1),
                coord_qp.dimension(2), coord_qp.dimension(2)));
   PHX::MDField<RealType> f_mdf = PHX::MDField<RealType>("f_mdf", layout);
-  auto f_mdf_data = PHX::KokkosViewFactory<RealType, PHX::Device>::buildView(f_mdf.fieldTag());
+  auto f_mdf_data = PHX::KokkosViewFactory<RealType, typename PHX::DevLayout<RealType>::type, PHX::Device>::buildView(f_mdf.fieldTag());
   f_mdf.setFieldData(f_mdf_data);
     
   std::vector<Albany::MDArray> mda;
@@ -968,7 +968,7 @@ void testProjector (
     typedef Albany::MDArray::size_type size_t;
     mda_data[i].resize(f_mdf.dimension(0) * f_mdf.dimension(1) *
                        f_mdf.dimension(2) * f_mdf.dimension(3));
-    shards::Array<RealType, shards::NaturalOrder, Cell, QuadPoint, Dim, Dim> a;
+    shards::Array<RealType, shards::NaturalOrder, CELL, QP, DIM, DIM> a;
     a.assign(&mda_data[i][0], (size_t) f_mdf.dimension(0),
              (size_t) f_mdf.dimension(1), (size_t) f_mdf.dimension(2),
              (size_t) f_mdf.dimension(3));
@@ -1169,7 +1169,7 @@ fillRhs (const PHAL::Workset& workset, const Manager::BasisField& wbf,
   Teuchos::RCP<Layout> layout = Teuchos::rcp(
     new Layout(workset.numCells, num_qp, num_dim, num_dim));
   PHX::MDField<RealType> f_mdf = PHX::MDField<RealType>("f_mdf", layout);
-  auto f_mdf_data = PHX::KokkosViewFactory<RealType, PHX::Device>::buildView(f_mdf.fieldTag());
+  auto f_mdf_data = PHX::KokkosViewFactory<RealType, typename PHX::DevLayout<RealType>::type,PHX::Device>::buildView(f_mdf.fieldTag());
   f_mdf.setFieldData(f_mdf_data);
 
   for (int test = 0; test < Impl::ntests; ++test) {
@@ -1225,7 +1225,7 @@ interp (const PHAL::Workset& workset, const Manager::BasisField& bf,
   for (int i = 0; i < 2; ++i) {
     typedef Albany::MDArray::size_type size_t;
     mda_data[i].resize(workset.numCells * num_qp * num_dim * num_dim);
-    shards::Array<RealType, shards::NaturalOrder, Cell, QuadPoint, Dim, Dim> a;
+    shards::Array<RealType, shards::NaturalOrder, CELL, QP, DIM, DIM> a;
     a.assign(&mda_data[i][0], workset.numCells, num_qp, num_dim, num_dim);
     mda.push_back(a);
   }

--- a/src/disc/pumi/Albany_PUMINodeData.hpp
+++ b/src/disc/pumi/Albany_PUMINodeData.hpp
@@ -92,7 +92,7 @@ template <typename T>
 struct PUMINodeData_Traits<T, 1> {
 
   enum { size = 1 }; // One array dimension tags: number of nodes in workset
-  typedef shards::Array<T, shards::NaturalOrder, Node> field_type ;
+  typedef shards::Array<T, shards::NaturalOrder, NODE> field_type ;
   static field_type buildArray(T *buf, unsigned nelems, const std::vector<PHX::DataLayout::size_type>& dims){
 
     return field_type(buf, nelems);
@@ -106,7 +106,7 @@ template <typename T>
 struct PUMINodeData_Traits<T, 2> {
 
   enum { size = 2 }; // Two array dimension tags: Nodes and vec dim
-  typedef shards::Array<T, shards::NaturalOrder, Node, Dim> field_type ;
+  typedef shards::Array<T, shards::NaturalOrder, NODE, DIM> field_type ;
   static field_type buildArray(T *buf, unsigned nelems, const std::vector<PHX::DataLayout::size_type>& dims){
 
     return field_type(buf, nelems, dims[1]);
@@ -120,7 +120,7 @@ template <typename T>
 struct PUMINodeData_Traits<T, 3> {
 
   enum { size = 3 }; // Three array dimension tags: Nodes, Dim and Dim
-  typedef shards::Array<T, shards::NaturalOrder, Node, Dim, Dim> field_type ;
+  typedef shards::Array<T, shards::NaturalOrder, NODE, DIM, DIM> field_type ;
   static field_type buildArray(T *buf, unsigned nelems, const std::vector<PHX::DataLayout::size_type>& dims){
 
     return field_type(buf, nelems, dims[1], dims[2]);

--- a/src/disc/pumi/Albany_PUMIQPData.hpp
+++ b/src/disc/pumi/Albany_PUMIQPData.hpp
@@ -55,7 +55,7 @@ namespace Albany {
   struct PUMIQPData_Traits<T, 1> {
 
     enum { size = 1 }; // One array dimension tags: Cell
-    typedef shards::Array<T, shards::NaturalOrder, Cell> field_type ;
+    typedef shards::Array<T, shards::NaturalOrder, CELL> field_type ;
     static Albany::MDArray buildArray(T *buf, unsigned nelems, std::vector<PHX::DataLayout::size_type>& dims){
 
       return field_type(buf, nelems);
@@ -69,7 +69,7 @@ namespace Albany {
   struct PUMIQPData_Traits<T, 2> {
 
     enum { size = 2 }; // Two array dimension tags: Cell and QuadPoint
-    typedef shards::Array<T, shards::NaturalOrder, Cell, QuadPoint> field_type ;
+    typedef shards::Array<T, shards::NaturalOrder, CELL, QP> field_type ;
     static Albany::MDArray buildArray(T *buf, unsigned nelems, std::vector<PHX::DataLayout::size_type>& dims){
 
       return field_type(buf, nelems, dims[1]);
@@ -83,7 +83,7 @@ namespace Albany {
   struct PUMIQPData_Traits<T, 3> {
 
     enum { size = 3 }; // Three array dimension tags: Cell, QuadPoint, and Dim
-    typedef shards::Array<T, shards::NaturalOrder, Cell, QuadPoint, Dim> field_type ;
+    typedef shards::Array<T, shards::NaturalOrder, CELL, QP, DIM> field_type ;
     static Albany::MDArray buildArray(T *buf, unsigned nelems, std::vector<PHX::DataLayout::size_type>& dims){
 
       return field_type(buf, nelems, dims[1], dims[2]);
@@ -97,7 +97,7 @@ namespace Albany {
   struct PUMIQPData_Traits<T, 4> {
 
     enum { size = 4 }; // Four array dimension tags: Cell, QuadPoint, Dim, and Dim
-    typedef shards::Array<T, shards::NaturalOrder, Cell, QuadPoint, Dim, Dim> field_type ;
+    typedef shards::Array<T, shards::NaturalOrder, CELL, QP, DIM, DIM> field_type ;
     static Albany::MDArray buildArray(T *buf, unsigned nelems, std::vector<PHX::DataLayout::size_type>& dims){
 
       return field_type(buf, nelems, dims[1], dims[2], dims[3]);

--- a/src/disc/stk/Aeras_SpectralDiscretization.cpp
+++ b/src/disc/stk/Aeras_SpectralDiscretization.cpp
@@ -2365,7 +2365,7 @@ void Aeras::SpectralDiscretization::computeWorksetInfo()
          svs != scalarValue_states.end(); ++svs)
     {
       const int size = 1;
-      shards::Array<double, shards::NaturalOrder, Cell> array(&time[**svs], size);
+      shards::Array<double, shards::NaturalOrder, CELL> array(&time[**svs], size);
       // Debug
       // std::cout << "Buck.size(): " << buck.size() << " SVState dim[0]: "
       //           << array.extent(0) << std::endl;

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -2257,7 +2257,7 @@ STKDiscretization::computeWorksetInfo()
     //              svs != scalarValue_states.end(); ++svs){
     for (size_t i = 0; i < scalarValue_states.size(); i++) {
       const int                                         size = 1;
-      shards::Array<double, shards::NaturalOrder, Cell> array(
+      shards::Array<double, shards::NaturalOrder, CELL> array(
           &time[*scalarValue_states[i]], size);
       MDArray ar = array;
       // Debug


### PR DESCRIPTION
The following PR in Trilinos is a major refactor of the MDField internals. The DimTag object requirement has been removed. This PR contains changes needed for Albany when the Trilinos push goes through. The PR has passed the autotester and has been tested on cuda and against drekar, charon and empire as well. I'd like to push on Monday morning unless you would like to do more testing of Albany with this branch and the Trilinos PR. I did a simple build of Albany but don't have access to PUMA, so you might want to run more tests than the default build. Can anyone help with this?

https://github.com/trilinos/Trilinos/pull/5520

@ikalash @mperego @bartgol 