### PR TITLE
Hessian-vector product of the residual with AD

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -2412,7 +2412,6 @@ Application::evaluateResidual_HessVecProd_xx(
     const auto& wsPhysIndex  = disc->getWsPhysIndex();
 
     if (dfm != Teuchos::null) {
-      dfm_set(workset, x, xdot, xdotdot);
       loadWorksetNodesetInfo(workset);
 
       dfm->preEvaluate<EvalT>(workset);
@@ -2484,7 +2483,6 @@ Application::evaluateResidual_HessVecProd_xp(
     const auto& wsPhysIndex  = disc->getWsPhysIndex();
 
     if (dfm != Teuchos::null) {
-      dfm_set(workset, x, xdot, xdotdot);
       loadWorksetNodesetInfo(workset);
 
       dfm->preEvaluate<EvalT>(workset);
@@ -2556,7 +2554,6 @@ Application::evaluateResidual_HessVecProd_px(
     const auto& wsPhysIndex  = disc->getWsPhysIndex();
 
     if (dfm != Teuchos::null) {
-      dfm_set(workset, x, xdot, xdotdot);
       loadWorksetNodesetInfo(workset);
 
       dfm->preEvaluate<EvalT>(workset);
@@ -2630,7 +2627,6 @@ Application::evaluateResidual_HessVecProd_pp(
     const auto& wsPhysIndex  = disc->getWsPhysIndex();
 
     if (dfm != Teuchos::null) {
-      dfm_set(workset, x, xdot, xdotdot);
       loadWorksetNodesetInfo(workset);
 
       dfm->preEvaluate<EvalT>(workset);

--- a/src/Albany_Application.hpp
+++ b/src/Albany_Application.hpp
@@ -413,6 +413,54 @@ public:
       const std::string&                      dist_param_direction_name,
       const Teuchos::RCP<Thyra_MultiVector>&  Hv_g_pp);
 
+void
+  evaluateResidual_HessVecProd_xx(
+      const double                            current_time,
+      const Teuchos::RCP<const Thyra_MultiVector>& v,
+      const Teuchos::RCP<const Thyra_Vector>& z,
+      const Teuchos::RCP<const Thyra_Vector>& x,
+      const Teuchos::RCP<const Thyra_Vector>& xdot,
+      const Teuchos::RCP<const Thyra_Vector>& xdotdot,
+      const Teuchos::Array<ParamVec>&         param_array,
+      const Teuchos::RCP<Thyra_MultiVector>&  Hv_f_xx);
+
+  void
+  evaluateResidual_HessVecProd_xp(
+      const double                            current_time,
+      const Teuchos::RCP<const Thyra_MultiVector>& v,
+      const Teuchos::RCP<const Thyra_Vector>& z,
+      const Teuchos::RCP<const Thyra_Vector>& x,
+      const Teuchos::RCP<const Thyra_Vector>& xdot,
+      const Teuchos::RCP<const Thyra_Vector>& xdotdot,
+      const Teuchos::Array<ParamVec>&         param_array,
+      const std::string&                      dist_param_name,
+      const Teuchos::RCP<Thyra_MultiVector>&  Hv_f_xp);
+
+  void
+  evaluateResidual_HessVecProd_px(
+      const double                            current_time,
+      const Teuchos::RCP<const Thyra_MultiVector>& v,
+      const Teuchos::RCP<const Thyra_Vector>& z,
+      const Teuchos::RCP<const Thyra_Vector>& x,
+      const Teuchos::RCP<const Thyra_Vector>& xdot,
+      const Teuchos::RCP<const Thyra_Vector>& xdotdot,
+      const Teuchos::Array<ParamVec>&         param_array,
+      const std::string&                      dist_param_name,
+      const Teuchos::RCP<Thyra_MultiVector>&  Hv_f_px);
+
+  void
+  evaluateResidual_HessVecProd_pp(
+      const double                            current_time,
+      const Teuchos::RCP<const Thyra_MultiVector>& v,
+      const Teuchos::RCP<const Thyra_Vector>& z,
+      const Teuchos::RCP<const Thyra_Vector>& x,
+      const Teuchos::RCP<const Thyra_Vector>& xdot,
+      const Teuchos::RCP<const Thyra_Vector>& xdotdot,
+      const Teuchos::Array<ParamVec>&         param_array,
+      const std::string&                      dist_param_name,
+      const std::string&                      dist_param_direction_name,
+      const Teuchos::RCP<Thyra_MultiVector>&  Hv_f_pp);
+
   //! Provide access to shapeParameters -- no AD
   PHAL::AlbanyTraits::Residual::ScalarT&
   getValue(const std::string& n);

--- a/src/PHAL_AlbanyTraits.hpp
+++ b/src/PHAL_AlbanyTraits.hpp
@@ -87,6 +87,10 @@ namespace PHAL {
     struct DistParamDeriv : EvaluationType<TanFadType, RealType, TanFadType> {};
 #endif
 
+/**
+ * @brief EvaluationType used to compute Hessian-vector products using automatic differentation
+ * by nesting FAD types.
+ */
 #if defined(ALBANY_MESH_DEPENDS_ON_PARAMETERS) || defined(ALBANY_MESH_DEPENDS_ON_SOLUTION)
     struct HessianVec : EvaluationType<HessianVecFad, HessianVecFad, HessianVecFad> {};
 #else

--- a/src/PHAL_Workset.hpp
+++ b/src/PHAL_Workset.hpp
@@ -45,6 +45,8 @@ struct HessianWorkset
   Teuchos::RCP<Thyra_MultiVector> direction_x;
   Teuchos::RCP<Thyra_MultiVector> direction_p;
 
+  Teuchos::RCP<Thyra_Vector> f_multiplier;
+
   Teuchos::RCP<Thyra_MultiVector> hess_vec_prod_f_xx;
   Teuchos::RCP<Thyra_MultiVector> hess_vec_prod_f_xp;
   Teuchos::RCP<Thyra_MultiVector> hess_vec_prod_f_px;

--- a/src/evaluators/bc/PHAL_Dirichlet.hpp
+++ b/src/evaluators/bc/PHAL_Dirichlet.hpp
@@ -120,6 +120,16 @@ class Dirichlet<PHAL::AlbanyTraits::HessianVec,Traits>
    : public DirichletBase<PHAL::AlbanyTraits::HessianVec, Traits> {
 public:
   Dirichlet(Teuchos::ParameterList& p);
+
+  /**
+  * @brief preEvaluate phase for PHAL::AlbanyTraits::HessianVec EvaluationType.
+  *
+  * During the computation of the Hessian-vector product of the residual
+  * multiplied by Lagrange multipliers, a preEvaluate phase is used to zero
+  * out the Lagrange multipliers associated to degrees of freedom constrained
+  * by a Dirichlet boundary condition.
+  */
+  void preEvaluate(typename Traits::EvalData d);
   void evaluateFields(typename Traits::EvalData d);
 };
 

--- a/src/evaluators/bc/PHAL_DirichletField.hpp
+++ b/src/evaluators/bc/PHAL_DirichletField.hpp
@@ -102,6 +102,16 @@ class DirichletField<PHAL::AlbanyTraits::HessianVec, Traits>
   public:
     DirichletField(Teuchos::ParameterList& p);
     typedef typename PHAL::AlbanyTraits::HessianVec::ScalarT ScalarT;
+
+    /**
+    * @brief preEvaluate phase for PHAL::AlbanyTraits::HessianVec EvaluationType.
+    *
+    * During the computation of the Hessian-vector product of the residual
+    * multiplied by Lagrange multipliers, a preEvaluate phase is used to zero
+    * out the Lagrange multipliers associated to degrees of freedom constrained
+    * by a Dirichlet boundary condition.
+    */
+    void preEvaluate(typename Traits::EvalData d);
     void evaluateFields(typename Traits::EvalData d);
 };
 

--- a/src/evaluators/bc/PHAL_DirichletField_Def.hpp
+++ b/src/evaluators/bc/PHAL_DirichletField_Def.hpp
@@ -313,10 +313,27 @@ DirichletField(Teuchos::ParameterList& p) :
 }
 
 // **********************************************************************
+
+template<typename Traits>
+void DirichletField<PHAL::AlbanyTraits::HessianVec, Traits>::
+preEvaluate(typename Traits::EvalData dirichletWorkset) {
+  const bool f_multiplier_is_active = !dirichletWorkset.hessianWorkset.f_multiplier.is_null();
+
+  const std::vector<std::vector<int> >& nsNodes = dirichletWorkset.nodeSets->find(this->nodeSetID)->second;
+
+  if(f_multiplier_is_active) {
+    auto f_multiplier_data = Albany::getNonconstLocalData(dirichletWorkset.hessianWorkset.f_multiplier);
+
+    for (size_t ns_node = 0; ns_node < nsNodes.size(); ns_node++) {
+      int const dof = nsNodes[ns_node][this->offset];
+      f_multiplier_data[dof] = 0.;
+    }
+  }
+}
+
 template<typename Traits>
 void DirichletField<PHAL::AlbanyTraits::HessianVec, Traits>::
 evaluateFields(typename Traits::EvalData dirichletWorkset) {
-  TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "HessianVec specialization of DirichletField::evaluateFields is not implemented yet"<< std::endl);
 }
 
 } // namespace PHAL

--- a/src/evaluators/bc/PHAL_Dirichlet_Def.hpp
+++ b/src/evaluators/bc/PHAL_Dirichlet_Def.hpp
@@ -271,12 +271,32 @@ Dirichlet(Teuchos::ParameterList& p) :
 {
 }
 
+template <typename Traits>
+void
+Dirichlet<PHAL::AlbanyTraits::HessianVec, Traits>::preEvaluate(
+    typename Traits::EvalData dirichlet_workset)
+{
+  const bool f_multiplier_is_active = !dirichlet_workset.hessianWorkset.f_multiplier.is_null();
+  const bool is_x_direction_active = !dirichlet_workset.hessianWorkset.direction_x.is_null();
+  const bool is_p_direction_active = !dirichlet_workset.hessianWorkset.direction_p.is_null();
+
+  const std::vector<std::vector<int> >& nsNodes = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
+
+  if(f_multiplier_is_active) {
+    auto f_multiplier_data = Albany::getNonconstLocalData(dirichlet_workset.hessianWorkset.f_multiplier);
+
+    for (size_t ns_node = 0; ns_node < nsNodes.size(); ns_node++) {
+      int const dof = nsNodes[ns_node][this->offset];
+      f_multiplier_data[dof] = 0.;
+    }
+  }
+}
+
 // **********************************************************************
 template<typename Traits>
 void Dirichlet<PHAL::AlbanyTraits::HessianVec, Traits>::
 evaluateFields(typename Traits::EvalData dirichletWorkset)
 {
-  TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "HessianVec specialization of Dirichlet::evaluateFields is not implemented yet"<< std::endl);
 }
 
 // **********************************************************************

--- a/src/evaluators/bc/PHAL_SDirichlet.hpp
+++ b/src/evaluators/bc/PHAL_SDirichlet.hpp
@@ -124,6 +124,17 @@ class SDirichlet<PHAL::AlbanyTraits::HessianVec, Traits>
 
   SDirichlet(Teuchos::ParameterList& p);
 
+  /**
+  * @brief preEvaluate phase for PHAL::AlbanyTraits::HessianVec EvaluationType.
+  *
+  * During the computation of the Hessian-vector product of the residual
+  * multiplied by Lagrange multipliers, a preEvaluate phase is used to zero
+  * out the Lagrange multipliers associated to degrees of freedom constrained
+  * by a Dirichlet boundary condition.
+  */
+  void
+  preEvaluate(typename Traits::EvalData d);
+
   void
   evaluateFields(typename Traits::EvalData d);
 };

--- a/src/evaluators/bc/PHAL_SDirichletField.hpp
+++ b/src/evaluators/bc/PHAL_SDirichletField.hpp
@@ -127,6 +127,15 @@ class SDirichletField<PHAL::AlbanyTraits::HessianVec, Traits>
 
     SDirichletField(Teuchos::ParameterList& p);
 
+    /**
+    * @brief preEvaluate phase for PHAL::AlbanyTraits::HessianVec EvaluationType.
+    *
+    * During the computation of the Hessian-vector product of the residual
+    * multiplied by Lagrange multipliers, a preEvaluate phase is used to zero
+    * out the Lagrange multipliers associated to degrees of freedom constrained
+    * by a Dirichlet boundary condition.
+    */
+    void preEvaluate(typename Traits::EvalData d);
     void evaluateFields(typename Traits::EvalData d);
 };
 

--- a/src/evaluators/bc/PHAL_SDirichlet_Def.hpp
+++ b/src/evaluators/bc/PHAL_SDirichlet_Def.hpp
@@ -336,6 +336,27 @@ SDirichlet<PHAL::AlbanyTraits::HessianVec, Traits>::SDirichlet(
   return;
 }
 
+template <typename Traits>
+void
+SDirichlet<PHAL::AlbanyTraits::HessianVec, Traits>::preEvaluate(
+    typename Traits::EvalData dirichlet_workset)
+{
+  const bool f_multiplier_is_active = !dirichlet_workset.hessianWorkset.f_multiplier.is_null();
+  const bool is_x_direction_active = !dirichlet_workset.hessianWorkset.direction_x.is_null();
+  const bool is_p_direction_active = !dirichlet_workset.hessianWorkset.direction_p.is_null();
+
+  const std::vector<std::vector<int> >& nsNodes = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
+
+  if(f_multiplier_is_active) {
+    auto f_multiplier_data = Albany::getNonconstLocalData(dirichlet_workset.hessianWorkset.f_multiplier);
+
+    for (size_t ns_node = 0; ns_node < nsNodes.size(); ns_node++) {
+      int const dof = nsNodes[ns_node][this->offset];
+      f_multiplier_data[dof] = 0.;
+    }
+  }
+}
+
 //
 //
 //
@@ -344,7 +365,26 @@ void
 SDirichlet<PHAL::AlbanyTraits::HessianVec, Traits>::evaluateFields(
     typename Traits::EvalData dirichlet_workset)
 {
-  TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "HessianVec specialization of SDirichlet::evaluateFields is not implemented yet"<< std::endl);
+  const bool f_xx_is_active = !dirichlet_workset.hessianWorkset.hess_vec_prod_f_xx.is_null();
+  const bool f_xp_is_active = !dirichlet_workset.hessianWorkset.hess_vec_prod_f_xp.is_null();
+
+  Teuchos::ArrayRCP<Teuchos::ArrayRCP<ST> > hess_vec_prod_f_xx_data, hess_vec_prod_f_xp_data;
+
+  if(f_xx_is_active)
+    hess_vec_prod_f_xx_data = Albany::getNonconstLocalData(dirichlet_workset.hessianWorkset.overlapped_hess_vec_prod_f_xx);
+  if(f_xp_is_active)
+    hess_vec_prod_f_xp_data = Albany::getNonconstLocalData(dirichlet_workset.hessianWorkset.overlapped_hess_vec_prod_f_xp);
+
+  const std::vector<std::vector<int> >& nsNodes = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
+
+  for (size_t ns_node = 0; ns_node < nsNodes.size(); ns_node++) {
+    int const dof = nsNodes[ns_node][this->offset];
+
+    if(f_xx_is_active)
+      hess_vec_prod_f_xx_data[0][dof] = 0.;
+    if(f_xp_is_active)
+      hess_vec_prod_f_xp_data[0][dof] = 0.;
+  }
 }
 
 }  // namespace PHAL

--- a/src/evaluators/gather/PHAL_GatherScalarNodalParameter.hpp
+++ b/src/evaluators/gather/PHAL_GatherScalarNodalParameter.hpp
@@ -125,6 +125,42 @@ private:
 // **************************************************************
 // HessianVec
 // **************************************************************
+
+/**
+ * @brief Template specialization of the GatherScalarNodalParameter Class for PHAL::AlbanyTraits::HessianVec EvaluationType.
+ *
+ * This specialization is used to gather the distributed parameter for the computation of:
+ * <ul>
+ *  <li> The @f$ H_{xp_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *       \f[
+ *         H_{xp_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{p_2x}(g)v_{x} @f$ contribution of the Hessian-vector product of the response function:
+ *       \f[
+ *         H_{p_2x}(g)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x+ r\,v_{x},p_1, p_2)\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{p_2p_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *       \f[
+ *         H_{p_2p_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{xp_1}(f,z)v_{p_1} @f$ contribution of the Hessian-vector product of the residual:
+ *       \f[
+ *         H_{xp_1}(f,z)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} \left\langle f(x, p_1+ r\,v_{p_1}, p_2),z\right\rangle\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{p_2x}(f,z)v_{x} @f$ contribution of the Hessian-vector product of the residual:
+ *       \f[
+ *         H_{p_2x}(f,z)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x+ r\,v_{x},p_1, p_2),z\right\rangle\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{p_2p_1}(f,z)v_{p_1} @f$ contribution of the Hessian-vector product of the residual:
+ *       \f[
+ *         H_{p_2p_1}(f,z)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x, p_1+ r\,v_{p_1}, p_2),z\right\rangle\right|_{r=0},
+ *       \f]
+ * </ul>
+ *
+ *  where  @f$ x @f$  is the solution,  @f$ p_1 @f$  is a first distributed parameter,  @f$ p_2 @f$  is a potentially different second distributed parameter,
+ *  @f$  g @f$  is the response function, @f$  f @f$  is the residual, @f$  z  @f$ is the Lagrange multiplier vector,  @f$ v_{x} @f$  is a direction vector
+ *  with the same dimension as the vector  @f$ x @f$, and @f$ v_{p_1} @f$  is a direction vector with the same dimension as the vector  @f$ p_1 @f$.
+ */
 template<typename Traits>
 class GatherScalarNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits> :
     public GatherScalarNodalParameterBase<PHAL::AlbanyTraits::HessianVec,Traits>  {
@@ -139,6 +175,41 @@ private:
 };
 
 
+/**
+ * @brief Template specialization of the GatherScalarExtruded2DNodalParameter Class for PHAL::AlbanyTraits::HessianVec EvaluationType.
+ *
+ * This specialization is used to gather the extruded distributed parameter for the computation of:
+ * <ul>
+ *  <li> The @f$ H_{xp_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *       \f[
+ *         H_{xp_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{p_2x}(g)v_{x} @f$ contribution of the Hessian-vector product of the response function:
+ *       \f[
+ *         H_{p_2x}(g)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x+ r\,v_{x},p_1, p_2)\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{p_2p_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *       \f[
+ *         H_{p_2p_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{xp_1}(f,z)v_{p_1} @f$ contribution of the Hessian-vector product of the residual:
+ *       \f[
+ *         H_{xp_1}(f,z)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} \left\langle f(x, p_1+ r\,v_{p_1}, p_2),z\right\rangle\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{p_2x}(f,z)v_{x} @f$ contribution of the Hessian-vector product of the residual:
+ *       \f[
+ *         H_{p_2x}(f,z)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x+ r\,v_{x},p_1, p_2),z\right\rangle\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{p_2p_1}(f,z)v_{p_1} @f$ contribution of the Hessian-vector product of the residual:
+ *       \f[
+ *         H_{p_2p_1}(f,z)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x, p_1+ r\,v_{p_1}, p_2),z\right\rangle\right|_{r=0},
+ *       \f]
+ * </ul>
+ *
+ *  where  @f$ x @f$  is the solution,  @f$ p_1 @f$  is a first distributed parameter which can be extruded,  @f$ p_2 @f$  is a potentially different second distributed parameter which can be extruded too,
+ *  @f$  g @f$  is the response function, @f$  f @f$  is the residual, @f$  z  @f$ is the Lagrange multiplier vector,  @f$ v_{x} @f$  is a direction vector
+ *  with the same dimension as the vector  @f$ x @f$, and @f$ v_{p_1} @f$  is a direction vector with the same dimension as the vector  @f$ p_1 @f$.
+ */
 template<typename Traits>
 class GatherScalarExtruded2DNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits> :
     public GatherScalarNodalParameterBase<PHAL::AlbanyTraits::HessianVec,Traits>  {

--- a/src/evaluators/gather/PHAL_GatherSolution.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolution.hpp
@@ -291,6 +291,43 @@ private:
 // **************************************************************
 // HessianVec
 // **************************************************************
+
+/**
+ * @brief Template specialization of the GatherSolution Class for PHAL::AlbanyTraits::HessianVec EvaluationType.
+ *
+ * This specialization is used to gather the solution for the computation of:
+ * <ul>
+ *  <li> The @f$ H_{xx}(g)v_{x} @f$ contribution of the Hessian-vector product of the response function:
+ *       \f[
+ *         H_{xx}(g)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{x} g(x+ r\,v_{x},p_1, p_2)\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{xp_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *       \f[
+ *         H_{xp_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{p_2x}(g)v_{x} @f$ contribution of the Hessian-vector product of the response function:
+ *       \f[
+ *         H_{p_2x}(g)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x+ r\,v_{x},p_1, p_2)\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{xx}(f,z)v_{x} @f$ contribution of the Hessian-vector product of the residual:
+ *       \f[
+ *         H_{xx}(f,z)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{x} \left\langle f(x+ r\,v_{x},p_1, p_2),z\right\rangle\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{xp_1}(f,z)v_{p_1} @f$ contribution of the Hessian-vector product of the residual:
+ *       \f[
+ *         H_{xp_1}(f,z)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} \left\langle f(x, p_1+ r\,v_{p_1}, p_2),z\right\rangle\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{p_2x}(f,z)v_{x} @f$ contribution of the Hessian-vector product of the residual:
+ *       \f[
+ *         H_{p_2x}(f,z)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x+ r\,v_{x},p_1, p_2),z\right\rangle\right|_{r=0},
+ *       \f]
+ * </ul>
+ *
+ *  where  @f$ x @f$  is the solution,  @f$ p_1 @f$  is a first distributed parameter,  @f$ p_2 @f$  is a potentially different second distributed parameter,
+ *  @f$  g @f$  is the response function, @f$  f @f$  is the residual, @f$  z  @f$ is the Lagrange multiplier vector,  @f$ v_{x} @f$  is a direction vector
+ *  with the same dimension as the vector  @f$ x @f$, and @f$ v_{p_1} @f$  is a direction vector with the same dimension as the vector  @f$ p_1 @f$.
+ */
+
 template<typename Traits>
 class GatherSolution<PHAL::AlbanyTraits::HessianVec,Traits>
    : public GatherSolutionBase<PHAL::AlbanyTraits::HessianVec, Traits>  {

--- a/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse.hpp
+++ b/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse.hpp
@@ -234,6 +234,35 @@ private:
 // **************************************************************
 // HessianVec
 // **************************************************************
+
+/**
+ * @brief Template specialization of the SeparableScatterScalarResponse Class for PHAL::AlbanyTraits::HessianVec EvaluationType.
+ *
+ * This specialization is used to scatter the solution for the computation of:
+ * <ul>
+ *  <li> The @f$ H_{xx}(g)v_{x} @f$ contribution of the Hessian-vector product of the response function:
+ *       \f[
+ *         H_{xx}(g)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{x} g(x+ r\,v_{x},p_1, p_2)\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{xp_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *       \f[
+ *         H_{xp_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{p_2x}(g)v_{x} @f$ contribution of the Hessian-vector product of the response function:
+ *       \f[
+ *         H_{p_2x}(g)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x+ r\,v_{x},p_1, p_2)\right|_{r=0},
+ *       \f]
+ *  <li> The @f$ H_{p_2p_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *       \f[
+ *         H_{p_2p_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *       \f]
+ * </ul>
+ *
+ *  where  @f$ x @f$  is the solution,  @f$ p_1 @f$  is a first distributed parameter,  @f$ p_2 @f$  is a potentially different second distributed parameter,
+ *  @f$  g @f$  is the response function,  @f$ v_{x} @f$  is a direction vector
+ *  with the same dimension as the vector  @f$ x @f$, and @f$ v_{p_1} @f$  is a direction vector with the same dimension as the vector  @f$ p_1 @f$.
+ */
+
 template<typename Traits>
 class SeparableScatterScalarResponse<PHAL::AlbanyTraits::HessianVec,Traits>
   : public ScatterScalarResponseBase<PHAL::AlbanyTraits::HessianVec, Traits>,

--- a/src/problems/Albany_BCUtils_Def.hpp
+++ b/src/problems/Albany_BCUtils_Def.hpp
@@ -912,6 +912,9 @@ Albany::BCUtils<BCTraits>::buildFieldManager(
   PHX::Tag<AlbanyTraits::DistParamDeriv::ScalarT> dpd_tag0(allBC, dummy);
   fm->requireField<AlbanyTraits::DistParamDeriv>(dpd_tag0);
 
+  PHX::Tag<AlbanyTraits::HessianVec::ScalarT> Hv_tag0(allBC, dummy);
+  fm->requireField<AlbanyTraits::HessianVec>(Hv_tag0);
+
   return fm;
 }
 


### PR DESCRIPTION
This PR adds the capability to use Automatic Differentiation (AD) to compute the Hessian-vector products of the residual by nesting AD types.

This PR adds four contributions of the Hessian-vector products to the previously merged ones:
- <img src="https://render.githubusercontent.com/render/math?math=\large\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}\boldsymbol{v}_{\boldsymbol{x}}=\left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} \left\langle \boldsymbol{f}(\boldsymbol{x}%2Br \boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0}">,
- <img src="https://render.githubusercontent.com/render/math?math=\large\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}\boldsymbol{v}_{\boldsymbol{p}_1}=\left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} \left\langle \boldsymbol{f}(\boldsymbol{x},\boldsymbol{p}_1%2Br \boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0}">,
- <img src="https://render.githubusercontent.com/render/math?math=\large\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}\boldsymbol{v}_{\boldsymbol{x}}=\left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} \left\langle \boldsymbol{f}(\boldsymbol{x}%2Br \boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0}">,
- <img src="https://render.githubusercontent.com/render/math?math=\large\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}\boldsymbol{v}_{\boldsymbol{p}_1}=\left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} \left\langle \boldsymbol{f}(\boldsymbol{x},\boldsymbol{p}_1%2Br \boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0}">, 

where <img src="https://render.githubusercontent.com/render/math?math=\large\boldsymbol{x}"> is the solution, <img src="https://render.githubusercontent.com/render/math?math=\large\boldsymbol{p}_1"> is a first distributed parameter, <img src="https://render.githubusercontent.com/render/math?math=\large\boldsymbol{p}_2"> is a potentially different second distributed parameter, <img src="https://render.githubusercontent.com/render/math?math=\large \boldsymbol{f}"> is the residual, <img src="https://render.githubusercontent.com/render/math?math=\large \boldsymbol{z}"> is the Lagrange multiplier vector, <img src="https://render.githubusercontent.com/render/math?math=\large\boldsymbol{v}_\boldsymbol{x}"> is a direction vector with the same dimension as the vector <img src="https://render.githubusercontent.com/render/math?math=\large\boldsymbol{x}">, <img src="https://render.githubusercontent.com/render/math?math=\large\boldsymbol{v}_{\boldsymbol{p}_1}"> is a direction vector with the same dimension as the vector <img src="https://render.githubusercontent.com/render/math?math=\large\boldsymbol{p}_1">, and <img src="https://render.githubusercontent.com/render/math?math=\large\boldsymbol{v}_{\boldsymbol{p}_2}"> is a direction vector with the same dimension as the vector <img src="https://render.githubusercontent.com/render/math?math=\large\boldsymbol{p}_2">.

The implementation has been tested comparing results computed with AD and with Finite Differences (FD) of the gradients on a heat problem and FO_GIS examples.
However, this PR does not include tests yet. They will be included in a second PR.