### PR TITLE
Enable explicit traspose of Jacobian (for optimization problems)

### DIFF
--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -681,6 +681,7 @@ evalModelImpl(const Thyra_InArgs&  inArgs,
 
   //! If a parameter has changed in value, saved/unsaved fields must be updated
 
+  bool transposeJacobian = false;
   ObserverImpl observer(app);
   auto out = Teuchos::VerboseObjectBase::getDefaultOStream();
   auto& analysisParams = appParams->sublist("Piro").sublist("Analysis");
@@ -709,6 +710,7 @@ evalModelImpl(const Thyra_InArgs&  inArgs,
         iteration = iter;
       }
     }
+    transposeJacobian = opt_paramList.get("Compute Transposed Jacobian", false);
   }
 
   // Thyra vectors
@@ -842,6 +844,10 @@ evalModelImpl(const Thyra_InArgs&  inArgs,
         x, x_dot, x_dotdot,
         sacado_param_vec,
         f_out, W_op_out, dt);
+    if(transposeJacobian) {
+      Albany::transpose(W_op_out);
+    }
+
     f_already_computed = true;
   }
 

--- a/src/utility/Albany_ThyraUtils.hpp
+++ b/src/utility/Albany_ThyraUtils.hpp
@@ -103,7 +103,9 @@ void addToLocalRowValues (const Teuchos::RCP<Thyra_LinearOp>& lop,
 
 void scale (const Teuchos::RCP<Thyra_LinearOp>& lop, const ST val); 
 
-Teuchos::RCP<Thyra_LinearOp> transpose (const Teuchos::RCP<const Thyra_LinearOp>& lop); 
+Teuchos::RCP<Thyra_LinearOp> getTransposedOp (const Teuchos::RCP<const Thyra_LinearOp>& lop);
+
+void transpose (const Teuchos::RCP<Thyra_LinearOp> lop);
 
 // Math properties helpers
 double computeConditionNumber (const Teuchos::RCP<const Thyra_LinearOp>& lop);


### PR DESCRIPTION
Explicitly transpose the jacobian when Piro sets to true the option
`Piro->Analysis->Optimization Status->Compute Transposed Jacobian`