### PR TITLE
Attempt to fix slowdown in Epetra build (issue #519)

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -1477,6 +1477,14 @@ Application::computeGlobalJacobianImpl(
                   this, ps, explicit_scheme));
     }
 
+#ifdef ALBANY_KOKKOS_UNDER_DEVELOPMENT
+    if (!workset.f.is_null()) {
+      workset.f_kokkos = getNonconstDeviceData(workset.f);
+    }
+    if (!workset.Jac.is_null()) {
+      workset.Jac_kokkos = getNonconstDeviceData(workset.Jac);
+    }
+#endif
     for (int ws = 0; ws < numWorksets; ws++) {
       loadWorksetBucketInfo<PHAL::AlbanyTraits::Jacobian>(workset, ws);
       // FillType template argument used to specialize Sacado

--- a/src/PHAL_Workset.hpp
+++ b/src/PHAL_Workset.hpp
@@ -81,6 +81,9 @@ struct Workset
   Teuchos::RCP<Thyra_MultiVector> fpV;
   Teuchos::RCP<Thyra_MultiVector> Vp_bc;
 
+  Albany::DeviceView1d<ST>        f_kokkos;
+  Albany::DeviceLocalMatrix<ST>   Jac_kokkos;
+
   Teuchos::RCP<const Albany::NodeSetList>      nodeSets;
   Teuchos::RCP<const Albany::NodeSetCoordList> nodeSetCoords;
 

--- a/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
@@ -488,10 +488,10 @@ template<typename Traits>
 void ScatterResidual<PHAL::AlbanyTraits::Jacobian, Traits>::
 evaluateFields(typename Traits::EvalData workset)
 {
+#ifndef ALBANY_KOKKOS_UNDER_DEVELOPMENT
   Teuchos::RCP<Thyra_Vector>   f   = workset.f;
   Teuchos::RCP<Thyra_LinearOp> Jac = workset.Jac;
 
-#ifndef ALBANY_KOKKOS_UNDER_DEVELOPMENT
   auto nodeID = workset.wsElNodeEqID;
   const bool loadResid = Teuchos::nonnull(f);
   Teuchos::Array<LO> col;
@@ -553,12 +553,12 @@ evaluateFields(typename Traits::EvalData workset)
   neq = nodeID.extent(2);
   nunk = neq*this->numNodes;
 
-  // Get Tpetra vector view and local matrix
+  // Get Kokkos vector view and local matrix
   const bool loadResid = Teuchos::nonnull(workset.f);
   if (loadResid) {
-    f_kokkos = Albany::getNonconstDeviceData(workset.f);
+    f_kokkos = workset.f_kokkos;
   }
-  Jac_kokkos = Albany::getNonconstDeviceData(workset.Jac);
+  Jac_kokkos = workset.Jac_kokkos;
 
   if (this->tensorRank == 0) {
     // Get MDField views from std::vector


### PR DESCRIPTION
This mini PR attempts to remove (or limit) the slowdown observed in some Epetra test cases (see #519).

In particular, we avoid creating a Kokkos view of the local matrix at every call to evaluateFields during the Jacobian scattering. Instead, we preload the kokkos device data once from the Application side _before_ calling the evaluation method.

@ikalash Can you please try this fix with your timers and see if it improves a bit the performance?