### PR TITLE
GPU build failures on ride

### DIFF
--- a/src/Albany_KokkosTypes.hpp
+++ b/src/Albany_KokkosTypes.hpp
@@ -37,10 +37,10 @@ template<typename Scalar, typename MemoryTraits = Kokkos::MemoryUnmanaged>
 using DeviceView2d = Kokkos::View<Scalar**, Kokkos::LayoutLeft, PHX::Device, MemoryTraits>;
 
 // Kokkos types for local graphs/matrices, to be used for on-device kernels
-using DeviceLocalGraph  = Kokkos::StaticCrsGraph<LO, Kokkos::LayoutLeft, PHX::Device>;
+using DeviceLocalGraph  = Kokkos::StaticCrsGraph<LO, Kokkos::LayoutLeft, KokkosNode::device_type, void, size_t>;
 
 template<typename Scalar>
-using DeviceLocalMatrix = KokkosSparse::CrsMatrix<Scalar, LO, PHX::Device, Kokkos::MemoryUnmanaged, DeviceLocalGraph::size_type>;
+using DeviceLocalMatrix = KokkosSparse::CrsMatrix<Scalar, LO, KokkosNode::device_type, void, DeviceLocalGraph::size_type>;
 
 } // namespace Albany
 

--- a/src/Albany_TpetraTypes.hpp
+++ b/src/Albany_TpetraTypes.hpp
@@ -61,4 +61,13 @@ typedef Tpetra::Operator<ST, Tpetra_LO, Tpetra_GO, KokkosNode>        Tpetra_Ope
 typedef Tpetra::Vector<ST, Tpetra_LO, Tpetra_GO, KokkosNode>          Tpetra_Vector;
 typedef Tpetra::MultiVector<ST, Tpetra_LO, Tpetra_GO, KokkosNode>     Tpetra_MultiVector;
 
+// Make sure our Kokkos types are compatible with what tpetra uses
+// This will make it easier to debug problems such as the one in issue #612 on GitHub
+static_assert (std::is_same<typename Tpetra_CrsGraph::local_graph_type,Albany::DeviceLocalGraph>::value,
+               "Error! Tpetra's local_graph_type does not match Albany's DeviceLocalGraph.\n"
+               "       Most likely there was a change in Tpetra, and you need to update Albany_KokkosTypes.hpp.\n");
+static_assert (std::is_same<typename Tpetra_CrsMatrix::local_matrix_type,Albany::DeviceLocalMatrix<ST>>::value,
+               "Error! Tpetra's local_graph_type does not match Albany's DeviceLocalGraph.\n"
+               "       Most likely there was a change in Tpetra, and you need to update Albany_KokkosTypes.hpp.\n");
+
 #endif // ALBANY_TPETRA_TYPES_HPP


### PR DESCRIPTION
There are some GPU build failures on ride, which are due to type mismatch for two size_type template arguments (size_t on one side, and unsigned int (the size type for cuda) on the other), during a view copy constructor.

I am not sure why these are showing up now. I don't recall any code in the FECrs PR that might have changed our types. Additionally, I _think_ our `DeviceLocalMatrix` type should be compatible with the `local_matrix_type` inside Tpetra::CrsMatrix (they might have different local ordinal types, since Albany usee `int32_t`, while Trilinos uses plain `int`, but I don't think that is related to the error). It is almost as if one of the two views had the wrong execution space, which is hard to believe.

One solution might be to use Tpetra::CrsMatrix to get the type of a device local matrix. However, I'd like to understand why we get this error in the first place.