### PR TITLE
LandIce: refactoring of NullSpaceUtility

### DIFF
--- a/src/Albany_NullSpaceUtils.hpp
+++ b/src/Albany_NullSpaceUtils.hpp
@@ -8,6 +8,7 @@
 #define ALBANY_NULL_SPACE_UTILS_HPP
 
 #include "Albany_ThyraTypes.hpp"
+#include "Albany_MeshSpecs.hpp"
 
 namespace Albany {
 
@@ -17,14 +18,11 @@ struct TraitsImplBase;
 class RigidBodyModes {
 public:
   //! Construct RBM object.
-  RigidBodyModes(int numPDEs);
-
-  //! Update the number of PDEs present.
-  void setNumPDEs(int numPDEs_) { numPDEs = numPDEs_; }
+  RigidBodyModes();
 
   //! Set sizes of nullspace etc.
-  void setParameters(const int numPDEs, const int numElasticityDim,
-                     const int numScalar, const int nullSpaceDim, const bool setNonElastRBM = false);
+  void setParameters(const int numPDEs, const bool computeConstantModes,
+      const int physVectorDim = 0, const bool computeRotationModes = false);
 
   //! Set Piro solver parameter list.
   void setPiroPL(const Teuchos::RCP<Teuchos::ParameterList>& piroParams);
@@ -41,12 +39,15 @@ public:
   //! Is FROSch used on this problem?
   bool isFROSchUsed() const { return froschUsed; }
 
-  //! Pass coordinates and, if numElasticityDim > 0, the null space to ML,
-  //! MueLu or FROSch. The data accessed through getCoordArrays must have
-  //! been set. soln_map must be set only if using MueLu and numElasticityDim >
-  //! 0. Both maps are nonoverlapping.
-  void setCoordinatesAndNullspace(
+  //! Pass coordinates and the null space to ML, MueLu or FROSch.
+  //! The null space is computed only if
+  //! computeConstantModes or computeRotationModes are true
+  //! The data accessed through getCoordArrays must have been set
+  //! soln_map must be set only if using MueLu or FROSch
+  //! Both maps are nonoverlapped.
+  void setCoordinatesAndComputeNullspace(
     const Teuchos::RCP<Thyra_MultiVector> &coordMV,
+    DiscType interleavedOrdering,
     const Teuchos::RCP<const Thyra_VectorSpace>& soln_vs = Teuchos::null,
     const Teuchos::RCP<const Thyra_VectorSpace>& soln_overlap_vs = Teuchos::null);
 
@@ -54,14 +55,20 @@ public:
   void setCoordinates(const Teuchos::RCP<Thyra_MultiVector> &coordMV);
 
 private:
-  int numPDEs, numElasticityDim, numScalar, nullSpaceDim;
+  int numPDEs;
+  DiscType interleavedOrdering;
+  bool computeConstantModes; //translations
+  int physVectorDim;
+  bool computeRotationModes;
+  int nullSpaceDim;
   bool mlUsed, mueLuUsed, froschUsed, setNonElastRBM;
+  bool areProbParametersSet, arePiroParametersSet;
 
   Teuchos::RCP<Teuchos::ParameterList> plist;
 
   Teuchos::RCP<Thyra_MultiVector> coordMV;
 
-  Teuchos::RCP<TraitsImplBase> traits;
+  Teuchos::RCP<TraitsImplBase> nullSpaceTraits;
 };
 
 } // namespace Albany

--- a/src/LandIce/interface_with_mpas/Interface.cpp
+++ b/src/LandIce/interface_with_mpas/Interface.cpp
@@ -588,6 +588,14 @@ void velocity_solver_extrude_3d_grid(int nLayers, int globalTrianglesStride,
 
   paramList->sublist("Problem").sublist("Body Force").set("Type", "FO INTERP SURF GRAD");
 
+  //! set Rigid body modes for prec. near null space
+  if(!paramList->sublist("Problem").isSublist("LandIce Rigid Body Modes For Preconditioner")) {
+    Teuchos::ParameterList& rbmList = paramList->sublist("Problem").sublist("LandIce Rigid Body Modes For Preconditioner");
+    rbmList.set<bool>("Compute Constant Modes", true);
+    rbmList.set<bool>("Compute Rotation Modes", true);
+  }
+
+
   auto discretizationList = Teuchos::sublist(paramList, "Discretization", true);
   discretizationList->set("Element Shape", discretizationList->get("Element Shape", "Tetrahedron")); //set to Extruded is not defined
   elemShape = discretizationList->get<std::string>("Element Shape");

--- a/src/LandIce/problems/LandIce_Enthalpy.cpp
+++ b/src/LandIce/problems/LandIce_Enthalpy.cpp
@@ -47,16 +47,9 @@ Enthalpy(const Teuchos::RCP<Teuchos::ParameterList>& params_,
     physics_list.set("Seconds per Year", 3.1536e7);
   }
 
-  // Check if we want to give ML RBMs (from parameterlist)
-  const int numRBMs = params_->get<int>("Number RBMs for ML", neq);
-  const int numScalar = std::max(int(neq)-1,0);
-  if (numRBMs - numScalar == 1) {
-    const bool setRBMs = true;
-    rigidBodyModes->setParameters(neq, numDim, numScalar, numRBMs, setRBMs);
-  }
-  else
-    TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "The specified number of RBMs " << numRBMs
-      << " is not valid!  Valid values are " << 1 + numScalar << ".");
+  // Compute Rigid Body Modes for near null space to pass to preconditioners
+  const bool computeConstantModes = true;
+  rigidBodyModes->setParameters(neq, computeConstantModes);
 }
 
 LandIce::Enthalpy::

--- a/src/LandIce/problems/LandIce_Hydrology.cpp
+++ b/src/LandIce/problems/LandIce_Hydrology.cpp
@@ -115,6 +115,10 @@ Hydrology::Hydrology (const Teuchos::RCP<Teuchos::ParameterList>& problemParams_
       }
     }
   }
+
+  // Compute Rigid Body Modes for near null space to pass to preconditioners
+  const bool computeConstantModes = false;
+  rigidBodyModes->setParameters(neq, computeConstantModes);
 }
 
 void Hydrology::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpecsStruct> >  meshSpecs,

--- a/src/LandIce/problems/LandIce_SchoofFit.cpp
+++ b/src/LandIce/problems/LandIce_SchoofFit.cpp
@@ -30,7 +30,7 @@ SchoofFit (const Teuchos::RCP<Teuchos::ParameterList>& params_,
   neq = 1;
 
   // Set the num PDEs for the null space object to pass to ML
-  this->rigidBodyModes->setNumPDEs(neq);
+  //this->rigidBodyModes->setParameters(neq);
 
   // Need to allocate a fields in mesh database
   Teuchos::Array<std::string> s_req = params->get<Teuchos::Array<std::string> > ("Required Scalar Fields");

--- a/src/LandIce/problems/LandIce_Stokes.cpp
+++ b/src/LandIce/problems/LandIce_Stokes.cpp
@@ -69,8 +69,6 @@ Stokes( const Teuchos::RCP<Teuchos::ParameterList>& params_,
 
   haveSource = true;
 
-
-
   // Compute number of equations
   int num_eq = 0;
   if (haveFlowEq) num_eq += numDim+1;
@@ -84,6 +82,10 @@ Stokes( const Teuchos::RCP<Teuchos::ParameterList>& params_,
     for (int i(0); i<req.size(); ++i)
       this->requirements.push_back(req[i]);
   }
+
+  // Compute Rigid Body Modes for near null space to pass to preconditioners
+  const bool computeConstantModes = false;
+  rigidBodyModes->setParameters(num_eq, computeConstantModes);
 
   // Print out a summary of the problem
   *out << "Stokes problem:" << std::endl

--- a/src/LandIce/problems/LandIce_StokesFO.cpp
+++ b/src/LandIce/problems/LandIce_StokesFO.cpp
@@ -38,19 +38,8 @@ StokesFO( const Teuchos::RCP<Teuchos::ParameterList>& params_,
 
   neq =  params_->sublist("Equation Set").get<int>("Num Equations", neq);
 
-  // the following function returns the problem information required for setting the rigid body modes (RBMs) for elasticity problems
-  //written by IK, Feb. 2012
-  //Check if we want to give ML RBMs (from parameterlist)
-  int numRBMs = params_->get<int>("Number RBMs for ML", neq);
-  if (numRBMs > 0) {
-    bool setRBMs = true;
-    int numScalar = std::max(int(neq)-2,0); //we assume that if neq>=2,  the first 2 equations are the FO equations, and the remaining ones are scalar equations
-    if (numRBMs - numScalar == 2 || numRBMs - numScalar == 3)
-      rigidBodyModes->setParameters(neq, numDim, numScalar, numRBMs, setRBMs);
-    else
-      TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"The specified number of RBMs "
-                                     << numRBMs << " is not valid!  Valid values are 0, " << 2 +numScalar<< " and " << 3 + numScalar << ".");
-  }
+  // Set parameters for passing coords/near-null space to preconditioner
+  rigidBodyModes->setParameters(neq, computeConstantModes, vecDimFO, computeRotationModes);
 
   adjustSurfaceHeight = false;
   adjustBedTopo = false;

--- a/src/LandIce/problems/LandIce_StokesFOBase.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.cpp
@@ -105,6 +105,17 @@ StokesFOBase (const Teuchos::RCP<Teuchos::ParameterList>& params_,
   // By default, we are not coupled to any other physics
   temperature_coupled = false;
   hydrology_coupled = false;
+
+  // Determine what Rigid Body Modes to compute and pass to the preconditioner
+  std::string rmb_list_name = "LandIce Rigid Body Modes For Preconditioner";
+  if(params->isSublist(rmb_list_name)) {
+    auto rbm_list = params_->sublist("LandIce Rigid Body Modes For Preconditioner");
+    computeConstantModes = params->sublist(rmb_list_name).get<bool>("Compute Constant Modes");
+    computeRotationModes = params->sublist(rmb_list_name).get<bool>("Compute Rotation Modes");
+  } else {
+    computeConstantModes = true;
+    computeRotationModes = false;
+  }
 }
 
 void StokesFOBase::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpecsStruct> >  meshSpecs,
@@ -285,7 +296,7 @@ StokesFOBase::getStokesFOBaseProblemParameters () const
   validPL->sublist("LandIce Noise", false, "");
   validPL->set<bool>("Use Time Parameter", false, "Solely to use Solver Method = Continuation");
   validPL->set<bool>("Print Stress Tensor", false, "Whether to save stress tensor in the mesh");
-
+  validPL->sublist("LandIce Rigid Body Modes For Preconditioner", false, "");
   return validPL;
 }
 

--- a/src/LandIce/problems/LandIce_StokesFOBase.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.hpp
@@ -201,6 +201,9 @@ protected:
   bool viscosity_use_corrected_temperature;
   bool compute_dissipation;
 
+  //Wether to compute rigid body modes
+  bool computeConstantModes, computeRotationModes;
+
   // Variables used to track properties of fields and parameters
   std::map<std::string, bool>               is_input_field;
   std::map<std::string, bool>               is_computed_field;

--- a/src/LandIce/problems/LandIce_StokesFOThermoCoupled.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOThermoCoupled.cpp
@@ -86,14 +86,8 @@ StokesFOThermoCoupled( const Teuchos::RCP<Teuchos::ParameterList>& params_,
   adjustSurfaceHeight = false;
   adjustBedTopo = false;
 
-  int numRBMs = params_->get<int>("Number RBMs for ML", neq);
-  bool setRBMs = true;
-  int numScalar = neq-2; //the first 2 equations are the FO equations, and the remaining ones are scalar equations
-  if (numRBMs == neq || numRBMs == neq+1)  //
-    rigidBodyModes->setParameters(neq, numDim, numScalar, numRBMs, setRBMs);
-  else
-    TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"The specified number of RBMs "
-                               << numRBMs << " is not valid!  Valid values are " << neq << " and " << neq+1 << ".");
+  // Set parameters for passing coords/near-null space to preconditioner
+  rigidBodyModes->setParameters(neq, computeConstantModes, vecDimFO, computeRotationModes);
 }
 
 Teuchos::Array< Teuchos::RCP<const PHX::FieldTag> >

--- a/src/LandIce/problems/LandIce_StokesL1L2.cpp
+++ b/src/LandIce/problems/LandIce_StokesL1L2.cpp
@@ -26,7 +26,7 @@ StokesL1L2( const Teuchos::RCP<Teuchos::ParameterList>& params_,
   neq = 2; //there are 2 PDEs for L1L2 equations
 
   // Set the num PDEs for the null space object to pass to ML
-  this->rigidBodyModes->setNumPDEs(neq);
+  //this->rigidBodyModes->setParameters(neq);
 
   // Need to allocate a surface height and temperature fields in mesh database
   this->requirements.push_back("surface_height");

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -519,7 +519,7 @@ STKDiscretization::setupMLCoords()
     for (int j = 0; j < numDim; j++) { coordMV_data[j][node_lid] = X[j]; }
   }
 
-  rigidBodyModes->setCoordinatesAndNullspace(coordMV, m_vs, m_overlap_vs);
+  rigidBodyModes->setCoordinatesAndComputeNullspace(coordMV, interleavedOrdering, m_vs, m_overlap_vs);
 
   // Some optional matrix-market output was tagged on here; keep that
   // functionality.

--- a/src/problems/Albany_AbstractProblem.cpp
+++ b/src/problems/Albany_AbstractProblem.cpp
@@ -20,7 +20,7 @@ Albany::AbstractProblem::AbstractProblem(
   params(params_),
   paramLib(paramLib_),
   //distParamLib(distParamLib_),
-  rigidBodyModes(Teuchos::rcp(new Albany::RigidBodyModes(neq_)))
+  rigidBodyModes(Teuchos::rcp(new Albany::RigidBodyModes()))
 {
 
  /* 
@@ -86,7 +86,6 @@ void
 Albany::AbstractProblem::setNumEquations(const int neq_)
 {
   neq = neq_;
-  rigidBodyModes->setNumPDEs(neq_);
 }
 
 
@@ -115,8 +114,6 @@ Albany::AbstractProblem::getGenericProblemParams(std::string listname) const
   Teuchos::RCP<Teuchos::ParameterList> validPL =
      Teuchos::rcp(new Teuchos::ParameterList(listname));;
   validPL->set<std::string>("Name", "", "String to designate Problem Class");
-  //The following is for LandIce problems.
-  validPL->set<int>("Number RBMs for ML", 0, "Number of RBMs provided to ML");
   validPL->set<int>("Number of Spatial Processors", -1, "Number of spatial processors in multi-level parallelism");
   validPL->set<int>("Phalanx Graph Visualization Detail", 0,
                     "Flag to select outpuy of Phalanx Graph and level of detail");

--- a/src/problems/Albany_HeatProblem.cpp
+++ b/src/problems/Albany_HeatProblem.cpp
@@ -62,6 +62,9 @@ HeatProblem( const Teuchos::RCP<Teuchos::ParameterList>& params_,
         break;
     } 
   }
+  // Set parameters for passing coords/near null space to preconditioners
+  const bool computeConstantModes = false;
+  rigidBodyModes->setParameters(neq, computeConstantModes);
 }
 
 void

--- a/src/problems/Albany_PopulateMesh.cpp
+++ b/src/problems/Albany_PopulateMesh.cpp
@@ -23,9 +23,6 @@ PopulateMesh::PopulateMesh (const Teuchos::RCP<Teuchos::ParameterList>& params_,
   use_sdbcs_(false)
 {
   neq = 1;
-
-  // Set the num PDEs for the null space object to pass to ML
-  this->rigidBodyModes->setNumPDEs(neq);
 }
 
 PopulateMesh::~PopulateMesh()

--- a/src/problems/Albany_ThermalProblem.cpp
+++ b/src/problems/Albany_ThermalProblem.cpp
@@ -37,6 +37,10 @@ ThermalProblem( const Teuchos::RCP<Teuchos::ParameterList>& params_,
   rho = params->get<double>("Density", 1.0);
   C = params->get<double>("Heat Capacity", 1.0);
   thermal_source = params->get<std::string>("Thermal Source", "None"); 
+
+  // Set Parameters for passing coords/near null space to preconditioners
+  const bool computeConstantModes = false;
+  rigidBodyModes->setParameters(neq, computeConstantModes);
 }
 
 Albany::ThermalProblem::

--- a/tests/small/LandIce/FO_AIS/input_FROSch.yaml
+++ b/tests/small/LandIce/FO_AIS/input_FROSch.yaml
@@ -7,7 +7,9 @@ ANONYMOUS:
     Phalanx Graph Visualization Detail: 0
     Solution Method: Steady
     Name: LandIce Stokes First Order 3D
-    Number RBMs for ML: 3
+    LandIce Rigid Body Modes For Preconditioner:
+      Compute Constant Modes: true
+      Compute Rotation Modes: true    
     Required Fields: [temperature]
     Basal Side Name: basalside
     Surface Side Name: upperside

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_unstructT_FROSch.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_unstructT_FROSch.yaml
@@ -8,7 +8,9 @@ ANONYMOUS:
     Phalanx Graph Visualization Detail: 0
     Solution Method: Continuation
     Name: LandIce Stokes First Order 3D
-    Number RBMs for ML: 3
+    LandIce Rigid Body Modes For Preconditioner:
+      Compute Constant Modes: true
+      Compute Rotation Modes: true
     Compute Sensitivities: true
     Required Fields: [temperature]
     Basal Side Name: basalside

--- a/tests/small/LandIce/FO_Test/input_fo_confinedShelf_depthIntBCT.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_confinedShelf_depthIntBCT.yaml
@@ -4,7 +4,9 @@ ANONYMOUS:
   Build Type: Tpetra
   Problem: 
     Phalanx Graph Visualization Detail: 2
-    Number RBMs for ML: 2
+    LandIce Rigid Body Modes For Preconditioner:
+      Compute Constant Modes: true
+      Compute Rotation Modes: false
     Solution Method: Continuation
     Name: LandIce Stokes First Order 3D
     Dirichlet BCs: 


### PR DESCRIPTION
This is a refactoring of the nullSpaceUtility class. Becuase of different implementations of elasticity/nonelesticity problems it became hard to look at the code and understand how to compute the null space dimension. Hope you find this refactor  useful.  Before merging the branch I'll fix the input files of the performance repo, so that they comply with these changes.

For scalar equations it often makes sense to have constants in the near null space
For elesticity type problems, the null space is constituted of rigid body modes,
 consisting of constants/transalations and rotations associated to a physical vector
Here we assume that the we have a set of equations and possibly the the first 2 or 3  equations
 are for a 2d or 3d physical vector (e.g. velocity).
We can compute constant modes for all the equations and then add rotations for the vector.
It is possible to choose whether to compute constant modes and/or rotation modes.
The dimension of the null space is determined by the class and does not need to be computed by the user.
Different checks have beed added to make sure that the methods of the RigidBodyModes class
 are called in the right sequence.
Also we check whether the interleaved ordering is compatible with what implemented.