### PR TITLE
PHAL::SDirichletField class and fixes/additions to PHAL::SDirichlet

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -1680,6 +1680,9 @@ Application::computeGlobalJacobianImpl(
 
     dfm_set(workset, x, xdot, xdotdot, rc_mgr);
 
+    if(problem->useSDBCs() == true)
+      dfm->preEvaluate<EvalT>(workset);
+
     loadWorksetNodesetInfo(workset);
 
     if (scaleBCdofs == true) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -295,6 +295,7 @@ SET(SOURCES ${SOURCES}
   evaluators/bc/PHAL_SDirichlet.cpp
   evaluators/bc/PHAL_DirichletCoordinateFunction.cpp
   evaluators/bc/PHAL_DirichletField.cpp
+  evaluators/bc/PHAL_SDirichletField.cpp
   evaluators/bc/PHAL_DirichletOffNodeSet.cpp
   evaluators/bc/PHAL_IdentityCoordinateFunctionTraits.cpp
   evaluators/bc/PHAL_Neumann.cpp
@@ -413,6 +414,8 @@ SET(HEADERS ${HEADERS}
   evaluators/bc/PHAL_DirichletCoordinateFunction_Def.hpp
   evaluators/bc/PHAL_DirichletField.hpp
   evaluators/bc/PHAL_DirichletField_Def.hpp
+  evaluators/bc/PHAL_SDirichletField.hpp
+  evaluators/bc/PHAL_SDirichletField_Def.hpp
   evaluators/bc/PHAL_DirichletOffNodeSet.hpp
   evaluators/bc/PHAL_DirichletOffNodeSet_Def.hpp
   evaluators/bc/PHAL_Dirichlet_Def.hpp

--- a/src/PHAL_FactoryTraits.hpp
+++ b/src/PHAL_FactoryTraits.hpp
@@ -33,6 +33,7 @@
 #include "PHAL_TimeDepSDBC.hpp"
 #include "PHAL_DirichletCoordinateFunction.hpp"
 #include "PHAL_DirichletField.hpp"
+#include "PHAL_SDirichletField.hpp"
 #include "PHAL_DirichletOffNodeSet.hpp"
 #include "PHAL_GatherCoordinateVector.hpp"
 #include "PHAL_GatherScalarNodalParameter.hpp"
@@ -72,12 +73,13 @@ namespace PHAL {
     static const int id_timedep_bc                     =  5; // Only for LCM probs
     static const int id_timedep_sdbc                   =  6; // Only for LCM probs
     static const int id_sdbc                           =  7;
-    static const int id_kfield_bc                      =  8; // Only for LCM probs
-    static const int id_eq_concentration_bc            =  9; // Only for LCM probs
-    static const int id_time                           = 10; // Only for LCM probs
-    static const int id_torsion_bc                     = 11; // Only for LCM probs
-    static const int id_schwarz_bc                     = 12; // Only for LCM probs
-    static const int id_strong_schwarz_bc              = 13; // Only for LCM probs
+    static const int id_sdirichlet_field               =  8;
+    static const int id_kfield_bc                      =  9; // Only for LCM probs
+    static const int id_eq_concentration_bc            = 10; // Only for LCM probs
+    static const int id_time                           = 11; // Only for LCM probs
+    static const int id_torsion_bc                     = 12; // Only for LCM probs
+    static const int id_schwarz_bc                     = 13; // Only for LCM probs
+    static const int id_strong_schwarz_bc              = 14; // Only for LCM probs
 
     typedef Sacado::mpl::vector<
         PHAL::Dirichlet<_,Traits>,                //  0
@@ -87,19 +89,20 @@ namespace PHAL {
         PHAL::DirichletOffNodeSet<_,Traits>,      //  4
         PHAL::TimeDepDBC<_, Traits>,              //  5
         PHAL::TimeDepSDBC<_, Traits>,             //  6
-        PHAL::SDirichlet<_, Traits>               //  7
+        PHAL::SDirichlet<_, Traits>,              //  7
+        PHAL::SDirichletField<_, Traits>          //  8
 #if defined(ALBANY_LCM)
         ,
-        LCM::KfieldBC<_,Traits>,                  //  8
-        LCM::EquilibriumConcentrationBC<_,Traits>, // 9
-        LCM::Time<_, Traits>,                     //  10
-        LCM::TorsionBC<_, Traits>                  // 11
+        LCM::KfieldBC<_,Traits>,                   //  9
+        LCM::EquilibriumConcentrationBC<_,Traits>, // 10
+        LCM::Time<_, Traits>,                      // 11
+        LCM::TorsionBC<_, Traits>                  // 12
 #endif
 #if defined(ALBANY_LCM) && defined(ALBANY_STK) 
         ,
-        LCM::SchwarzBC<_, Traits>,                 // 12
-        LCM::StrongSchwarzBC<_, Traits>,           // 13
-        LCM::PDNeighborFitBC<_, Traits>            // 14
+        LCM::SchwarzBC<_, Traits>,                 // 13
+        LCM::StrongSchwarzBC<_, Traits>,           // 14
+        LCM::PDNeighborFitBC<_, Traits>            // 15
 #endif
         > EvaluatorTypes;
 };

--- a/src/evaluators/bc/PHAL_SDirichlet.hpp
+++ b/src/evaluators/bc/PHAL_SDirichlet.hpp
@@ -64,6 +64,9 @@ class SDirichlet<PHAL::AlbanyTraits::Jacobian, Traits>
   SDirichlet(Teuchos::ParameterList& p);
 
   void
+  preEvaluate(typename Traits::EvalData d);
+
+  void
   evaluateFields(typename Traits::EvalData d);
 
   void
@@ -85,6 +88,9 @@ class SDirichlet<PHAL::AlbanyTraits::Tangent, Traits>
   using ScalarT = typename PHAL::AlbanyTraits::Tangent::ScalarT;
 
   SDirichlet(Teuchos::ParameterList& p);
+
+  void
+  preEvaluate(typename Traits::EvalData d);
 
   void
   evaluateFields(typename Traits::EvalData d);

--- a/src/evaluators/bc/PHAL_SDirichletField.cpp
+++ b/src/evaluators/bc/PHAL_SDirichletField.cpp
@@ -1,0 +1,13 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#include "PHAL_AlbanyTraits.hpp"
+
+#include "PHAL_SDirichletField.hpp"
+#include "PHAL_SDirichletField_Def.hpp"
+
+PHAL_INSTANTIATE_TEMPLATE_CLASS(PHAL::SDirichletField)
+

--- a/src/evaluators/bc/PHAL_SDirichletField.hpp
+++ b/src/evaluators/bc/PHAL_SDirichletField.hpp
@@ -1,0 +1,120 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef PHAL_SDIRICHLET_FIELD_HPP
+#define PHAL_SDIRICHLET_FIELD_HPP
+
+#include "Phalanx_config.hpp"
+#include "Phalanx_Evaluator_WithBaseImpl.hpp"
+#include "Phalanx_Evaluator_Derived.hpp"
+#include "Phalanx_MDField.hpp"
+#include "Teuchos_ParameterList.hpp"
+#include "Sacado_ParameterAccessor.hpp"
+
+#include "PHAL_AlbanyTraits.hpp"
+#include "PHAL_Dirichlet.hpp"
+#include "PHAL_IdentityCoordinateFunctionTraits.hpp"
+
+namespace PHAL {
+
+
+
+// **************************************************************
+// **************************************************************
+// * Specialization of the DirichletBase class
+// **************************************************************
+// **************************************************************
+
+/// Strong Dirichlet boundary condition evaluator prescribing a field
+/// Note, the field must be available before the volume field manager evaluation
+
+template<typename EvalT, typename Traits>
+class SDirichletField;
+
+template <typename EvalT, typename Traits>
+class SDirichletField_Base : public PHAL::DirichletBase<EvalT, Traits> {
+  public:
+    typedef typename EvalT::ScalarT ScalarT;
+    SDirichletField_Base(Teuchos::ParameterList& p);
+
+  protected:
+    /// name of the field used to prescribe boundary conditions
+    /// Note, the field must be available before the volume field manager evaluation
+    std::string field_name;
+};
+
+// **************************************************************
+// Residual
+// **************************************************************
+template<typename Traits>
+class SDirichletField<PHAL::AlbanyTraits::Residual, Traits>
+    : public SDirichletField_Base<PHAL::AlbanyTraits::Residual, Traits> {
+  public:
+    using ScalarT = typename PHAL::AlbanyTraits::Residual::ScalarT;
+
+    SDirichletField(Teuchos::ParameterList& p);
+
+    void preEvaluate(typename Traits::EvalData d);
+
+    void evaluateFields(typename Traits::EvalData d);
+};
+
+// **************************************************************
+// Jacobian
+// **************************************************************
+template<typename Traits>
+class SDirichletField<PHAL::AlbanyTraits::Jacobian, Traits>
+    : public SDirichletField_Base<PHAL::AlbanyTraits::Jacobian, Traits> {
+  public:
+    using ScalarT = typename PHAL::AlbanyTraits::Jacobian::ScalarT;
+
+    SDirichletField(Teuchos::ParameterList& p);
+
+    void preEvaluate(typename Traits::EvalData d);
+
+    void evaluateFields(typename Traits::EvalData d);
+
+    void set_row_and_col_is_dbc(typename Traits::EvalData d);
+
+   protected:
+    Teuchos::RCP<Thyra_Vector> row_is_dbc_;
+    Teuchos::RCP<Thyra_Vector> col_is_dbc_;
+};
+
+// **************************************************************
+// Tangent
+// **************************************************************
+template<typename Traits>
+class SDirichletField<PHAL::AlbanyTraits::Tangent, Traits>
+    : public SDirichletField_Base<PHAL::AlbanyTraits::Tangent, Traits> {
+  public:
+    using ScalarT = typename PHAL::AlbanyTraits::Tangent::ScalarT;
+
+    void preEvaluate(typename Traits::EvalData d);
+
+    SDirichletField(Teuchos::ParameterList& p);
+
+    void evaluateFields(typename Traits::EvalData d);
+};
+
+// **************************************************************
+// Distributed Parameter Derivative
+//  -- Currently assuming no parameter derivative
+// **************************************************************
+template<typename Traits>
+class SDirichletField<PHAL::AlbanyTraits::DistParamDeriv, Traits>
+    : public SDirichletField_Base<PHAL::AlbanyTraits::DistParamDeriv, Traits> {
+  public:
+    using ScalarT = typename PHAL::AlbanyTraits::DistParamDeriv::ScalarT;
+
+    SDirichletField(Teuchos::ParameterList& p);
+
+    void evaluateFields(typename Traits::EvalData d);
+};
+
+}
+
+#endif

--- a/src/evaluators/bc/PHAL_SDirichletField_Def.hpp
+++ b/src/evaluators/bc/PHAL_SDirichletField_Def.hpp
@@ -1,0 +1,394 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#include "Teuchos_TestForException.hpp"
+#include "Phalanx_DataLayout.hpp"
+#include "Sacado_ParameterRegistration.hpp"
+
+#include "Albany_ThyraUtils.hpp"
+#include "Albany_NodalDOFManager.hpp"
+#include "Albany_DistributedParameterLibrary.hpp"
+#include "Albany_AbstractDiscretization.hpp"
+#include "Albany_GlobalLocalIndexer.hpp"
+
+#include "PHAL_SDirichletField.hpp"
+
+#include "Albany_TpetraThyraUtils.hpp"
+
+// **********************************************************************
+// Genereric Template Code for Constructor and PostRegistrationSetup
+// **********************************************************************
+
+namespace PHAL {
+
+template <typename EvalT, typename Traits>
+SDirichletField_Base<EvalT, Traits>::
+SDirichletField_Base(Teuchos::ParameterList& p) :
+  PHAL::DirichletBase<EvalT, Traits>(p) {
+
+  // Get field type and corresponding layouts
+  field_name = p.get<std::string>("Field Name");
+}
+
+// **********************************************************************
+// Specialization: Residual
+// **********************************************************************
+template<typename Traits>
+SDirichletField<PHAL::AlbanyTraits::Residual, Traits>::
+SDirichletField(Teuchos::ParameterList& p) :
+  SDirichletField_Base<PHAL::AlbanyTraits::Residual, Traits>(p) {
+}
+
+template<typename Traits>
+void
+SDirichletField<PHAL::AlbanyTraits::Residual, Traits>::preEvaluate(
+    typename Traits::EvalData dirichlet_workset)
+{
+#ifdef DEBUG_OUTPUT
+  Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::VerboseObjectBase::getDefaultOStream();
+  *out << "SDirichletField preEvaluate Residual\n";
+#endif
+  Teuchos::RCP<const Thyra_Vector> x = dirichlet_workset.x;
+  Teuchos::ArrayRCP<ST> x_view = Teuchos::arcp_const_cast<ST>(Albany::getLocalData(x));
+
+  const Albany::NodalDOFManager& fieldDofManager = dirichlet_workset.disc->getDOFManager(this->field_name);
+  //MP: If the parameter is scalar, then the parameter offset is set to zero. Otherwise the parameter offset is the same of the solution's one.
+  auto fieldNodeVs = dirichlet_workset.disc->getNodeVectorSpace(this->field_name);
+  auto fieldVs = dirichlet_workset.disc->getVectorSpace(this->field_name);
+  bool isFieldScalar = (fieldNodeVs->dim() == fieldVs->dim());
+  int fieldOffset = isFieldScalar ? 0 : this->offset;
+  const std::vector<GO>& nsNodesGIDs = dirichlet_workset.disc->getNodeSetGIDs().find(this->nodeSetID)->second;
+
+  Teuchos::RCP<const Thyra_Vector> pvec = dirichlet_workset.distParamLib->get(this->field_name)->vector();
+  Teuchos::ArrayRCP<const ST> p_constView = Albany::getLocalData(pvec);
+
+  const std::vector<std::vector<int> >& nsNodes = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
+  auto field_node_indexer = Albany::createGlobalLocalIndexer(fieldNodeVs);
+  for (unsigned int inode = 0; inode < nsNodes.size(); inode++) {
+      int lunk = nsNodes[inode][this->offset];
+      GO node_gid = nsNodesGIDs[inode];
+      int lfield = fieldDofManager.getLocalDOF(field_node_indexer->getLocalElement(node_gid),fieldOffset);
+      x_view[lunk] = p_constView[lfield];
+  }
+}
+
+
+
+// **********************************************************************
+template<typename Traits>
+void
+SDirichletField<PHAL::AlbanyTraits::Residual, Traits>::
+evaluateFields(typename Traits::EvalData dirichlet_workset) {
+  Teuchos::RCP<Thyra_Vector> f      = dirichlet_workset.f;
+  Teuchos::ArrayRCP<ST>      f_view = Albany::getNonconstLocalData(f);
+
+  // Grab the vector of node GIDs for this Node Set ID
+  auto&  ns_nodes = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
+
+  for (size_t ns_node = 0; ns_node < ns_nodes.size(); ns_node++) {
+    int const dof = ns_nodes[ns_node][this->offset];
+    f_view[dof]   = 0.0;
+  }
+}
+
+// **********************************************************************
+// Specialization: Jacobian
+// **********************************************************************
+template<typename Traits>
+SDirichletField<PHAL::AlbanyTraits::Jacobian, Traits>::
+SDirichletField(Teuchos::ParameterList& p) :
+  SDirichletField_Base<PHAL::AlbanyTraits::Jacobian, Traits>(p) {
+}
+
+template<typename Traits>
+void
+SDirichletField<PHAL::AlbanyTraits::Jacobian, Traits>::preEvaluate(
+    typename Traits::EvalData dirichlet_workset)
+{
+#ifdef DEBUG_OUTPUT
+  Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::VerboseObjectBase::getDefaultOStream();
+  *out << "SDirichletField preEvaluate Jacobian\n";
+#endif
+  if(Teuchos::nonnull(dirichlet_workset.f)) {
+    Teuchos::RCP<const Thyra_Vector> x = dirichlet_workset.x;
+    Teuchos::ArrayRCP<ST> x_view = Teuchos::arcp_const_cast<ST>(Albany::getLocalData(x));
+
+    const Albany::NodalDOFManager& fieldDofManager = dirichlet_workset.disc->getDOFManager(this->field_name);
+    //MP: If the parameter is scalar, then the parameter offset is set to zero. Otherwise the parameter offset is the same of the solution's one.
+    auto fieldNodeVs = dirichlet_workset.disc->getNodeVectorSpace(this->field_name);
+    auto fieldVs = dirichlet_workset.disc->getVectorSpace(this->field_name);
+    bool isFieldScalar = (fieldNodeVs->dim() == fieldVs->dim());
+    int fieldOffset = isFieldScalar ? 0 : this->offset;
+    const std::vector<GO>& nsNodesGIDs = dirichlet_workset.disc->getNodeSetGIDs().find(this->nodeSetID)->second;
+
+    Teuchos::RCP<const Thyra_Vector> pvec = dirichlet_workset.distParamLib->get(this->field_name)->vector();
+    Teuchos::ArrayRCP<const ST> p_constView = Albany::getLocalData(pvec);
+
+    const std::vector<std::vector<int> >& nsNodes = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
+    auto field_node_indexer = Albany::createGlobalLocalIndexer(fieldNodeVs);
+    for (unsigned int inode = 0; inode < nsNodes.size(); inode++) {
+        int lunk = nsNodes[inode][this->offset];
+        GO node_gid = nsNodesGIDs[inode];
+        int lfield = fieldDofManager.getLocalDOF(field_node_indexer->getLocalElement(node_gid),fieldOffset);
+        x_view[lunk] = p_constView[lfield];
+    }
+  }
+}
+
+template <typename Traits>
+void
+SDirichletField<PHAL::AlbanyTraits::Jacobian, Traits>::set_row_and_col_is_dbc(
+    typename Traits::EvalData dirichlet_workset)
+{
+  Teuchos::RCP<const Thyra_LinearOp> J = dirichlet_workset.Jac;
+
+  auto  range_vs  = J->range();
+  auto  col_vs    = Albany::getColumnSpace(J);
+  auto& ns_nodes  = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
+  auto  domain_vs = range_vs;  // we are assuming this!
+
+  row_is_dbc_ = Thyra::createMember(range_vs);
+  col_is_dbc_ = Thyra::createMember(col_vs);
+  row_is_dbc_->assign(0.0);
+  col_is_dbc_->assign(0.0);
+
+  auto row_is_dbc_data = Albany::getNonconstLocalData(row_is_dbc_);
+  for (size_t ns_node = 0; ns_node < ns_nodes.size(); ns_node++) {
+    auto dof             = ns_nodes[ns_node][this->offset];
+    row_is_dbc_data[dof] = 1.0;
+  }
+
+  auto cas_manager = Albany::createCombineAndScatterManager(domain_vs, col_vs);
+  cas_manager->scatter(row_is_dbc_, col_is_dbc_, Albany::CombineMode::INSERT);
+}
+
+// **********************************************************************
+template<typename Traits>
+void SDirichletField<PHAL::AlbanyTraits::Jacobian, Traits>::
+evaluateFields(typename Traits::EvalData dirichlet_workset)
+{
+
+  Teuchos::RCP<Thyra_Vector>       f = dirichlet_workset.f;
+  if(Teuchos::nonnull(f)) {
+    Teuchos::RCP<const Thyra_Vector> x = dirichlet_workset.x;
+    Teuchos::ArrayRCP<ST> x_view = Teuchos::arcp_const_cast<ST>(Albany::getLocalData(x));
+
+    const Albany::NodalDOFManager& fieldDofManager = dirichlet_workset.disc->getDOFManager(this->field_name);
+    //MP: If the parameter is scalar, then the parameter offset is set to zero. Otherwise the parameter offset is the same of the solution's one.
+    auto fieldNodeVs = dirichlet_workset.disc->getNodeVectorSpace(this->field_name);
+    auto fieldVs = dirichlet_workset.disc->getVectorSpace(this->field_name);
+    bool isFieldScalar = (fieldNodeVs->dim() == fieldVs->dim());
+    int fieldOffset = isFieldScalar ? 0 : this->offset;
+    const std::vector<GO>& nsNodesGIDs = dirichlet_workset.disc->getNodeSetGIDs().find(this->nodeSetID)->second;
+
+    Teuchos::RCP<const Thyra_Vector> pvec = dirichlet_workset.distParamLib->get(this->field_name)->vector();
+    Teuchos::ArrayRCP<const ST> p_constView = Albany::getLocalData(pvec);
+
+    const std::vector<std::vector<int> >& nsNodes = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
+    auto field_node_indexer = Albany::createGlobalLocalIndexer(fieldNodeVs);
+    for (unsigned int inode = 0; inode < nsNodes.size(); inode++) {
+        int lunk = nsNodes[inode][this->offset];
+        GO node_gid = nsNodesGIDs[inode];
+        int lfield = fieldDofManager.getLocalDOF(field_node_indexer->getLocalElement(node_gid),fieldOffset);
+        x_view[lunk] = p_constView[lfield];
+    }
+  }
+
+  const std::vector<std::vector<int> >& nsNodes = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
+
+  Teuchos::RCP<const Thyra_Vector> x = dirichlet_workset.x;
+  //Teuchos::RCP<Thyra_Vector>       f = dirichlet_workset.f;
+  Teuchos::RCP<Thyra_LinearOp>     J = dirichlet_workset.Jac;
+
+  bool const fill_residual = f != Teuchos::null;
+
+  auto f_view = fill_residual ? Albany::getNonconstLocalData(f) : Teuchos::null;
+  Teuchos::Array<ST> entries;
+  Teuchos::Array<LO> indices;
+  Teuchos::Array<ST> value(1);
+  value[0] = dirichlet_workset.j_coeff;;
+
+  this->set_row_and_col_is_dbc(dirichlet_workset);
+
+  auto     col_is_dbc_data = Albany::getLocalData(col_is_dbc_.getConst());
+  auto     range_spmd_vs   = Albany::getSpmdVectorSpace(J->range());
+  const LO num_local_rows  = range_spmd_vs->localSubDim();
+
+  for (LO local_row = 0; local_row < num_local_rows; ++local_row) {
+    Albany::getLocalRowValues(J, local_row, indices, entries);
+    auto row_is_dbc = col_is_dbc_data[local_row] > 0;
+    if (row_is_dbc && fill_residual == true) {
+      int lunk = nsNodes[local_row][this->offset];
+      f_view[lunk] = 0.0;
+    }
+
+    const LO num_row_entries = entries.size();
+
+    for (LO row_entry = 0; row_entry < num_row_entries; ++row_entry) {
+      auto local_col         = indices[row_entry];
+      auto is_diagonal_entry = local_col == local_row;
+      if ( is_diagonal_entry) { continue; }
+
+      auto col_is_dbc = col_is_dbc_data[local_col] > 0;
+      if (row_is_dbc || col_is_dbc) { entries[row_entry] = 0.0; }
+    }
+    Albany::setLocalRowValues(J, local_row, indices(), entries());
+  }
+}
+
+// **********************************************************************
+// Specialization: Tangent
+// **********************************************************************
+template<typename Traits>
+SDirichletField<PHAL::AlbanyTraits::Tangent, Traits>::
+SDirichletField(Teuchos::ParameterList& p) :
+  SDirichletField_Base<PHAL::AlbanyTraits::Tangent, Traits>(p) {
+}
+
+template<typename Traits>
+void
+SDirichletField<PHAL::AlbanyTraits::Tangent, Traits>::preEvaluate(
+    typename Traits::EvalData dirichlet_workset)
+{
+
+  #ifdef DEBUG_OUTPUT
+    Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::VerboseObjectBase::getDefaultOStream();
+    *out << "SDirichletField preEvaluate Tangent\n";
+  #endif
+  if(Teuchos::nonnull(dirichlet_workset.f)) {
+    Teuchos::RCP<const Thyra_Vector> x = dirichlet_workset.x;
+    Teuchos::ArrayRCP<ST> x_view = Teuchos::arcp_const_cast<ST>(Albany::getLocalData(x));
+
+    const Albany::NodalDOFManager& fieldDofManager = dirichlet_workset.disc->getDOFManager(this->field_name);
+    //MP: If the parameter is scalar, then the parameter offset is set to zero. Otherwise the parameter offset is the same of the solution's one.
+    auto fieldNodeVs = dirichlet_workset.disc->getNodeVectorSpace(this->field_name);
+    auto fieldVs = dirichlet_workset.disc->getVectorSpace(this->field_name);
+    bool isFieldScalar = (fieldNodeVs->dim() == fieldVs->dim());
+    int fieldOffset = isFieldScalar ? 0 : this->offset;
+    const std::vector<GO>& nsNodesGIDs = dirichlet_workset.disc->getNodeSetGIDs().find(this->nodeSetID)->second;
+
+    Teuchos::RCP<const Thyra_Vector> pvec = dirichlet_workset.distParamLib->get(this->field_name)->vector();
+    Teuchos::ArrayRCP<const ST> p_constView = Albany::getLocalData(pvec);
+
+    const std::vector<std::vector<int> >& nsNodes = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
+    auto field_node_indexer = Albany::createGlobalLocalIndexer(fieldNodeVs);
+    for (unsigned int inode = 0; inode < nsNodes.size(); inode++) {
+        int lunk = nsNodes[inode][this->offset];
+        GO node_gid = nsNodesGIDs[inode];
+        int lfield = fieldDofManager.getLocalDOF(field_node_indexer->getLocalElement(node_gid),fieldOffset);
+        x_view[lunk] = p_constView[lfield];
+    }
+  }
+}
+
+// **********************************************************************
+template<typename Traits>
+void SDirichletField<PHAL::AlbanyTraits::Tangent, Traits>::
+evaluateFields(typename Traits::EvalData dirichlet_workset) {
+
+  Teuchos::RCP<const Thyra_Vector> x = dirichlet_workset.x;
+  Teuchos::RCP<Thyra_Vector>       f = dirichlet_workset.f;
+
+  Teuchos::RCP<const Thyra_MultiVector> Vx = dirichlet_workset.Vx;
+  Teuchos::RCP<Thyra_MultiVector>       fp = dirichlet_workset.fp;
+  Teuchos::RCP<Thyra_MultiVector>       JV = dirichlet_workset.JV;
+
+  Teuchos::ArrayRCP<const ST> x_constView;
+  Teuchos::ArrayRCP<ST>       f_nonconstView;
+
+  Teuchos::ArrayRCP<Teuchos::ArrayRCP<const ST>> Vx_const2dView;
+  Teuchos::ArrayRCP<Teuchos::ArrayRCP<ST>>       JV_nonconst2dView;
+  Teuchos::ArrayRCP<Teuchos::ArrayRCP<ST>>       fp_nonconst2dView;
+
+  if (f != Teuchos::null) {
+    f_nonconstView = Albany::getNonconstLocalData(f);
+  }
+  if (JV != Teuchos::null) {
+    JV_nonconst2dView = Albany::getNonconstLocalData(JV);
+    Vx_const2dView    = Albany::getLocalData(Vx);
+  }
+
+  if (fp != Teuchos::null) {
+    fp_nonconst2dView = Albany::getNonconstLocalData(fp);
+  }
+
+  const RealType j_coeff = dirichlet_workset.j_coeff;
+  const std::vector<std::vector<int> >& nsNodes = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
+
+  for (unsigned int inode = 0; inode < nsNodes.size(); inode++) {
+    int lunk = nsNodes[inode][this->offset];
+
+    if (f != Teuchos::null) {
+      f_nonconstView[lunk] = 0.0;
+    }
+
+    if (JV != Teuchos::null) {
+      for (int i=0; i<dirichlet_workset.num_cols_x; i++) {
+        JV_nonconst2dView[i][lunk] = j_coeff*Vx_const2dView[i][lunk];
+      }
+    }
+
+    if (fp != Teuchos::null) {
+      for (int i=0; i<dirichlet_workset.num_cols_p; i++) {
+        fp_nonconst2dView[i][lunk] = 0;
+      }
+    }
+  }
+}
+
+// **********************************************************************
+// Specialization: DistParamDeriv
+// **********************************************************************
+template<typename Traits>
+SDirichletField<PHAL::AlbanyTraits::DistParamDeriv, Traits>::
+SDirichletField(Teuchos::ParameterList& p) :
+  SDirichletField_Base<PHAL::AlbanyTraits::DistParamDeriv, Traits>(p) {
+}
+
+// **********************************************************************
+template<typename Traits>
+void SDirichletField<PHAL::AlbanyTraits::DistParamDeriv, Traits>::
+evaluateFields(typename Traits::EvalData dirichlet_workset) {
+
+  bool isFieldParameter =  dirichlet_workset.dist_param_deriv_name == this->field_name;
+  TEUCHOS_TEST_FOR_EXCEPTION(
+      isFieldParameter,
+      std::logic_error,
+      "Error, SDirichletField cannot handle dirichlet parameter " <<  this->field_name << ", use DirichletField instead." << std::endl);
+
+  bool trans = dirichlet_workset.transpose_dist_param_deriv;
+
+  Teuchos::RCP<Thyra_MultiVector> fpV = dirichlet_workset.fpV;
+
+  int num_cols = fpV->domain()->dim();
+
+  const std::vector<std::vector<int> >& nsNodes = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
+
+  if (trans) {
+    // For (df/dp)^T*V we zero out corresponding entries in V
+    Teuchos::RCP<Thyra_MultiVector> Vp = dirichlet_workset.Vp_bc;
+    Teuchos::ArrayRCP<Teuchos::ArrayRCP<ST>> Vp_nonconst2dView = Albany::getNonconstLocalData(Vp);
+
+    for (unsigned int inode = 0; inode < nsNodes.size(); inode++) {
+      int lunk = nsNodes[inode][this->offset];
+      for (int col=0; col<num_cols; ++col) {
+        Vp_nonconst2dView[col][lunk] = 0.0;
+      }
+    }
+  } else {
+    // for (df/dp)*V we zero out corresponding entries in df/dp
+    Teuchos::ArrayRCP<Teuchos::ArrayRCP<ST>> fpV_nonconst2dView = Albany::getNonconstLocalData(fpV);
+    Teuchos::ArrayRCP<Teuchos::ArrayRCP<const ST>> Vp_const2dView = Albany::getLocalData(dirichlet_workset.Vp);
+    for (unsigned int inode = 0; inode < nsNodes.size(); inode++) {
+      int lunk = nsNodes[inode][this->offset];
+      for (int col=0; col<num_cols; ++col) {
+        fpV_nonconst2dView[col][lunk] = 0.0;
+      }
+    }
+  }
+}
+
+} // namespace PHAL

--- a/src/problems/Albany_BCUtils.hpp
+++ b/src/problems/Albany_BCUtils.hpp
@@ -1,4 +1,4 @@
-//*****************************************************************//
+ //*****************************************************************//
 //    Albany 3.0:  Copyright 2016 Sandia Corporation               //
 //    This Software is released under the BSD license detailed     //
 //    in the file "license.txt" in the top-level Albany directory  //
@@ -82,6 +82,10 @@ struct DirichletTraits
   enum
   {
     typeF = PHAL::DirichletFactoryTraits<PHAL::AlbanyTraits>::id_dirichlet_field
+  };
+  enum
+  {
+    typeSF = PHAL::DirichletFactoryTraits<PHAL::AlbanyTraits>::id_sdirichlet_field
   };
   enum
   {

--- a/src/problems/Albany_BCUtils_Def.hpp
+++ b/src/problems/Albany_BCUtils_Def.hpp
@@ -445,6 +445,27 @@ Albany::BCUtils<Albany::DirichletTraits>::buildEvaluatorsList(
     }
   }
 
+  for (std::size_t i = 0; i < nodeSetIDs.size(); i++) {
+    for (std::size_t j = 0; j < bcNames.size(); j++) {
+      string ss = traits_type::constructSDBCNameField(nodeSetIDs[i], bcNames[j]);
+      if (BCparams.isParameter(ss)) {
+        RCP<ParameterList> p = rcp(new ParameterList);
+        p->set<int>("Type", traits_type::typeSF);
+        p->set<RCP<DataLayout>>("Data Layout", dummy);
+        p->set<string>("Dirichlet Name", ss);
+        p->set<RealType>("Dirichlet Value", 0.0);
+        p->set<string>("Field Name", BCparams.get<string>(ss));
+        p->set<string>("Node Set ID", nodeSetIDs[i]);
+        p->set<int>("Equation Offset", j);
+        offsets_[i].push_back(j);
+        p->set<RCP<ParamLib>>("Parameter Library", paramLib);
+        evaluators_to_build[evaluatorsToBuildName(ss)] = p;
+        bcs->push_back(ss);
+        use_sdbcs_ = true;
+      }
+    }
+  }
+
   ///
   /// Time dependent BC specific
   ///
@@ -948,14 +969,14 @@ Albany::BCUtils<Albany::DirichletTraits>::buildEvaluatorsList(
     delete value;
   }
 
-  if ((use_dbcs_ == true) && (use_sdbcs_ == true)) {
+/*  if ((use_dbcs_ == true) && (use_sdbcs_ == true)) {
     TEUCHOS_TEST_FOR_EXCEPTION(
         true,
         std::logic_error,
         "You are attempting to prescribe a mix of SDBCs and DBCs, which is not "
         "allowed!\n");
   }
-
+*/
   string allBC = "Evaluator for all Dirichlet BCs";
   {
     RCP<ParameterList> p = rcp(new ParameterList);

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_paramT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_paramT.yaml
@@ -6,10 +6,10 @@ ANONYMOUS:
     Name: Heat 2D
     Compute Sensitivities: true
     Dirichlet BCs: 
-      DBC on NS NodeSet0 for DOF T: 1.00000000000000000e+00
-      DBC on NS NodeSet1 for DOF T: 0.00000000000000000e+00
-      DBC on NS NodeSet2 for DOF T: -1.00000000000000000e+00
-      DBC on NS NodeSet3 for DOF T: 0.00000000000000000e+00
+      SDBC on NS NodeSet0 for DOF T: 1.00000000000000000e+00
+      SDBC on NS NodeSet1 for DOF T: 0.00000000000000000e+00
+      SDBC on NS NodeSet2 for DOF T: -1.00000000000000000e+00
+      SDBC on NS NodeSet3 for DOF T: 0.00000000000000000e+00
     Distributed Parameters: 
       Number of Parameter Vectors: 1
       Distributed Parameter 0: 


### PR DESCRIPTION
List of changes:

1. Added `PHAL::SDirichletField` class to implement symmetric Dirichlet conditions in the case the
   dirichlet values are provided using a distributed field
2. Added/fixed Tangent adn DistParamDeriv implementation to `PAHL::SDirichlet` class
3. Performing a `preEvaluate` for the volume field, manager to allow computation
   of the dirichlet field (used e.g. in the enthalpy solver) before the dirichlet `preEvaluate` is run
4. modified two tests to use new symmetric dirichlet conditions

Issues:
When the dirichlet field is computed by a volume field manager, we need to `preEvaluate` it before calling the `PHAL::SDirichletField::preEvaluate`. However this can be expensive. In fact in the case of the `PHAL::LoadStateField` class, we are pre-evaluating all the fields needed by the volume field manager, also those not needed at the pre-evaluate time.
Not sure how to proceed. It would be nice to be able to pre-evaluate quantities in general. As an example one could pre-evaluate the total area of an ice sheet and use it to scale the responses. Another use is that one could pre-compute the lumped mass matrix and then use it to scale terms in a sort of finite-volume approach.

Another issue I have is that I get a weird error at the preEvaluate phase of the `PHAL::LoadStateField` at the Jacobian evaluation, when mesh depends on parameters.. @bartgol  any clue of what could be happening?

Thanks,
Mauro
   