### PR TITLE
Add UnitTests for scatterScalarResponse and scatterResidual with the HessianVec EvaluationType.

### DIFF
--- a/tests/unit/evaluators/CMakeLists.txt
+++ b/tests/unit/evaluators/CMakeLists.txt
@@ -36,6 +36,18 @@ SET(SOURCES_gatherDistributedParameters
           ${CMAKE_SOURCE_DIR}/src/evaluators/interpolation/PHAL_DOFInterpolation.cpp
 )
 
+SET(SOURCES_scatterScalarResponse
+          ./scatterScalarResponse.cpp
+          ../Albany_UnitTestMain.cpp
+          ${CMAKE_SOURCE_DIR}/src/evaluators/interpolation/PHAL_DOFInterpolation.cpp
+)
+
+SET(SOURCES_scatterResidual
+          ./scatterResidual.cpp
+          ../Albany_UnitTestMain.cpp
+          ${CMAKE_SOURCE_DIR}/src/evaluators/interpolation/PHAL_DOFInterpolation.cpp
+)
+
 SET(HEADERS
           ${CMAKE_SOURCE_DIR}/src/evaluators/utility/PHAL_ComputeBasisFunctions.hpp
           ${CMAKE_SOURCE_DIR}/src/evaluators/interpolation/PHAL_DOFInterpolation.hpp
@@ -60,6 +72,16 @@ ADD_EXECUTABLE(
   ${HEADERS} ${SOURCES_gatherDistributedParameters}
 )
 
+ADD_EXECUTABLE(
+  scatterScalarResponse_unit_tester
+  ${HEADERS} ${SOURCES_scatterScalarResponse}
+)
+
+ADD_EXECUTABLE(
+  scatterResidual_unit_tester
+  ${HEADERS} ${SOURCES_scatterResidual}
+)
+
 set_target_properties(evaluator_unit_tester PROPERTIES
   PUBLIC_HEADER "${HEADERS}")
 
@@ -74,6 +96,16 @@ set_target_properties(gatherDistributedParameters_unit_tester PROPERTIES
   PUBLIC_HEADER "${HEADERS}")
 
 TARGET_LINK_LIBRARIES(gatherDistributedParameters_unit_tester albanyLib ${ALB_TRILINOS_LIBS} ${Trilinos_EXTRA_LD_FLAGS})
+
+set_target_properties(scatterScalarResponse_unit_tester PROPERTIES
+  PUBLIC_HEADER "${HEADERS}")
+
+TARGET_LINK_LIBRARIES(scatterScalarResponse_unit_tester albanyLib ${ALB_TRILINOS_LIBS} ${Trilinos_EXTRA_LD_FLAGS})
+
+set_target_properties(scatterResidual_unit_tester PROPERTIES
+  PUBLIC_HEADER "${HEADERS}")
+
+TARGET_LINK_LIBRARIES(scatterResidual_unit_tester albanyLib ${ALB_TRILINOS_LIBS} ${Trilinos_EXTRA_LD_FLAGS})
 
 # We should always run the unit tests in both serial and parallel if possible (they should run quickly)
 IF (ALBANY_MPI)
@@ -95,6 +127,18 @@ IF (ALBANY_MPI)
   ADD_TEST(
     Albany_Parallel_GatherDistributedParameters_Unit_Test ${PARALLEL_CALL} ${CMAKE_CURRENT_BINARY_DIR}/gatherDistributedParameters_unit_tester
   )
+  ADD_TEST(
+    Albany_Serial_ScatterScalarResponse_Unit_Test ${SERIAL_CALL} ${CMAKE_CURRENT_BINARY_DIR}/scatterScalarResponse_unit_tester
+  )
+  ADD_TEST(
+    Albany_Parallel_ScatterScalarResponse_Unit_Test ${PARALLEL_CALL} ${CMAKE_CURRENT_BINARY_DIR}/scatterScalarResponse_unit_tester
+  )
+  ADD_TEST(
+    Albany_Serial_ScatterResidual_Unit_Test ${SERIAL_CALL} ${CMAKE_CURRENT_BINARY_DIR}/scatterResidual_unit_tester
+  )
+  ADD_TEST(
+    Albany_Parallel_ScatterResidual_Unit_Test ${PARALLEL_CALL} ${CMAKE_CURRENT_BINARY_DIR}/scatterResidual_unit_tester
+  )
 ELSE(ALBANY_MPI)
   ADD_TEST(
     Albany_Unit_Test ${CMAKE_CURRENT_BINARY_DIR}/evaluator_unit_tester
@@ -104,6 +148,12 @@ ELSE(ALBANY_MPI)
   )
   ADD_TEST(
     Albany_GatherDistributedParameters_Unit_Test ${CMAKE_CURRENT_BINARY_DIR}/gatherDistributedParameters_unit_tester
+  )
+  ADD_TEST(
+    Albany_ScatterScalarResponse_Unit_Test ${CMAKE_CURRENT_BINARY_DIR}/scatterScalarResponse_unit_tester
+  )
+  ADD_TEST(
+    Albany_ScatterResidual_Unit_Test ${CMAKE_CURRENT_BINARY_DIR}/scatterResidual_unit_tester
   )
 ENDIF(ALBANY_MPI)
 

--- a/tests/unit/evaluators/EvalTestSetup.hpp
+++ b/tests/unit/evaluators/EvalTestSetup.hpp
@@ -92,11 +92,10 @@ createTestLayoutAndBasis(Teuchos::RCP<Albany::Layouts> &dl,
 
 }
 
-void createTestMapsAndWorksetConns(
+Albany::WorksetConn createTestMapsAndWorksetConns(
    Teuchos::RCP<Tpetra_Map> &cell_map,
    Teuchos::RCP<Tpetra_Map> &overlapped_node_map,
    Albany::WorksetConn wsGlobalElNodeEqID,
-   Albany::WorksetConn wsLocalElNodeEqID,
    int numCells,
    int nodes_per_element,
    int neq,
@@ -189,11 +188,13 @@ void createTestMapsAndWorksetConns(
 
    overlapped_node_map = Teuchos::rcp(new Tpetra_Map(x_size, overlapped_nodes, 0, comm));
 
-   Kokkos::resize(wsLocalElNodeEqID, cell_map->getNodeNumElements(), nodes_per_element, neq);
+   Albany::WorksetConn wsLocalElNodeEqID("wsLocalElNodeEqID", cell_map->getNodeNumElements(), nodes_per_element, neq);
 
    for (int cell=0; cell<cell_map->getNodeNumElements(); ++cell)
       for(int node=0; node<nodes_per_element; ++node)
          wsLocalElNodeEqID(cell,node,0) = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell),node,0));
+
+   return wsLocalElNodeEqID;
 }
 
 }

--- a/tests/unit/evaluators/gatherDistributedParameters.cpp
+++ b/tests/unit/evaluators/gatherDistributedParameters.cpp
@@ -45,8 +45,27 @@ PHX_EXTENT(R)
 
 /**
 * gatherDistributedParametersHessianVec test
-* 
+*
 * This unit test is used to test the gathering of a distributed parameter with HessianVec EvaluationType.
+*
+* The GatherScalarNodalParameter evaluator is tested as follows:
+* - A PHAL::Workset phxWorkset is created for a 2x2x2 hexahedral mesh,
+* - The entries of a distributed parameter are set to the value 6,
+* - 5 cases are then tested: not setting phxWorkset.hessianWorkset.hess_vec_prod_g_**,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_xx,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_xp,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_px,
+*                            and only setting phxWorkset.hessianWorkset.hess_vec_prod_g_pp,
+* - If phxWorkset.hessianWorkset.hess_vec_prod_g_xx or phxWorkset.hessianWorkset.hess_vec_prod_g_px is set,
+*   the direction phxWorkset.hessianWorkset.direction_x is set and its entries are set to 0.4,
+* - If phxWorkset.hessianWorkset.hess_vec_prod_g_xp or phxWorkset.hessianWorkset.hess_vec_prod_g_pp is set,
+*   the direction phxWorkset.hessianWorkset.direction_p is set and its entries are set to 0.4,
+* - The evaluator is then evaluated,
+* - A 2D MDField called solution_out is created with the expected ouput of the GatherScalarNodalParameter,
+* - The entries of solution_out are set to 6: solution_out.deep_copy(6.0);
+* - Depending on whether phxWorkset.hessianWorkset.hess_vec_prod_g_** is set, the values of the derivatives
+*   of solution_out are set accordingly,
+* - The output of the evaluator is compared to the solution_out MDField comparing every entry one by one.
 */
 TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherDistributedParametersHessianVec)
 {

--- a/tests/unit/evaluators/gatherDistributedParameters.cpp
+++ b/tests/unit/evaluators/gatherDistributedParameters.cpp
@@ -35,7 +35,6 @@ PHX_EXTENT(R)
 
 // requires the dim tags defined above
 #include "PHAL_DOFInterpolation.hpp"
-#include "PHAL_GatherSolution.hpp"
 #include "PHAL_GatherScalarNodalParameter.hpp"
 #include "EvalTestSetup.hpp"
 
@@ -63,10 +62,9 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherDistributedParametersHessianVec)
 
   RCP<Tpetra_Map> cell_map, overlapped_node_map;
   Albany::WorksetConn wsGlobalElNodeEqID("wsGlobalElNodeEqID", numCells, nodes_per_element, neq);
-  Albany::WorksetConn wsLocalElNodeEqID("wsLocalElNodeEqID", numCells, nodes_per_element, neq);
   RCP<const Teuchos::Comm<int>> comm = rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
 
-  Albany::createTestMapsAndWorksetConns(cell_map,overlapped_node_map,wsGlobalElNodeEqID,wsLocalElNodeEqID,numCells,nodes_per_element,neq,x_size,comm);
+  Albany::WorksetConn wsLocalElNodeEqID = Albany::createTestMapsAndWorksetConns(cell_map,overlapped_node_map,wsGlobalElNodeEqID,numCells,nodes_per_element,neq,x_size,comm);
 
   Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_node_map);
 
@@ -124,7 +122,6 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherDistributedParametersHessianVec)
   const int num_dim = 3;
 
   std::string param_name("Thermal conductivity");
-  std::string param_name_none("None");
 
   const int tensorRank = 0;
 

--- a/tests/unit/evaluators/gatherSolution.cpp
+++ b/tests/unit/evaluators/gatherSolution.cpp
@@ -45,8 +45,16 @@ PHX_EXTENT(R)
 
 /**
 * gatherSolutionResidual test
-* 
+*
 * This unit test is used to test the gathering of the solution with Residual EvaluationType.
+*
+* The GatherSolution evaluator is tested as follows:
+* - A PHAL::Workset phxWorkset is created for a 2x2x2 hexahedral mesh,
+* - The entries of the vector phxWorkset.x are set to the value 6,
+* - The evaluator is then evaluated,
+* - A 2D MDField called solution_out is created with the expected ouput of the GatherSolution,
+* - The entries of solution_out are set to 6: solution_out.deep_copy(6.0);
+* - The output of the evaluator is compared to the solution_out MDField comparing every entry one by one.
 */
 TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionResidual)
 {
@@ -129,8 +137,27 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionResidual)
 
 /**
 * gatherSolutionHessianVec test
-* 
+*
 * This unit test is used to test the gathering of the solution with HessianVec EvaluationType.
+*
+* The GatherSolution evaluator is tested as follows:
+* - A PHAL::Workset phxWorkset is created for a 2x2x2 hexahedral mesh,
+* - The entries of the vector phxWorkset.x are set to the value 6,
+* - 5 cases are then tested: not setting phxWorkset.hessianWorkset.hess_vec_prod_g_**,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_xx,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_xp,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_px,
+*                            and only setting phxWorkset.hessianWorkset.hess_vec_prod_g_pp,
+* - If phxWorkset.hessianWorkset.hess_vec_prod_g_xx or phxWorkset.hessianWorkset.hess_vec_prod_g_px is set,
+*   the direction phxWorkset.hessianWorkset.direction_x is set and its entries are set to 0.4,
+* - If phxWorkset.hessianWorkset.hess_vec_prod_g_xp or phxWorkset.hessianWorkset.hess_vec_prod_g_pp is set,
+*   the direction phxWorkset.hessianWorkset.direction_p is set and its entries are set to 0.4,
+* - The evaluator is then evaluated,
+* - A 2D MDField called solution_out is created with the expected ouput of the GatherSolution,
+* - The entries of solution_out are set to 6: solution_out.deep_copy(6.0);
+* - Depending on whether phxWorkset.hessianWorkset.hess_vec_prod_g_** is set, the values of the derivatives
+*   of solution_out are set accordingly,
+* - The output of the evaluator is compared to the solution_out MDField comparing every entry one by one.
 */
 TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionHessianVec)
 {

--- a/tests/unit/evaluators/gatherSolution.cpp
+++ b/tests/unit/evaluators/gatherSolution.cpp
@@ -43,6 +43,11 @@ PHX_EXTENT(R)
 #include "Albany_DistributedParameterLibrary.hpp"
 #include <stk_mesh/base/CoordinateSystems.hpp>
 
+/**
+* gatherSolutionResidual test
+* 
+* This unit test is used to test the gathering of the solution with Residual EvaluationType.
+*/
 TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionResidual)
 {
   using namespace std;
@@ -55,18 +60,22 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionResidual)
   PHAL::Setup phxSetup;
   PHAL::Workset phxWorkset;
 
-  const int x_size = 27;
-  const int numCells = 8;
+  const int numCells_per_direction = 2;
   const int nodes_per_element = 8;
   const int neq = 1;
 
-  RCP<Tpetra_Map> cell_map, overlapped_node_map;
+  const int numCells = numCells_per_direction * numCells_per_direction * numCells_per_direction;
+
+  RCP<Tpetra_Map> cell_map, overlapped_node_map, overlapped_dof_map;
   Albany::WorksetConn wsGlobalElNodeEqID("wsGlobalElNodeEqID", numCells, nodes_per_element, neq);
+  Albany::WorksetConn wsLocalElNodeEqID("wsLocalElNodeEqID", numCells, nodes_per_element, neq);
   RCP<const Teuchos::Comm<int>> comm = rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
 
-  Albany::WorksetConn wsLocalElNodeEqID = Albany::createTestMapsAndWorksetConns(cell_map,overlapped_node_map,wsGlobalElNodeEqID,numCells,nodes_per_element,neq,x_size,comm);
+  Albany::createTestMapsAndWorksetConns(cell_map, overlapped_node_map, overlapped_dof_map, wsGlobalElNodeEqID, wsLocalElNodeEqID, numCells_per_direction, nodes_per_element, neq, comm);
 
-  Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_node_map);
+  Kokkos::resize(wsLocalElNodeEqID, cell_map->getNodeNumElements(), nodes_per_element, neq);
+
+  Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_dof_map);
 
   const Teuchos::RCP<Thyra_Vector> overlapped_x = Thyra::createMember(overlapped_x_space);
 
@@ -76,7 +85,7 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionResidual)
   phxWorkset.wsElNodeEqID = wsLocalElNodeEqID;
 
   auto x_array = Albany::getNonconstLocalData(overlapped_x);
-  for (size_t i=0; i<x_array.size(); ++i)
+  for (size_t i = 0; i < x_array.size(); ++i)
     x_array[i] = 6.;
 
   phxWorkset.numCells = cell_map->getNodeNumElements();
@@ -96,12 +105,12 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionResidual)
 
   // Need dl->node_scalar, dl->node_qp_scalar, dl->qp_scalar for this evaluator (PHAL_DOFInterpolation_Def.hpp line 20)
   RCP<Albany::Layouts> dl;
-  RCP<PHAL::ComputeBasisFunctions<EvalType,PHAL::AlbanyTraits>> FEBasis =
-     Albany::createTestLayoutAndBasis<EvalType,PHAL::AlbanyTraits>(dl, phxWorkset.numCells, cubature_degree, num_dim);
+  RCP<PHAL::ComputeBasisFunctions<EvalType, PHAL::AlbanyTraits>> FEBasis =
+      Albany::createTestLayoutAndBasis<EvalType, PHAL::AlbanyTraits>(dl, phxWorkset.numCells, cubature_degree, num_dim);
 
   // Same as DOFInterpolationBase<EvalType,AlbanyTraits,Evalt::ScalarT>
-  RCP<PHAL::GatherSolution<EvalType,PHAL::AlbanyTraits>> GatherSolution =
-        rcp(new PHAL::GatherSolution<EvalType,PHAL::AlbanyTraits>(*p, dl));
+  RCP<PHAL::GatherSolution<EvalType, PHAL::AlbanyTraits>> GatherSolution =
+      rcp(new PHAL::GatherSolution<EvalType, PHAL::AlbanyTraits>(*p, dl));
 
   // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
   PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
@@ -110,7 +119,7 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionResidual)
   Kokkos::fence();
 
   // This is the "gold_field" - what is the solution that we should get?
-  MDField<Scalar,CELL,NODE> solution_out = allocateUnmanagedMDField<Scalar,CELL,NODE>(dof_name, dl->node_scalar);
+  MDField<Scalar, CELL, NODE> solution_out = allocateUnmanagedMDField<Scalar, CELL, NODE>(dof_name, dl->node_scalar);
   solution_out.deep_copy(6.0);
   const Scalar tol = 1000.0 * std::numeric_limits<Scalar>::epsilon();
 
@@ -118,6 +127,11 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionResidual)
   tester.checkFloatValues2(solution_out, tol, success, out);
 }
 
+/**
+* gatherSolutionHessianVec test
+* 
+* This unit test is used to test the gathering of the solution with HessianVec EvaluationType.
+*/
 TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionHessianVec)
 {
   using namespace std;
@@ -130,27 +144,33 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionHessianVec)
   PHAL::Setup phxSetup;
   PHAL::Workset phxWorkset;
 
-  const int x_size = 27;
-  const int numCells = 8;
+  const int numCells_per_direction = 2;
   const int nodes_per_element = 8;
   const int neq = 1;
 
-  RCP<Tpetra_Map> cell_map, overlapped_node_map;
+  const int numCells = numCells_per_direction * numCells_per_direction * numCells_per_direction;
+
+  RCP<Tpetra_Map> cell_map, overlapped_node_map, overlapped_dof_map;
   Albany::WorksetConn wsGlobalElNodeEqID("wsGlobalElNodeEqID", numCells, nodes_per_element, neq);
+  Albany::WorksetConn wsLocalElNodeEqID("wsLocalElNodeEqID", numCells, nodes_per_element, neq);
   RCP<const Teuchos::Comm<int>> comm = rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
 
-  Albany::WorksetConn wsLocalElNodeEqID = Albany::createTestMapsAndWorksetConns(cell_map,overlapped_node_map,wsGlobalElNodeEqID,numCells,nodes_per_element,neq,x_size,comm);
+  Albany::createTestMapsAndWorksetConns(cell_map, overlapped_node_map, overlapped_dof_map, wsGlobalElNodeEqID, wsLocalElNodeEqID, numCells_per_direction, nodes_per_element, neq, comm);
 
-  Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_node_map);
+  Kokkos::resize(wsLocalElNodeEqID, cell_map->getNodeNumElements(), nodes_per_element, neq);
+
+  Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_dof_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> overlapped_p_space = Albany::createThyraVectorSpace(overlapped_node_map);
 
   const Teuchos::RCP<Thyra_Vector> overlapped_x = Thyra::createMember(overlapped_x_space);
   const Teuchos::RCP<Thyra_Vector> direction_x = Thyra::createMember(overlapped_x_space);
-  const Teuchos::RCP<Thyra_Vector> direction_p = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> direction_p = Thyra::createMember(overlapped_p_space);
 
   const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xx = Thyra::createMember(overlapped_x_space);
   const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xp = Thyra::createMember(overlapped_x_space);
-  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_px = Thyra::createMember(overlapped_x_space);
-  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_pp = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_px = Thyra::createMember(overlapped_p_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_pp = Thyra::createMember(overlapped_p_space);
 
   Kokkos::fence();
 
@@ -158,15 +178,15 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionHessianVec)
   phxWorkset.wsElNodeEqID = wsLocalElNodeEqID;
 
   auto x_array = Albany::getNonconstLocalData(overlapped_x);
-  for (size_t i=0; i<x_array.size(); ++i)
+  for (size_t i = 0; i < x_array.size(); ++i)
     x_array[i] = 6.;
 
   auto direction_x_array = Albany::getNonconstLocalData(direction_x);
-  for (size_t i=0; i<direction_x_array.size(); ++i)
+  for (size_t i = 0; i < direction_x_array.size(); ++i)
     direction_x_array[i] = 0.4;
 
   auto direction_p_array = Albany::getNonconstLocalData(direction_p);
-  for (size_t i=0; i<direction_p_array.size(); ++i)
+  for (size_t i = 0; i < direction_p_array.size(); ++i)
     direction_p_array[i] = 0.4;
 
   phxWorkset.numCells = cell_map->getNodeNumElements();
@@ -186,12 +206,12 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionHessianVec)
 
   // Need dl->node_scalar, dl->node_qp_scalar, dl->qp_scalar for this evaluator (PHAL_DOFInterpolation_Def.hpp line 20)
   RCP<Albany::Layouts> dl;
-  RCP<PHAL::ComputeBasisFunctions<EvalType,PHAL::AlbanyTraits>> FEBasis =
-     Albany::createTestLayoutAndBasis<EvalType,PHAL::AlbanyTraits>(dl, phxWorkset.numCells, cubature_degree, num_dim);
+  RCP<PHAL::ComputeBasisFunctions<EvalType, PHAL::AlbanyTraits>> FEBasis =
+      Albany::createTestLayoutAndBasis<EvalType, PHAL::AlbanyTraits>(dl, phxWorkset.numCells, cubature_degree, num_dim);
 
   // Same as DOFInterpolationBase<EvalType,AlbanyTraits,Evalt::ScalarT>
-  RCP<PHAL::GatherSolution<EvalType,PHAL::AlbanyTraits>> GatherSolution =
-        rcp(new PHAL::GatherSolution<EvalType,PHAL::AlbanyTraits>(*p, dl));
+  RCP<PHAL::GatherSolution<EvalType, PHAL::AlbanyTraits>> GatherSolution =
+      rcp(new PHAL::GatherSolution<EvalType, PHAL::AlbanyTraits>(*p, dl));
 
   std::vector<PHX::index_size_type> derivative_dimensions;
   derivative_dimensions.push_back(8);
@@ -200,7 +220,7 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionHessianVec)
   const scalarType tol = 1000.0 * std::numeric_limits<scalarType>::epsilon();
 
   // This is the "gold_field" - what is the solution that we should get?
-  MDField<Scalar,CELL,NODE> solution_out = allocateUnmanagedMDField<Scalar,CELL,NODE>(dof_name, dl->node_scalar, derivative_dimensions);
+  MDField<Scalar, CELL, NODE> solution_out = allocateUnmanagedMDField<Scalar, CELL, NODE>(dof_name, dl->node_scalar, derivative_dimensions);
 
   // Test without setting hess_vec_prod_g_**
   {
@@ -232,10 +252,12 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionHessianVec)
 
     auto solution_out_field = Kokkos::create_mirror_view(solution_out.get_view());
 
-    for (std::size_t cell=0; cell < static_cast<int>(solution_out_field.extent(0)); ++cell) {
-      for (std::size_t node=0; node < static_cast<int>(solution_out_field.extent(1)); ++node) {
-        solution_out_field(cell,node).fastAccessDx(node).val() = 1;
-        solution_out_field(cell,node).val().fastAccessDx(0) = direction_x_array[wsLocalElNodeEqID(cell,node,0)];
+    for (std::size_t cell = 0; cell < static_cast<int>(solution_out_field.extent(0)); ++cell)
+    {
+      for (std::size_t node = 0; node < static_cast<int>(solution_out_field.extent(1)); ++node)
+      {
+        solution_out_field(cell, node).fastAccessDx(node).val() = 1;
+        solution_out_field(cell, node).val().fastAccessDx(0) = direction_x_array[wsLocalElNodeEqID(cell, node, 0)];
       }
     }
 
@@ -262,9 +284,11 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionHessianVec)
 
     auto solution_out_field = Kokkos::create_mirror_view(solution_out.get_view());
 
-    for (std::size_t cell=0; cell < static_cast<int>(solution_out_field.extent(0)); ++cell) {
-      for (std::size_t node=0; node < static_cast<int>(solution_out_field.extent(1)); ++node) {
-        solution_out_field(cell,node).fastAccessDx(node).val() = 1;
+    for (std::size_t cell = 0; cell < static_cast<int>(solution_out_field.extent(0)); ++cell)
+    {
+      for (std::size_t node = 0; node < static_cast<int>(solution_out_field.extent(1)); ++node)
+      {
+        solution_out_field(cell, node).fastAccessDx(node).val() = 1;
       }
     }
 
@@ -291,9 +315,11 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionHessianVec)
 
     auto solution_out_field = Kokkos::create_mirror_view(solution_out.get_view());
 
-    for (std::size_t cell=0; cell < static_cast<int>(solution_out_field.extent(0)); ++cell) {
-      for (std::size_t node=0; node < static_cast<int>(solution_out_field.extent(1)); ++node) {
-        solution_out_field(cell,node).val().fastAccessDx(0) = direction_x_array[wsLocalElNodeEqID(cell,node,0)];
+    for (std::size_t cell = 0; cell < static_cast<int>(solution_out_field.extent(0)); ++cell)
+    {
+      for (std::size_t node = 0; node < static_cast<int>(solution_out_field.extent(1)); ++node)
+      {
+        solution_out_field(cell, node).val().fastAccessDx(0) = direction_x_array[wsLocalElNodeEqID(cell, node, 0)];
       }
     }
 

--- a/tests/unit/evaluators/gatherSolution.cpp
+++ b/tests/unit/evaluators/gatherSolution.cpp
@@ -36,7 +36,6 @@ PHX_EXTENT(R)
 // requires the dim tags defined above
 #include "PHAL_DOFInterpolation.hpp"
 #include "PHAL_GatherSolution.hpp"
-#include "PHAL_GatherScalarNodalParameter.hpp"
 #include "EvalTestSetup.hpp"
 
 #include "Albany_TpetraThyraUtils.hpp"
@@ -63,10 +62,9 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionResidual)
 
   RCP<Tpetra_Map> cell_map, overlapped_node_map;
   Albany::WorksetConn wsGlobalElNodeEqID("wsGlobalElNodeEqID", numCells, nodes_per_element, neq);
-  Albany::WorksetConn wsLocalElNodeEqID("wsLocalElNodeEqID", numCells, nodes_per_element, neq);
   RCP<const Teuchos::Comm<int>> comm = rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
 
-  Albany::createTestMapsAndWorksetConns(cell_map,overlapped_node_map,wsGlobalElNodeEqID,wsLocalElNodeEqID,numCells,nodes_per_element,neq,x_size,comm);
+  Albany::WorksetConn wsLocalElNodeEqID = Albany::createTestMapsAndWorksetConns(cell_map,overlapped_node_map,wsGlobalElNodeEqID,numCells,nodes_per_element,neq,x_size,comm);
 
   Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_node_map);
 
@@ -139,10 +137,9 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionHessianVec)
 
   RCP<Tpetra_Map> cell_map, overlapped_node_map;
   Albany::WorksetConn wsGlobalElNodeEqID("wsGlobalElNodeEqID", numCells, nodes_per_element, neq);
-  Albany::WorksetConn wsLocalElNodeEqID("wsLocalElNodeEqID", numCells, nodes_per_element, neq);
   RCP<const Teuchos::Comm<int>> comm = rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
 
-  Albany::createTestMapsAndWorksetConns(cell_map,overlapped_node_map,wsGlobalElNodeEqID,wsLocalElNodeEqID,numCells,nodes_per_element,neq,x_size,comm);
+  Albany::WorksetConn wsLocalElNodeEqID = Albany::createTestMapsAndWorksetConns(cell_map,overlapped_node_map,wsGlobalElNodeEqID,numCells,nodes_per_element,neq,x_size,comm);
 
   Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_node_map);
 

--- a/tests/unit/evaluators/scatterResidual.cpp
+++ b/tests/unit/evaluators/scatterResidual.cpp
@@ -45,7 +45,15 @@ PHX_EXTENT(R)
 #include "Albany_DistributedParameterLibrary.hpp"
 #include <stk_mesh/base/CoordinateSystems.hpp>
 
-TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
+/**
+* scatterResidualHessianVecTensorRank0 test
+* 
+* This unit test is used to test the scatter of the residual with AD for the computation of
+* Hessian-vector products with rank 0 solution.
+*
+* The xx, xp, px, and pp contributions are tested.
+*/
+TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVecTensorRank0)
 {
   using namespace std;
   using namespace Teuchos;
@@ -57,53 +65,67 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
   PHAL::Setup phxSetup;
   PHAL::Workset phxWorkset;
 
-  const int x_size = 27;
-  const int numCells = 8;
+  const int numCells_per_direction = 2;
   const int nodes_per_element = 8;
   const int neq = 1;
 
-  RCP<Tpetra_Map> cell_map, overlapped_node_map;
+  const int numCells = numCells_per_direction * numCells_per_direction * numCells_per_direction;
+
+  RCP<Tpetra_Map> cell_map, overlapped_node_map, overlapped_dof_map;
   Albany::WorksetConn wsGlobalElNodeEqID("wsGlobalElNodeEqID", numCells, nodes_per_element, neq);
+  Albany::WorksetConn wsLocalElNodeEqID("wsLocalElNodeEqID", numCells, nodes_per_element, neq);
   RCP<const Teuchos::Comm<int>> comm = rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
 
-  Albany::WorksetConn wsLocalElNodeEqID = Albany::createTestMapsAndWorksetConns(cell_map,overlapped_node_map,wsGlobalElNodeEqID,numCells,nodes_per_element,neq,x_size,comm);
+  Albany::createTestMapsAndWorksetConns(cell_map, overlapped_node_map, overlapped_dof_map, wsGlobalElNodeEqID, wsLocalElNodeEqID, numCells_per_direction, nodes_per_element, neq, comm);
 
-  RCP<const Tpetra_Map> node_map = Tpetra::createOneToOne<Tpetra_Map::local_ordinal_type,Tpetra_Map::global_ordinal_type,Tpetra_Map::node_type>(overlapped_node_map);
+  Kokkos::resize(wsLocalElNodeEqID, cell_map->getNodeNumElements(), nodes_per_element, neq);
 
-  Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_node_map);
-  Teuchos::RCP<const Thyra_VectorSpace> x_space = Albany::createThyraVectorSpace(node_map);
+  RCP<const Tpetra_Map> node_map = Tpetra::createOneToOne<Tpetra_Map::local_ordinal_type, Tpetra_Map::global_ordinal_type, Tpetra_Map::node_type>(overlapped_node_map);
+
+  RCP<const Tpetra_Map> dof_map = Tpetra::createOneToOne<Tpetra_Map::local_ordinal_type, Tpetra_Map::global_ordinal_type, Tpetra_Map::node_type>(overlapped_dof_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_dof_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> overlapped_p_space = Albany::createThyraVectorSpace(overlapped_node_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> x_space = Albany::createThyraVectorSpace(dof_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> p_space = Albany::createThyraVectorSpace(node_map);
 
   const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_xx = Thyra::createMember(x_space);
   const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_xp = Thyra::createMember(x_space);
-  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_px = Thyra::createMember(x_space);
-  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_pp = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_px = Thyra::createMember(p_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_pp = Thyra::createMember(p_space);
 
   const Teuchos::RCP<Thyra_Vector> f_multiplier = Thyra::createMember(overlapped_x_space);
 
   const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_xx = Thyra::createMember(overlapped_x_space);
   const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_xp = Thyra::createMember(overlapped_x_space);
-  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_px = Thyra::createMember(overlapped_x_space);
-  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_pp = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_px = Thyra::createMember(overlapped_p_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_pp = Thyra::createMember(overlapped_p_space);
 
-  const Teuchos::RCP<Thyra_Vector> diff_out = Thyra::createMember(x_space);
-  const Teuchos::RCP<Thyra_Vector> one_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> diff_x_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> one_x_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> diff_p_out = Thyra::createMember(p_space);
+  const Teuchos::RCP<Thyra_Vector> one_p_out = Thyra::createMember(p_space);
 
   const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_xx_out = Thyra::createMember(x_space);
   const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_xp_out = Thyra::createMember(x_space);
-  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_px_out = Thyra::createMember(x_space);
-  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_pp_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_px_out = Thyra::createMember(p_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_pp_out = Thyra::createMember(p_space);
 
   const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_xx_out = Thyra::createMember(overlapped_x_space);
   const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_xp_out = Thyra::createMember(overlapped_x_space);
-  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_px_out = Thyra::createMember(overlapped_x_space);
-  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_pp_out = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_px_out = Thyra::createMember(overlapped_p_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_pp_out = Thyra::createMember(overlapped_p_space);
 
   overlapped_hess_vec_prod_f_xx->assign(0.0);
   overlapped_hess_vec_prod_f_xp->assign(0.0);
   overlapped_hess_vec_prod_f_px->assign(0.0);
   overlapped_hess_vec_prod_f_pp->assign(0.0);
 
-  one_out->assign(1.0);
+  one_x_out->assign(1.0);
+  one_p_out->assign(1.0);
 
   f_multiplier->assign(1.0);
 
@@ -117,10 +139,10 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
   auto hess_vec_prod_f_px_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_f_px_out);
   auto hess_vec_prod_f_pp_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_f_pp_out);
 
-
-  for (int cell=0; cell<cell_map->getNodeNumElements(); ++cell)
-    for(int node=0; node<nodes_per_element; ++node) {
-      size_t id = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell),node,0));
+  for (int cell = 0; cell < cell_map->getNodeNumElements(); ++cell)
+    for (int node = 0; node < nodes_per_element; ++node)
+    {
+      size_t id = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell), node, 0));
       hess_vec_prod_f_xx_out_array[id] += 4.;
       hess_vec_prod_f_xp_out_array[id] += 4.;
       hess_vec_prod_f_px_out_array[id] += 4.;
@@ -128,13 +150,15 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
     }
 
   RCP<Albany::CombineAndScatterManager> x_cas_manager = Albany::createCombineAndScatterManager(x_space, overlapped_x_space);
+  RCP<Albany::CombineAndScatterManager> p_cas_manager = Albany::createCombineAndScatterManager(p_space, overlapped_p_space);
+
   x_cas_manager->combine(overlapped_hess_vec_prod_f_xx_out, hess_vec_prod_f_xx_out, Albany::CombineMode::ADD);
   x_cas_manager->combine(overlapped_hess_vec_prod_f_xp_out, hess_vec_prod_f_xp_out, Albany::CombineMode::ADD);
-  x_cas_manager->combine(overlapped_hess_vec_prod_f_px_out, hess_vec_prod_f_px_out, Albany::CombineMode::ADD);
-  x_cas_manager->combine(overlapped_hess_vec_prod_f_pp_out, hess_vec_prod_f_pp_out, Albany::CombineMode::ADD);
+  p_cas_manager->combine(overlapped_hess_vec_prod_f_px_out, hess_vec_prod_f_px_out, Albany::CombineMode::ADD);
+  p_cas_manager->combine(overlapped_hess_vec_prod_f_pp_out, hess_vec_prod_f_pp_out, Albany::CombineMode::ADD);
 
   RCP<Teuchos::FancyOStream>
-    out_test = Teuchos::VerboseObjectBase::getDefaultOStream();
+      out_test = Teuchos::VerboseObjectBase::getDefaultOStream();
 
   Teuchos::EVerbosityLevel verbLevel = Teuchos::VERB_EXTREME;
 
@@ -150,17 +174,16 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
   for (std::size_t i = 0; i < numBucks; i++)
     wsElNodeEqID_ID_raw[i].resize(buck_size * nodes_per_element * neq);
 
-
-  for (int cell=0; cell<cell_map->getNodeNumElements(); ++cell)
-    for(int node=0; node<nodes_per_element; ++node)
-      wsElNodeEqID_ID_raw[0][cell*nodes_per_element+node] = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell),node,0));
+  for (int cell = 0; cell < cell_map->getNodeNumElements(); ++cell)
+    for (int node = 0; node < nodes_per_element; ++node)
+      wsElNodeEqID_ID_raw[0][cell * nodes_per_element * neq + node * neq] = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell), node, 0) / neq);
 
   for (std::size_t i = 0; i < numBucks; i++)
     wsElNodeEqID_ID[i].assign<stk::mesh::Cartesian, stk::mesh::Cartesian, stk::mesh::Cartesian>(
-          wsElNodeEqID_ID_raw[i].data(),
-          buck_size,
-          nodes_per_element,
-          neq);
+        wsElNodeEqID_ID_raw[i].data(),
+        buck_size,
+        nodes_per_element,
+        neq);
 
   Kokkos::fence();
 
@@ -174,8 +197,8 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
 
   // Need dl->node_scalar, dl->node_qp_scalar, dl->qp_scalar for this evaluator (PHAL_DOFInterpolation_Def.hpp line 20)
   RCP<Albany::Layouts> dl;
-  RCP<PHAL::ComputeBasisFunctions<EvalType,PHAL::AlbanyTraits>> FEBasis =
-     Albany::createTestLayoutAndBasis<EvalType,PHAL::AlbanyTraits>(dl, phxWorkset.numCells, cubature_degree, num_dim);
+  RCP<PHAL::ComputeBasisFunctions<EvalType, PHAL::AlbanyTraits>> FEBasis =
+      Albany::createTestLayoutAndBasis<EvalType, PHAL::AlbanyTraits>(dl, phxWorkset.numCells, cubature_degree, num_dim);
 
   std::string field_name = "Temperature";
 
@@ -186,19 +209,17 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
   p.set("Residual Name", residual_name);
   p.set("Tensor Rank", tensorRank);
   int worksetSize = dl->qp_scalar->extent(0);
-  auto residual_layout = Teuchos::rcp(new MDALayout<Cell, Node>(worksetSize,8));
-  PHX::Tag<Scalar> residual_tag(residual_name, residual_layout);
+  auto residual_layout = Teuchos::rcp(new MDALayout<Cell, Node>(worksetSize, nodes_per_element));
 
-  ParameterList* plist = new ParameterList("Parameter List");
-  p.set<ParameterList*>("Parameter List",plist);
+  ParameterList *plist = new ParameterList("Parameter List");
+  p.set<ParameterList *>("Parameter List", plist);
 
   // Same as DOFInterpolationBase<EvalType,AlbanyTraits,Evalt::ScalarT>
-  RCP<PHAL::ScatterResidual<EvalType,PHAL::AlbanyTraits>> ScatterResidual =
-        rcp(new PHAL::ScatterResidual<EvalType,PHAL::AlbanyTraits>(p, dl));
-
+  RCP<PHAL::ScatterResidual<EvalType, PHAL::AlbanyTraits>> ScatterResidual =
+      rcp(new PHAL::ScatterResidual<EvalType, PHAL::AlbanyTraits>(p, dl));
 
   std::vector<PHX::index_size_type> derivative_dimensions;
-  derivative_dimensions.push_back(8);
+  derivative_dimensions.push_back(nodes_per_element * neq);
 
   typedef typename Sacado::ScalarType<Scalar>::type scalarType;
   const scalarType tol = 1000.0 * std::numeric_limits<scalarType>::epsilon();
@@ -210,7 +231,7 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
       overlapped_x_space));
 
   parameter->set_workset_elem_dofs(Teuchos::rcpFromRef(wsElNodeEqID_ID));
-  const Albany::IDArray& wsElDofs = parameter->workset_elem_dofs()[0];
+  const Albany::IDArray &wsElDofs = parameter->workset_elem_dofs()[0];
   Teuchos::RCP<Thyra_Vector> dist_param = parameter->vector();
   dist_param->assign(6.0);
   parameter->scatter();
@@ -223,13 +244,16 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
   phxWorkset.hessianWorkset.dist_param_deriv_direction_name = param_name;
   phxWorkset.hessianWorkset.f_multiplier = f_multiplier;
 
-  MDField<Scalar,Cell, Node> residual = allocateUnmanagedMDField<Scalar,Cell, Node>(residual_name, residual_layout, derivative_dimensions);
+  MDField<Scalar, Cell, Node> residual = allocateUnmanagedMDField<Scalar, Cell, Node>(residual_name, residual_layout, derivative_dimensions);
   residual.deep_copy(0.0);
 
-  for (std::size_t cell=0; cell < static_cast<int>(residual.extent(0)); ++cell) {
-    for (std::size_t node1=0; node1 < static_cast<int>(residual.extent(1)); ++node1) {
-      for (std::size_t node2=0; node2 < static_cast<int>(residual.extent(1)); ++node2) {
-        residual(cell,node1).fastAccessDx(node2).fastAccessDx(0) = 0.5;
+  for (std::size_t cell = 0; cell < static_cast<int>(residual.extent(0)); ++cell)
+  {
+    for (std::size_t node1 = 0; node1 < static_cast<int>(residual.extent(1)); ++node1)
+    {
+      for (std::size_t node2 = 0; node2 < static_cast<int>(residual.extent(1)); ++node2)
+      {
+        residual(cell, node1).fastAccessDx(node2).fastAccessDx(0) = 0.5;
       }
     }
   }
@@ -247,56 +271,48 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
 
     x_cas_manager->combine(overlapped_hess_vec_prod_f_xx, hess_vec_prod_f_xx, Albany::CombineMode::ADD);
     x_cas_manager->combine(overlapped_hess_vec_prod_f_xp, hess_vec_prod_f_xp, Albany::CombineMode::ADD);
-    x_cas_manager->combine(overlapped_hess_vec_prod_f_px, hess_vec_prod_f_px, Albany::CombineMode::ADD);
-    x_cas_manager->combine(overlapped_hess_vec_prod_f_pp, hess_vec_prod_f_pp, Albany::CombineMode::ADD);
+    p_cas_manager->combine(overlapped_hess_vec_prod_f_px, hess_vec_prod_f_px, Albany::CombineMode::ADD);
+    p_cas_manager->combine(overlapped_hess_vec_prod_f_pp, hess_vec_prod_f_pp, Albany::CombineMode::ADD);
 
-    Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_f_xx);
-
-    TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_f_xx_out", *one_out,
-      "hess_vec_prod_f_xx", *diff_out,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
-
-    Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_f_xp);
+    Thyra::V_VmV(diff_x_out.ptr(), *one_x_out, *hess_vec_prod_f_xx);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_f_xp_out", *one_out,
-      "hess_vec_prod_f_xp", *diff_out,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_xx_out", *one_x_out,
+            "hess_vec_prod_f_xx", *diff_x_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
 
-    Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_f_px);
+    Thyra::V_VmV(diff_x_out.ptr(), *one_x_out, *hess_vec_prod_f_xp);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_f_px_out", *one_out,
-      "hess_vec_prod_f_px", *diff_out,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_xp_out", *one_x_out,
+            "hess_vec_prod_f_xp", *diff_x_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
 
-    Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_f_pp);
+    Thyra::V_VmV(diff_p_out.ptr(), *one_p_out, *hess_vec_prod_f_px);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_f_pp_out", *one_out,
-      "hess_vec_prod_f_pp", *diff_out,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_px_out", *one_p_out,
+            "hess_vec_prod_f_px", *diff_p_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    Thyra::V_VmV(diff_p_out.ptr(), *one_p_out, *hess_vec_prod_f_pp);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_pp_out", *one_p_out,
+            "hess_vec_prod_f_pp", *diff_p_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
   }
   // Test hess_vec_prod_f_xx
   {
@@ -315,14 +331,12 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
     x_cas_manager->combine(overlapped_hess_vec_prod_f_xx, hess_vec_prod_f_xx, Albany::CombineMode::ADD);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_f_xx_out", *hess_vec_prod_f_xx_out,
-      "hess_vec_prod_f_xx", *hess_vec_prod_f_xx,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_xx_out", *hess_vec_prod_f_xx_out,
+            "hess_vec_prod_f_xx", *hess_vec_prod_f_xx,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
 
     phxWorkset.hessianWorkset.hess_vec_prod_f_xx = Teuchos::null;
     phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_xx = Teuchos::null;
@@ -344,14 +358,12 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
     x_cas_manager->combine(overlapped_hess_vec_prod_f_xp, hess_vec_prod_f_xp, Albany::CombineMode::ADD);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_f_xp_out", *hess_vec_prod_f_xp_out,
-      "hess_vec_prod_f_xp", *hess_vec_prod_f_xp,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_xp_out", *hess_vec_prod_f_xp_out,
+            "hess_vec_prod_f_xp", *hess_vec_prod_f_xp,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
 
     phxWorkset.hessianWorkset.hess_vec_prod_f_xp = Teuchos::null;
     phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_xp = Teuchos::null;
@@ -370,17 +382,15 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
 
     Kokkos::fence();
 
-    x_cas_manager->combine(overlapped_hess_vec_prod_f_px, hess_vec_prod_f_px, Albany::CombineMode::ADD);
+    p_cas_manager->combine(overlapped_hess_vec_prod_f_px, hess_vec_prod_f_px, Albany::CombineMode::ADD);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_f_px_out", *hess_vec_prod_f_px_out,
-      "hess_vec_prod_f_px", *hess_vec_prod_f_px,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_px_out", *hess_vec_prod_f_px_out,
+            "hess_vec_prod_f_px", *hess_vec_prod_f_px,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
 
     phxWorkset.hessianWorkset.hess_vec_prod_f_px = Teuchos::null;
     phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_px = Teuchos::null;
@@ -399,17 +409,401 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
 
     Kokkos::fence();
 
-    x_cas_manager->combine(overlapped_hess_vec_prod_f_pp, hess_vec_prod_f_pp, Albany::CombineMode::ADD);
+    p_cas_manager->combine(overlapped_hess_vec_prod_f_pp, hess_vec_prod_f_pp, Albany::CombineMode::ADD);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_f_pp_out", *hess_vec_prod_f_pp_out,
-      "hess_vec_prod_f_pp", *hess_vec_prod_f_pp,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_pp_out", *hess_vec_prod_f_pp_out,
+            "hess_vec_prod_f_pp", *hess_vec_prod_f_pp,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    phxWorkset.hessianWorkset.hess_vec_prod_f_pp = Teuchos::null;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_pp = Teuchos::null;
+  }
+}
+
+/**
+* scatterResidualHessianVecTensorRank1 test
+* 
+* This unit test is used to test the scatter of the residual with AD for the computation of
+* Hessian-vector products with rank 1 solution.
+*
+* The xx, xp, px, and pp contributions are tested.
+*/
+TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVecTensorRank1)
+{
+  using namespace std;
+  using namespace Teuchos;
+  using namespace PHX;
+
+  using EvalType = PHAL::AlbanyTraits::HessianVec;
+  using Scalar = EvalType::ScalarT;
+
+  PHAL::Setup phxSetup;
+  PHAL::Workset phxWorkset;
+
+  const int tensorRank = 1;
+
+  const int numCells_per_direction = 2;
+  const int nodes_per_element = 8;
+  const int neq = 3;
+
+  const int numCells = numCells_per_direction * numCells_per_direction * numCells_per_direction;
+
+  RCP<Tpetra_Map> cell_map, overlapped_node_map, overlapped_dof_map;
+  Albany::WorksetConn wsGlobalElNodeEqID("wsGlobalElNodeEqID", numCells, nodes_per_element, neq);
+  Albany::WorksetConn wsLocalElNodeEqID("wsLocalElNodeEqID", numCells, nodes_per_element, neq);
+  RCP<const Teuchos::Comm<int>> comm = rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
+
+  Albany::createTestMapsAndWorksetConns(cell_map, overlapped_node_map, overlapped_dof_map, wsGlobalElNodeEqID, wsLocalElNodeEqID, numCells_per_direction, nodes_per_element, neq, comm);
+
+  Kokkos::resize(wsLocalElNodeEqID, cell_map->getNodeNumElements(), nodes_per_element, neq);
+
+  RCP<const Tpetra_Map> node_map = Tpetra::createOneToOne<Tpetra_Map::local_ordinal_type, Tpetra_Map::global_ordinal_type, Tpetra_Map::node_type>(overlapped_node_map);
+
+  RCP<const Tpetra_Map> dof_map = Tpetra::createOneToOne<Tpetra_Map::local_ordinal_type, Tpetra_Map::global_ordinal_type, Tpetra_Map::node_type>(overlapped_dof_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_dof_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> overlapped_p_space = Albany::createThyraVectorSpace(overlapped_node_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> x_space = Albany::createThyraVectorSpace(dof_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> p_space = Albany::createThyraVectorSpace(node_map);
+
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_xx = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_xp = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_px = Thyra::createMember(p_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_pp = Thyra::createMember(p_space);
+
+  const Teuchos::RCP<Thyra_Vector> f_multiplier = Thyra::createMember(overlapped_x_space);
+
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_xx = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_xp = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_px = Thyra::createMember(overlapped_p_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_pp = Thyra::createMember(overlapped_p_space);
+
+  const Teuchos::RCP<Thyra_Vector> diff_x_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> diff_p_out = Thyra::createMember(p_space);
+  const Teuchos::RCP<Thyra_Vector> one_x_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> one_p_out = Thyra::createMember(p_space);
+
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_xx_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_xp_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_px_out = Thyra::createMember(p_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_pp_out = Thyra::createMember(p_space);
+
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_xx_out = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_xp_out = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_px_out = Thyra::createMember(overlapped_p_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_pp_out = Thyra::createMember(overlapped_p_space);
+
+  overlapped_hess_vec_prod_f_xx->assign(0.0);
+  overlapped_hess_vec_prod_f_xp->assign(0.0);
+  overlapped_hess_vec_prod_f_px->assign(0.0);
+  overlapped_hess_vec_prod_f_pp->assign(0.0);
+
+  one_x_out->assign(1.0);
+  one_p_out->assign(1.0);
+
+  f_multiplier->assign(1.0);
+
+  overlapped_hess_vec_prod_f_xx_out->assign(0.0);
+  overlapped_hess_vec_prod_f_xp_out->assign(0.0);
+  overlapped_hess_vec_prod_f_px_out->assign(0.0);
+  overlapped_hess_vec_prod_f_pp_out->assign(0.0);
+
+  auto hess_vec_prod_f_xx_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_f_xx_out);
+  auto hess_vec_prod_f_xp_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_f_xp_out);
+  auto hess_vec_prod_f_px_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_f_px_out);
+  auto hess_vec_prod_f_pp_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_f_pp_out);
+
+  for (int cell = 0; cell < cell_map->getNodeNumElements(); ++cell)
+    for (int node = 0; node < nodes_per_element; ++node)
+    {
+      for (int eq = 0; eq < neq; ++eq)
+      {
+        size_t id = overlapped_dof_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell), node, eq));
+        hess_vec_prod_f_xx_out_array[id] += 12.;
+        hess_vec_prod_f_xp_out_array[id] += 12.;
+      }
+      size_t id = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell), node, 0) / neq);
+      hess_vec_prod_f_px_out_array[id] += 12.;
+      hess_vec_prod_f_pp_out_array[id] += 12.;
+    }
+
+  RCP<Albany::CombineAndScatterManager> x_cas_manager = Albany::createCombineAndScatterManager(x_space, overlapped_x_space);
+  RCP<Albany::CombineAndScatterManager> p_cas_manager = Albany::createCombineAndScatterManager(p_space, overlapped_p_space);
+
+  x_cas_manager->combine(overlapped_hess_vec_prod_f_xx_out, hess_vec_prod_f_xx_out, Albany::CombineMode::ADD);
+  x_cas_manager->combine(overlapped_hess_vec_prod_f_xp_out, hess_vec_prod_f_xp_out, Albany::CombineMode::ADD);
+  p_cas_manager->combine(overlapped_hess_vec_prod_f_px_out, hess_vec_prod_f_px_out, Albany::CombineMode::ADD);
+  p_cas_manager->combine(overlapped_hess_vec_prod_f_pp_out, hess_vec_prod_f_pp_out, Albany::CombineMode::ADD);
+
+  RCP<Teuchos::FancyOStream>
+      out_test = Teuchos::VerboseObjectBase::getDefaultOStream();
+
+  Teuchos::EVerbosityLevel verbLevel = Teuchos::VERB_EXTREME;
+
+  std::vector<Albany::IDArray> wsElNodeEqID_ID;
+
+  std::vector<std::vector<int>> wsElNodeEqID_ID_raw;
+
+  const int buck_size = cell_map->getNodeNumElements();
+  const int numBucks = 1;
+
+  wsElNodeEqID_ID.resize(numBucks);
+  wsElNodeEqID_ID_raw.resize(numBucks);
+  for (std::size_t i = 0; i < numBucks; i++)
+    wsElNodeEqID_ID_raw[i].resize(buck_size * nodes_per_element * neq);
+
+  for (int cell = 0; cell < cell_map->getNodeNumElements(); ++cell)
+    for (int node = 0; node < nodes_per_element; ++node)
+      wsElNodeEqID_ID_raw[0][cell * nodes_per_element * neq + node * neq] = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell), node, 0) / neq);
+
+  for (std::size_t i = 0; i < numBucks; i++)
+    wsElNodeEqID_ID[i].assign<stk::mesh::Cartesian, stk::mesh::Cartesian, stk::mesh::Cartesian>(
+        wsElNodeEqID_ID_raw[i].data(),
+        buck_size,
+        nodes_per_element,
+        neq);
+
+  Kokkos::fence();
+
+  phxWorkset.numCells = cell_map->getNodeNumElements();
+  const int cubature_degree = 2;
+  const int num_dim = 3;
+
+  std::string param_name("Thermal conductivity");
+
+  // Need dl->node_scalar, dl->node_qp_scalar, dl->qp_scalar for this evaluator (PHAL_DOFInterpolation_Def.hpp line 20)
+  RCP<Albany::Layouts> dl;
+  RCP<PHAL::ComputeBasisFunctions<EvalType, PHAL::AlbanyTraits>> FEBasis =
+      Albany::createTestLayoutAndBasis<EvalType, PHAL::AlbanyTraits>(dl, phxWorkset.numCells, cubature_degree, num_dim);
+
+  std::string field_name = "Temperature";
+
+  ParameterList p;
+  // Setup scatter evaluator
+  p.set("Stand-alone Evaluator", true);
+  std::string residual_name = "heatEq";
+  p.set("Residual Name", residual_name);
+  p.set("Tensor Rank", tensorRank);
+  int worksetSize = dl->qp_scalar->extent(0);
+  auto residual_layout = Teuchos::rcp(new MDALayout<Cell, Node, Dim>(worksetSize, nodes_per_element, neq));
+
+  ParameterList *plist = new ParameterList("Parameter List");
+  p.set<ParameterList *>("Parameter List", plist);
+
+  // Same as DOFInterpolationBase<EvalType,AlbanyTraits,Evalt::ScalarT>
+  RCP<PHAL::ScatterResidual<EvalType, PHAL::AlbanyTraits>> ScatterResidual =
+      rcp(new PHAL::ScatterResidual<EvalType, PHAL::AlbanyTraits>(p, dl));
+
+  std::vector<PHX::index_size_type> derivative_dimensions;
+  derivative_dimensions.push_back(nodes_per_element * neq);
+
+  typedef typename Sacado::ScalarType<Scalar>::type scalarType;
+  const scalarType tol = 1000.0 * std::numeric_limits<scalarType>::epsilon();
+
+  Teuchos::RCP<Albany::DistributedParameterLibrary> distParamLib = rcp(new Albany::DistributedParameterLibrary);
+  Teuchos::RCP<Albany::DistributedParameter> parameter(new Albany::DistributedParameter(
+      param_name,
+      overlapped_x_space,
+      overlapped_x_space));
+
+  parameter->set_workset_elem_dofs(Teuchos::rcpFromRef(wsElNodeEqID_ID));
+  const Albany::IDArray &wsElDofs = parameter->workset_elem_dofs()[0];
+  Teuchos::RCP<Thyra_Vector> dist_param = parameter->vector();
+  dist_param->assign(6.0);
+  parameter->scatter();
+  distParamLib->add(param_name, parameter);
+
+  phxWorkset.distParamLib = distParamLib;
+  phxWorkset.wsIndex = 0;
+  phxWorkset.wsElNodeEqID = wsLocalElNodeEqID;
+  phxWorkset.dist_param_deriv_name = param_name;
+  phxWorkset.hessianWorkset.dist_param_deriv_direction_name = param_name;
+  phxWorkset.hessianWorkset.f_multiplier = f_multiplier;
+
+  MDField<Scalar, Cell, Node, Dim> residual = allocateUnmanagedMDField<Scalar, Cell, Node, Dim>(residual_name, residual_layout, derivative_dimensions);
+  residual.deep_copy(0.0);
+
+  for (std::size_t cell = 0; cell < static_cast<int>(residual.extent(0)); ++cell)
+  {
+    for (std::size_t node1 = 0; node1 < static_cast<int>(residual.extent(1)); ++node1)
+    {
+      for (std::size_t dim = 0; dim < static_cast<int>(residual.extent(2)); ++dim)
+      {
+        for (std::size_t i = 0; i < static_cast<int>(residual.extent(1)) * static_cast<int>(residual.extent(2)); ++i)
+        {
+          residual(cell, node1, dim).fastAccessDx(i).fastAccessDx(0) = 0.5;
+        }
+      }
+    }
+  }
+
+  // Test without setting hess_vec_prod_f_**
+  {
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(ScatterResidual);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(residual);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_f_xx, hess_vec_prod_f_xx, Albany::CombineMode::ADD);
+    x_cas_manager->combine(overlapped_hess_vec_prod_f_xp, hess_vec_prod_f_xp, Albany::CombineMode::ADD);
+    p_cas_manager->combine(overlapped_hess_vec_prod_f_px, hess_vec_prod_f_px, Albany::CombineMode::ADD);
+    p_cas_manager->combine(overlapped_hess_vec_prod_f_pp, hess_vec_prod_f_pp, Albany::CombineMode::ADD);
+
+    Thyra::V_VmV(diff_x_out.ptr(), *one_x_out, *hess_vec_prod_f_xx);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_xx_out", *one_x_out,
+            "hess_vec_prod_f_xx", *diff_x_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    Thyra::V_VmV(diff_x_out.ptr(), *one_x_out, *hess_vec_prod_f_xp);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_xp_out", *one_x_out,
+            "hess_vec_prod_f_xp", *diff_x_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    Thyra::V_VmV(diff_p_out.ptr(), *one_p_out, *hess_vec_prod_f_px);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_px_out", *one_p_out,
+            "hess_vec_prod_f_px", *diff_p_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    Thyra::V_VmV(diff_p_out.ptr(), *one_p_out, *hess_vec_prod_f_pp);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_pp_out", *one_p_out,
+            "hess_vec_prod_f_pp", *diff_p_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+  }
+  // Test hess_vec_prod_f_xx
+  {
+    phxWorkset.hessianWorkset.hess_vec_prod_f_xx = hess_vec_prod_f_xx;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_xx = overlapped_hess_vec_prod_f_xx;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(ScatterResidual);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(residual);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_f_xx, hess_vec_prod_f_xx, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_xx_out", *hess_vec_prod_f_xx_out,
+            "hess_vec_prod_f_xx", *hess_vec_prod_f_xx,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    phxWorkset.hessianWorkset.hess_vec_prod_f_xx = Teuchos::null;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_xx = Teuchos::null;
+  }
+  // Test hess_vec_prod_f_xp
+  {
+    phxWorkset.hessianWorkset.hess_vec_prod_f_xp = hess_vec_prod_f_xp;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_xp = overlapped_hess_vec_prod_f_xp;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(ScatterResidual);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(residual);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_f_xp, hess_vec_prod_f_xp, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_xp_out", *hess_vec_prod_f_xp_out,
+            "hess_vec_prod_f_xp", *hess_vec_prod_f_xp,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    phxWorkset.hessianWorkset.hess_vec_prod_f_xp = Teuchos::null;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_xp = Teuchos::null;
+  }
+  // Test hess_vec_prod_f_px
+  {
+    phxWorkset.hessianWorkset.hess_vec_prod_f_px = hess_vec_prod_f_px;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_px = overlapped_hess_vec_prod_f_px;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(ScatterResidual);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(residual);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    p_cas_manager->combine(overlapped_hess_vec_prod_f_px, hess_vec_prod_f_px, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_px_out", *hess_vec_prod_f_px_out,
+            "hess_vec_prod_f_px", *hess_vec_prod_f_px,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    phxWorkset.hessianWorkset.hess_vec_prod_f_px = Teuchos::null;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_px = Teuchos::null;
+  }
+  // Test hess_vec_prod_f_pp
+  {
+    phxWorkset.hessianWorkset.hess_vec_prod_f_pp = hess_vec_prod_f_pp;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_pp = overlapped_hess_vec_prod_f_pp;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(ScatterResidual);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(residual);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    p_cas_manager->combine(overlapped_hess_vec_prod_f_pp, hess_vec_prod_f_pp, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_f_pp_out", *hess_vec_prod_f_pp_out,
+            "hess_vec_prod_f_pp", *hess_vec_prod_f_pp,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
 
     phxWorkset.hessianWorkset.hess_vec_prod_f_pp = Teuchos::null;
     phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_pp = Teuchos::null;

--- a/tests/unit/evaluators/scatterResidual.cpp
+++ b/tests/unit/evaluators/scatterResidual.cpp
@@ -1,0 +1,417 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#include "Phalanx_KokkosDeviceTypes.hpp"
+#include "Phalanx_DataLayout_MDALayout.hpp"
+#include "Phalanx_FieldTag_Tag.hpp"
+#include "Phalanx_FieldManager.hpp"
+#include "Phalanx_Print.hpp"
+#include "Phalanx_ExtentTraits.hpp"
+#include "Phalanx_Evaluator_UnmanagedFieldDummy.hpp"
+#include "Phalanx_Evaluator_UnitTester.hpp"
+#include "Phalanx_MDField_UnmanagedAllocator.hpp"
+
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_ArrayRCP.hpp"
+#include "Teuchos_Assert.hpp"
+#include "Teuchos_Array.hpp"
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+
+#include "Thyra_TestingTools.hpp"
+
+#include <limits>
+
+#include "Sacado_Fad_GeneralFadTestingHelpers.hpp"
+
+PHX_EXTENT(CELL)
+PHX_EXTENT(NODE)
+PHX_EXTENT(VERTEX)
+PHX_EXTENT(QP)
+PHX_EXTENT(DIM)
+PHX_EXTENT(R)
+
+// requires the dim tags defined above
+#include "PHAL_DOFInterpolation.hpp"
+#include "PHAL_ScatterResidual.hpp"
+#include "EvalTestSetup.hpp"
+
+#include "Albany_TpetraThyraUtils.hpp"
+#include "Albany_ThyraUtils.hpp"
+#include "Albany_DistributedParameterLibrary.hpp"
+#include <stk_mesh/base/CoordinateSystems.hpp>
+
+TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVec)
+{
+  using namespace std;
+  using namespace Teuchos;
+  using namespace PHX;
+
+  using EvalType = PHAL::AlbanyTraits::HessianVec;
+  using Scalar = EvalType::ScalarT;
+
+  PHAL::Setup phxSetup;
+  PHAL::Workset phxWorkset;
+
+  const int x_size = 27;
+  const int numCells = 8;
+  const int nodes_per_element = 8;
+  const int neq = 1;
+
+  RCP<Tpetra_Map> cell_map, overlapped_node_map;
+  Albany::WorksetConn wsGlobalElNodeEqID("wsGlobalElNodeEqID", numCells, nodes_per_element, neq);
+  RCP<const Teuchos::Comm<int>> comm = rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
+
+  Albany::WorksetConn wsLocalElNodeEqID = Albany::createTestMapsAndWorksetConns(cell_map,overlapped_node_map,wsGlobalElNodeEqID,numCells,nodes_per_element,neq,x_size,comm);
+
+  RCP<const Tpetra_Map> node_map = Tpetra::createOneToOne<Tpetra_Map::local_ordinal_type,Tpetra_Map::global_ordinal_type,Tpetra_Map::node_type>(overlapped_node_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_node_map);
+  Teuchos::RCP<const Thyra_VectorSpace> x_space = Albany::createThyraVectorSpace(node_map);
+
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_xx = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_xp = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_px = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_pp = Thyra::createMember(x_space);
+
+  const Teuchos::RCP<Thyra_Vector> f_multiplier = Thyra::createMember(overlapped_x_space);
+
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_xx = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_xp = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_px = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_pp = Thyra::createMember(overlapped_x_space);
+
+  const Teuchos::RCP<Thyra_Vector> diff_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> one_out = Thyra::createMember(x_space);
+
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_xx_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_xp_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_px_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_f_pp_out = Thyra::createMember(x_space);
+
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_xx_out = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_xp_out = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_px_out = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_f_pp_out = Thyra::createMember(overlapped_x_space);
+
+  overlapped_hess_vec_prod_f_xx->assign(0.0);
+  overlapped_hess_vec_prod_f_xp->assign(0.0);
+  overlapped_hess_vec_prod_f_px->assign(0.0);
+  overlapped_hess_vec_prod_f_pp->assign(0.0);
+
+  one_out->assign(1.0);
+
+  f_multiplier->assign(1.0);
+
+  overlapped_hess_vec_prod_f_xx_out->assign(0.0);
+  overlapped_hess_vec_prod_f_xp_out->assign(0.0);
+  overlapped_hess_vec_prod_f_px_out->assign(0.0);
+  overlapped_hess_vec_prod_f_pp_out->assign(0.0);
+
+  auto hess_vec_prod_f_xx_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_f_xx_out);
+  auto hess_vec_prod_f_xp_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_f_xp_out);
+  auto hess_vec_prod_f_px_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_f_px_out);
+  auto hess_vec_prod_f_pp_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_f_pp_out);
+
+
+  for (int cell=0; cell<cell_map->getNodeNumElements(); ++cell)
+    for(int node=0; node<nodes_per_element; ++node) {
+      size_t id = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell),node,0));
+      hess_vec_prod_f_xx_out_array[id] += 4.;
+      hess_vec_prod_f_xp_out_array[id] += 4.;
+      hess_vec_prod_f_px_out_array[id] += 4.;
+      hess_vec_prod_f_pp_out_array[id] += 4.;
+    }
+
+  RCP<Albany::CombineAndScatterManager> x_cas_manager = Albany::createCombineAndScatterManager(x_space, overlapped_x_space);
+  x_cas_manager->combine(overlapped_hess_vec_prod_f_xx_out, hess_vec_prod_f_xx_out, Albany::CombineMode::ADD);
+  x_cas_manager->combine(overlapped_hess_vec_prod_f_xp_out, hess_vec_prod_f_xp_out, Albany::CombineMode::ADD);
+  x_cas_manager->combine(overlapped_hess_vec_prod_f_px_out, hess_vec_prod_f_px_out, Albany::CombineMode::ADD);
+  x_cas_manager->combine(overlapped_hess_vec_prod_f_pp_out, hess_vec_prod_f_pp_out, Albany::CombineMode::ADD);
+
+  RCP<Teuchos::FancyOStream>
+    out_test = Teuchos::VerboseObjectBase::getDefaultOStream();
+
+  Teuchos::EVerbosityLevel verbLevel = Teuchos::VERB_EXTREME;
+
+  std::vector<Albany::IDArray> wsElNodeEqID_ID;
+
+  std::vector<std::vector<int>> wsElNodeEqID_ID_raw;
+
+  const int buck_size = cell_map->getNodeNumElements();
+  const int numBucks = 1;
+
+  wsElNodeEqID_ID.resize(numBucks);
+  wsElNodeEqID_ID_raw.resize(numBucks);
+  for (std::size_t i = 0; i < numBucks; i++)
+    wsElNodeEqID_ID_raw[i].resize(buck_size * nodes_per_element * neq);
+
+
+  for (int cell=0; cell<cell_map->getNodeNumElements(); ++cell)
+    for(int node=0; node<nodes_per_element; ++node)
+      wsElNodeEqID_ID_raw[0][cell*nodes_per_element+node] = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell),node,0));
+
+  for (std::size_t i = 0; i < numBucks; i++)
+    wsElNodeEqID_ID[i].assign<stk::mesh::Cartesian, stk::mesh::Cartesian, stk::mesh::Cartesian>(
+          wsElNodeEqID_ID_raw[i].data(),
+          buck_size,
+          nodes_per_element,
+          neq);
+
+  Kokkos::fence();
+
+  phxWorkset.numCells = cell_map->getNodeNumElements();
+  const int cubature_degree = 2;
+  const int num_dim = 3;
+
+  std::string param_name("Thermal conductivity");
+
+  const int tensorRank = 0;
+
+  // Need dl->node_scalar, dl->node_qp_scalar, dl->qp_scalar for this evaluator (PHAL_DOFInterpolation_Def.hpp line 20)
+  RCP<Albany::Layouts> dl;
+  RCP<PHAL::ComputeBasisFunctions<EvalType,PHAL::AlbanyTraits>> FEBasis =
+     Albany::createTestLayoutAndBasis<EvalType,PHAL::AlbanyTraits>(dl, phxWorkset.numCells, cubature_degree, num_dim);
+
+  std::string field_name = "Temperature";
+
+  ParameterList p;
+  // Setup scatter evaluator
+  p.set("Stand-alone Evaluator", true);
+  std::string residual_name = "heatEq";
+  p.set("Residual Name", residual_name);
+  p.set("Tensor Rank", tensorRank);
+  int worksetSize = dl->qp_scalar->extent(0);
+  auto residual_layout = Teuchos::rcp(new MDALayout<Cell, Node>(worksetSize,8));
+  PHX::Tag<Scalar> residual_tag(residual_name, residual_layout);
+
+  ParameterList* plist = new ParameterList("Parameter List");
+  p.set<ParameterList*>("Parameter List",plist);
+
+  // Same as DOFInterpolationBase<EvalType,AlbanyTraits,Evalt::ScalarT>
+  RCP<PHAL::ScatterResidual<EvalType,PHAL::AlbanyTraits>> ScatterResidual =
+        rcp(new PHAL::ScatterResidual<EvalType,PHAL::AlbanyTraits>(p, dl));
+
+
+  std::vector<PHX::index_size_type> derivative_dimensions;
+  derivative_dimensions.push_back(8);
+
+  typedef typename Sacado::ScalarType<Scalar>::type scalarType;
+  const scalarType tol = 1000.0 * std::numeric_limits<scalarType>::epsilon();
+
+  Teuchos::RCP<Albany::DistributedParameterLibrary> distParamLib = rcp(new Albany::DistributedParameterLibrary);
+  Teuchos::RCP<Albany::DistributedParameter> parameter(new Albany::DistributedParameter(
+      param_name,
+      overlapped_x_space,
+      overlapped_x_space));
+
+  parameter->set_workset_elem_dofs(Teuchos::rcpFromRef(wsElNodeEqID_ID));
+  const Albany::IDArray& wsElDofs = parameter->workset_elem_dofs()[0];
+  Teuchos::RCP<Thyra_Vector> dist_param = parameter->vector();
+  dist_param->assign(6.0);
+  parameter->scatter();
+  distParamLib->add(param_name, parameter);
+
+  phxWorkset.distParamLib = distParamLib;
+  phxWorkset.wsIndex = 0;
+  phxWorkset.wsElNodeEqID = wsLocalElNodeEqID;
+  phxWorkset.dist_param_deriv_name = param_name;
+  phxWorkset.hessianWorkset.dist_param_deriv_direction_name = param_name;
+  phxWorkset.hessianWorkset.f_multiplier = f_multiplier;
+
+  MDField<Scalar,Cell, Node> residual = allocateUnmanagedMDField<Scalar,Cell, Node>(residual_name, residual_layout, derivative_dimensions);
+  residual.deep_copy(0.0);
+
+  for (std::size_t cell=0; cell < static_cast<int>(residual.extent(0)); ++cell) {
+    for (std::size_t node1=0; node1 < static_cast<int>(residual.extent(1)); ++node1) {
+      for (std::size_t node2=0; node2 < static_cast<int>(residual.extent(1)); ++node2) {
+        residual(cell,node1).fastAccessDx(node2).fastAccessDx(0) = 0.5;
+      }
+    }
+  }
+
+  // Test without setting hess_vec_prod_f_**
+  {
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(ScatterResidual);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(residual);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_f_xx, hess_vec_prod_f_xx, Albany::CombineMode::ADD);
+    x_cas_manager->combine(overlapped_hess_vec_prod_f_xp, hess_vec_prod_f_xp, Albany::CombineMode::ADD);
+    x_cas_manager->combine(overlapped_hess_vec_prod_f_px, hess_vec_prod_f_px, Albany::CombineMode::ADD);
+    x_cas_manager->combine(overlapped_hess_vec_prod_f_pp, hess_vec_prod_f_pp, Albany::CombineMode::ADD);
+
+    Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_f_xx);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_f_xx_out", *one_out,
+      "hess_vec_prod_f_xx", *diff_out,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_f_xp);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_f_xp_out", *one_out,
+      "hess_vec_prod_f_xp", *diff_out,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_f_px);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_f_px_out", *one_out,
+      "hess_vec_prod_f_px", *diff_out,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_f_pp);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_f_pp_out", *one_out,
+      "hess_vec_prod_f_pp", *diff_out,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+  }
+  // Test hess_vec_prod_f_xx
+  {
+    phxWorkset.hessianWorkset.hess_vec_prod_f_xx = hess_vec_prod_f_xx;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_xx = overlapped_hess_vec_prod_f_xx;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(ScatterResidual);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(residual);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_f_xx, hess_vec_prod_f_xx, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_f_xx_out", *hess_vec_prod_f_xx_out,
+      "hess_vec_prod_f_xx", *hess_vec_prod_f_xx,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    phxWorkset.hessianWorkset.hess_vec_prod_f_xx = Teuchos::null;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_xx = Teuchos::null;
+  }
+  // Test hess_vec_prod_f_xp
+  {
+    phxWorkset.hessianWorkset.hess_vec_prod_f_xp = hess_vec_prod_f_xp;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_xp = overlapped_hess_vec_prod_f_xp;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(ScatterResidual);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(residual);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_f_xp, hess_vec_prod_f_xp, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_f_xp_out", *hess_vec_prod_f_xp_out,
+      "hess_vec_prod_f_xp", *hess_vec_prod_f_xp,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    phxWorkset.hessianWorkset.hess_vec_prod_f_xp = Teuchos::null;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_xp = Teuchos::null;
+  }
+  // Test hess_vec_prod_f_px
+  {
+    phxWorkset.hessianWorkset.hess_vec_prod_f_px = hess_vec_prod_f_px;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_px = overlapped_hess_vec_prod_f_px;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(ScatterResidual);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(residual);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_f_px, hess_vec_prod_f_px, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_f_px_out", *hess_vec_prod_f_px_out,
+      "hess_vec_prod_f_px", *hess_vec_prod_f_px,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    phxWorkset.hessianWorkset.hess_vec_prod_f_px = Teuchos::null;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_px = Teuchos::null;
+  }
+  // Test hess_vec_prod_f_pp
+  {
+    phxWorkset.hessianWorkset.hess_vec_prod_f_pp = hess_vec_prod_f_pp;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_pp = overlapped_hess_vec_prod_f_pp;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(ScatterResidual);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(residual);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_f_pp, hess_vec_prod_f_pp, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_f_pp_out", *hess_vec_prod_f_pp_out,
+      "hess_vec_prod_f_pp", *hess_vec_prod_f_pp,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    phxWorkset.hessianWorkset.hess_vec_prod_f_pp = Teuchos::null;
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_f_pp = Teuchos::null;
+  }
+}

--- a/tests/unit/evaluators/scatterResidual.cpp
+++ b/tests/unit/evaluators/scatterResidual.cpp
@@ -52,6 +52,18 @@ PHX_EXTENT(R)
 * Hessian-vector products with rank 0 solution.
 *
 * The xx, xp, px, and pp contributions are tested.
+*
+* The ScatterResidual evaluator is tested as follows:
+* - A PHAL::Workset phxWorkset is created for a 2x2x2 hexahedral mesh,
+* - A 2D MDField called residual is created and is used as the input of the ScatterResidual evaluator,
+* - 5 cases are then tested: not setting phxWorkset.hessianWorkset.hess_vec_prod_f_**,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_f_xx,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_f_xp,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_f_px,
+*                            and only setting phxWorkset.hessianWorkset.hess_vec_prod_f_pp,
+* - The evaluator is then evaluated,
+* - A Thyra vector is created with the expected ouput of the ScatterResidual based on the 2D MDField residual,
+* - The output of the evaluator is compared to the Thyra vector comparing the relative norm of their difference.
 */
 TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVecTensorRank0)
 {
@@ -431,6 +443,18 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVecTensorRank0)
 * Hessian-vector products with rank 1 solution.
 *
 * The xx, xp, px, and pp contributions are tested.
+*
+* The ScatterResidual evaluator is tested as follows:
+* - A PHAL::Workset phxWorkset is created for a 2x2x2 hexahedral mesh,
+* - A 3D MDField called residual is created and is used as the input of the ScatterResidual evaluator,
+* - 5 cases are then tested: not setting phxWorkset.hessianWorkset.hess_vec_prod_f_**,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_f_xx,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_f_xp,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_f_px,
+*                            and only setting phxWorkset.hessianWorkset.hess_vec_prod_f_pp,
+* - The evaluator is then evaluated,
+* - A Thyra vector is created with the expected ouput of the ScatterResidual based on the 3D MDField residual,
+* - The output of the evaluator is compared to the Thyra vector comparing the relative norm of their difference.
 */
 TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVecTensorRank1)
 {

--- a/tests/unit/evaluators/scatterScalarResponse.cpp
+++ b/tests/unit/evaluators/scatterScalarResponse.cpp
@@ -1,0 +1,412 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#include "Phalanx_KokkosDeviceTypes.hpp"
+#include "Phalanx_DataLayout_MDALayout.hpp"
+#include "Phalanx_FieldTag_Tag.hpp"
+#include "Phalanx_FieldManager.hpp"
+#include "Phalanx_Print.hpp"
+#include "Phalanx_ExtentTraits.hpp"
+#include "Phalanx_Evaluator_UnmanagedFieldDummy.hpp"
+#include "Phalanx_Evaluator_UnitTester.hpp"
+#include "Phalanx_MDField_UnmanagedAllocator.hpp"
+
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_ArrayRCP.hpp"
+#include "Teuchos_Assert.hpp"
+#include "Teuchos_Array.hpp"
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+
+#include "Thyra_TestingTools.hpp"
+
+#include <limits>
+
+#include "Sacado_Fad_GeneralFadTestingHelpers.hpp"
+
+PHX_EXTENT(CELL)
+PHX_EXTENT(NODE)
+PHX_EXTENT(VERTEX)
+PHX_EXTENT(QP)
+PHX_EXTENT(DIM)
+PHX_EXTENT(R)
+
+// requires the dim tags defined above
+#include "PHAL_DOFInterpolation.hpp"
+#include "PHAL_SeparableScatterScalarResponse.hpp"
+#include "EvalTestSetup.hpp"
+
+#include "Albany_TpetraThyraUtils.hpp"
+#include "Albany_ThyraUtils.hpp"
+#include "Albany_DistributedParameterLibrary.hpp"
+#include <stk_mesh/base/CoordinateSystems.hpp>
+
+TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVec)
+{
+  using namespace std;
+  using namespace Teuchos;
+  using namespace PHX;
+
+  using EvalType = PHAL::AlbanyTraits::HessianVec;
+  using Scalar = EvalType::ScalarT;
+
+  PHAL::Setup phxSetup;
+  PHAL::Workset phxWorkset;
+
+  const int x_size = 27;
+  const int numCells = 8;
+  const int nodes_per_element = 8;
+  const int neq = 1;
+
+  RCP<Tpetra_Map> cell_map, overlapped_node_map;
+  Albany::WorksetConn wsGlobalElNodeEqID("wsGlobalElNodeEqID", numCells, nodes_per_element, neq);
+  RCP<const Teuchos::Comm<int>> comm = rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
+
+  Albany::WorksetConn wsLocalElNodeEqID = Albany::createTestMapsAndWorksetConns(cell_map,overlapped_node_map,wsGlobalElNodeEqID,numCells,nodes_per_element,neq,x_size,comm);
+
+  RCP<const Tpetra_Map> node_map = Tpetra::createOneToOne<Tpetra_Map::local_ordinal_type,Tpetra_Map::global_ordinal_type,Tpetra_Map::node_type>(overlapped_node_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_node_map);
+  Teuchos::RCP<const Thyra_VectorSpace> x_space = Albany::createThyraVectorSpace(node_map);
+
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xx = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xp = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_px = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_pp = Thyra::createMember(x_space);
+
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_xx = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_xp = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_px = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_pp = Thyra::createMember(overlapped_x_space);
+
+  const Teuchos::RCP<Thyra_Vector> diff_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> one_out = Thyra::createMember(x_space);
+
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xx_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xp_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_px_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_pp_out = Thyra::createMember(x_space);
+
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_xx_out = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_xp_out = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_px_out = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_pp_out = Thyra::createMember(overlapped_x_space);
+
+  overlapped_hess_vec_prod_g_xx->assign(0.0);
+  overlapped_hess_vec_prod_g_xp->assign(0.0);
+  overlapped_hess_vec_prod_g_px->assign(0.0);
+  overlapped_hess_vec_prod_g_pp->assign(0.0);
+
+  one_out->assign(1.0);
+
+  overlapped_hess_vec_prod_g_xx_out->assign(0.0);
+  overlapped_hess_vec_prod_g_xp_out->assign(0.0);
+  overlapped_hess_vec_prod_g_px_out->assign(0.0);
+  overlapped_hess_vec_prod_g_pp_out->assign(0.0);
+
+  auto hess_vec_prod_g_xx_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_g_xx_out);
+  auto hess_vec_prod_g_xp_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_g_xp_out);
+  auto hess_vec_prod_g_px_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_g_px_out);
+  auto hess_vec_prod_g_pp_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_g_pp_out);
+
+
+  for (int cell=0; cell<cell_map->getNodeNumElements(); ++cell)
+    for(int node=0; node<nodes_per_element; ++node) {
+      size_t id = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell),node,0));
+      hess_vec_prod_g_xx_out_array[id] += 0.5;
+      hess_vec_prod_g_xp_out_array[id] += 0.5;
+      hess_vec_prod_g_px_out_array[id] += 0.5;
+      hess_vec_prod_g_pp_out_array[id] += 0.5;
+    }
+
+  RCP<Albany::CombineAndScatterManager> x_cas_manager = Albany::createCombineAndScatterManager(x_space, overlapped_x_space);
+  x_cas_manager->combine(overlapped_hess_vec_prod_g_xx_out, hess_vec_prod_g_xx_out, Albany::CombineMode::ADD);
+  x_cas_manager->combine(overlapped_hess_vec_prod_g_xp_out, hess_vec_prod_g_xp_out, Albany::CombineMode::ADD);
+  x_cas_manager->combine(overlapped_hess_vec_prod_g_px_out, hess_vec_prod_g_px_out, Albany::CombineMode::ADD);
+  x_cas_manager->combine(overlapped_hess_vec_prod_g_pp_out, hess_vec_prod_g_pp_out, Albany::CombineMode::ADD);
+
+  RCP<Teuchos::FancyOStream>
+    out_test = Teuchos::VerboseObjectBase::getDefaultOStream();
+
+  Teuchos::EVerbosityLevel verbLevel = Teuchos::VERB_EXTREME;
+
+  std::vector<Albany::IDArray> wsElNodeEqID_ID;
+
+  std::vector<std::vector<int>> wsElNodeEqID_ID_raw;
+
+  const int buck_size = cell_map->getNodeNumElements();
+  const int numBucks = 1;
+
+  wsElNodeEqID_ID.resize(numBucks);
+  wsElNodeEqID_ID_raw.resize(numBucks);
+  for (std::size_t i = 0; i < numBucks; i++)
+    wsElNodeEqID_ID_raw[i].resize(buck_size * nodes_per_element * neq);
+
+
+  for (int cell=0; cell<cell_map->getNodeNumElements(); ++cell)
+    for(int node=0; node<nodes_per_element; ++node)
+      wsElNodeEqID_ID_raw[0][cell*nodes_per_element+node] = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell),node,0));
+
+  for (std::size_t i = 0; i < numBucks; i++)
+    wsElNodeEqID_ID[i].assign<stk::mesh::Cartesian, stk::mesh::Cartesian, stk::mesh::Cartesian>(
+          wsElNodeEqID_ID_raw[i].data(),
+          buck_size,
+          nodes_per_element,
+          neq);
+
+  Kokkos::fence();
+
+  phxWorkset.numCells = cell_map->getNodeNumElements();
+  const int cubature_degree = 2;
+  const int num_dim = 3;
+
+  std::string param_name("Thermal conductivity");
+
+  // Need dl->node_scalar, dl->node_qp_scalar, dl->qp_scalar for this evaluator (PHAL_DOFInterpolation_Def.hpp line 20)
+  RCP<Albany::Layouts> dl;
+  RCP<PHAL::ComputeBasisFunctions<EvalType,PHAL::AlbanyTraits>> FEBasis =
+     Albany::createTestLayoutAndBasis<EvalType,PHAL::AlbanyTraits>(dl, phxWorkset.numCells, cubature_degree, num_dim);
+
+  std::string field_name = "Temperature";
+
+  ParameterList p;
+  // Setup scatter evaluator
+  p.set("Stand-alone Evaluator", true);
+  std::string local_response_name = "Local Response";
+  std::string global_response_name = "Global Response";
+  int worksetSize = dl->qp_scalar->extent(0);
+  int responseSize = 1;
+  auto local_response_layout = Teuchos::rcp(new MDALayout<Cell, Dim>(worksetSize, responseSize));
+  auto global_response_layout = Teuchos::rcp(new MDALayout<Dim>(responseSize));
+  PHX::Tag<Scalar> local_response_tag(local_response_name, local_response_layout);
+  PHX::Tag<Scalar> global_response_tag(global_response_name, global_response_layout);
+  p.set("Local Response Field Tag", local_response_tag);
+  p.set("Global Response Field Tag", global_response_tag);
+
+  ParameterList* plist = new ParameterList("Parameter List");
+  p.set<ParameterList*>("Parameter List",plist);
+
+  // Same as DOFInterpolationBase<EvalType,AlbanyTraits,Evalt::ScalarT>
+  RCP<PHAL::SeparableScatterScalarResponse<EvalType,PHAL::AlbanyTraits>> SeparableScatterScalarResponse =
+        rcp(new PHAL::SeparableScatterScalarResponse<EvalType,PHAL::AlbanyTraits>(p, dl));
+
+
+  std::vector<PHX::index_size_type> derivative_dimensions;
+  derivative_dimensions.push_back(8);
+
+  typedef typename Sacado::ScalarType<Scalar>::type scalarType;
+  const scalarType tol = 1000.0 * std::numeric_limits<scalarType>::epsilon();
+
+  Teuchos::RCP<Albany::DistributedParameterLibrary> distParamLib = rcp(new Albany::DistributedParameterLibrary);
+  Teuchos::RCP<Albany::DistributedParameter> parameter(new Albany::DistributedParameter(
+      param_name,
+      overlapped_x_space,
+      overlapped_x_space));
+
+  parameter->set_workset_elem_dofs(Teuchos::rcpFromRef(wsElNodeEqID_ID));
+  const Albany::IDArray& wsElDofs = parameter->workset_elem_dofs()[0];
+  Teuchos::RCP<Thyra_Vector> dist_param = parameter->vector();
+  dist_param->assign(6.0);
+  parameter->scatter();
+  distParamLib->add(param_name, parameter);
+
+  phxWorkset.distParamLib = distParamLib;
+  phxWorkset.wsIndex = 0;
+  phxWorkset.wsElNodeEqID = wsLocalElNodeEqID;
+  phxWorkset.dist_param_deriv_name = param_name;
+  phxWorkset.hessianWorkset.dist_param_deriv_direction_name = param_name;
+
+  MDField<Scalar, Dim> global_response = allocateUnmanagedMDField<Scalar, Dim>(global_response_name, global_response_layout, derivative_dimensions);
+  MDField<Scalar,Cell, Dim> local_response = allocateUnmanagedMDField<Scalar,Cell, Dim>(local_response_name, local_response_layout, derivative_dimensions);
+  local_response.deep_copy(0.0);
+
+  for (std::size_t cell=0; cell < static_cast<int>(local_response.extent(0)); ++cell) {
+    for (std::size_t dim=0; dim < static_cast<int>(local_response.extent(1)); ++dim) {
+      for(int node=0; node<nodes_per_element; ++node) {
+        local_response(cell,dim).fastAccessDx(node).fastAccessDx(0) = 0.5;
+      }
+    }
+  }
+
+  // Test without setting hess_vec_prod_g_**
+  {
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(SeparableScatterScalarResponse);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(global_response);
+    tester.setDependentFieldValues(local_response);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_g_xx, hess_vec_prod_g_xx, Albany::CombineMode::ADD);
+    x_cas_manager->combine(overlapped_hess_vec_prod_g_xp, hess_vec_prod_g_xp, Albany::CombineMode::ADD);
+    x_cas_manager->combine(overlapped_hess_vec_prod_g_px, hess_vec_prod_g_px, Albany::CombineMode::ADD);
+    x_cas_manager->combine(overlapped_hess_vec_prod_g_pp, hess_vec_prod_g_pp, Albany::CombineMode::ADD);
+
+    Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_g_xx);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_g_xx_out", *one_out,
+      "hess_vec_prod_g_xx", *diff_out,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_g_xp);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_g_xp_out", *one_out,
+      "hess_vec_prod_g_xp", *diff_out,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_g_px);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_g_px_out", *one_out,
+      "hess_vec_prod_g_px", *diff_out,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_g_pp);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_g_pp_out", *one_out,
+      "hess_vec_prod_g_pp", *diff_out,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+  }
+  // Test hess_vec_prod_g_xx
+  {
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_xx = overlapped_hess_vec_prod_g_xx;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(SeparableScatterScalarResponse);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(global_response);
+    tester.setDependentFieldValues(local_response);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_g_xx, hess_vec_prod_g_xx, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_g_xx_out", *hess_vec_prod_g_xx_out,
+      "hess_vec_prod_g_xx", *hess_vec_prod_g_xx,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_xx = Teuchos::null;
+  }
+  // Test hess_vec_prod_g_xp
+  {
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_xp = overlapped_hess_vec_prod_g_xp;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(SeparableScatterScalarResponse);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(global_response);
+    tester.setDependentFieldValues(local_response);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_g_xp, hess_vec_prod_g_xp, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_g_xp_out", *hess_vec_prod_g_xp_out,
+      "hess_vec_prod_g_xp", *hess_vec_prod_g_xp,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_xp = Teuchos::null;
+  }
+  // Test hess_vec_prod_g_px
+  {
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_px = overlapped_hess_vec_prod_g_px;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(SeparableScatterScalarResponse);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(global_response);
+    tester.setDependentFieldValues(local_response);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_g_px, hess_vec_prod_g_px, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_g_px_out", *hess_vec_prod_g_px_out,
+      "hess_vec_prod_g_px", *hess_vec_prod_g_px,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_px = Teuchos::null;
+  }
+  // Test hess_vec_prod_g_pp
+  {
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_pp = overlapped_hess_vec_prod_g_pp;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(SeparableScatterScalarResponse);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(global_response);
+    tester.setDependentFieldValues(local_response);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_g_pp, hess_vec_prod_g_pp, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+      !Thyra::testRelNormDiffErr(
+      "hess_vec_prod_g_pp_out", *hess_vec_prod_g_pp_out,
+      "hess_vec_prod_g_pp", *hess_vec_prod_g_pp,
+      "maxSensError", tol,
+      "warningTol", 1.0, // Don't warn
+      &*out_test, verbLevel
+      )
+    );
+
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_pp = Teuchos::null;
+  }
+}

--- a/tests/unit/evaluators/scatterScalarResponse.cpp
+++ b/tests/unit/evaluators/scatterScalarResponse.cpp
@@ -52,6 +52,18 @@ PHX_EXTENT(R)
 * Hessian-vector products with rank 0 solution.
 *
 * The xx, xp, px, and pp contributions are tested.
+*
+* The ScatterScalarResponse evaluator is tested as follows:
+* - A PHAL::Workset phxWorkset is created for a 2x2x2 hexahedral mesh,
+* - A 2D MDField called local_response is created and is used as the input of the ScatterScalarResponse evaluator,
+* - 5 cases are then tested: not setting phxWorkset.hessianWorkset.hess_vec_prod_g_**,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_xx,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_xp,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_px,
+*                            and only setting phxWorkset.hessianWorkset.hess_vec_prod_g_pp,
+* - The evaluator is then evaluated,
+* - A Thyra vector is created with the expected ouput of the ScatterScalarResponse based on the 2D MDField local_response,
+* - The output of the evaluator is compared to the Thyra vector comparing the relative norm of their difference.
 */
 TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVecTensorRank0)
 {
@@ -422,6 +434,18 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
 * Hessian-vector products with rank 1 solution.
 *
 * The xx, xp, px, and pp contributions are tested.
+*
+* The ScatterScalarResponse evaluator is tested as follows:
+* - A PHAL::Workset phxWorkset is created for a 2x2x2 hexahedral mesh,
+* - A 2D MDField called local_response is created and is used as the input of the ScatterScalarResponse evaluator,
+* - 5 cases are then tested: not setting phxWorkset.hessianWorkset.hess_vec_prod_g_**,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_xx,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_xp,
+*                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_px,
+*                            and only setting phxWorkset.hessianWorkset.hess_vec_prod_g_pp,
+* - The evaluator is then evaluated,
+* - A Thyra vector is created with the expected ouput of the ScatterScalarResponse based on the 2D MDField local_response,
+* - The output of the evaluator is compared to the Thyra vector comparing the relative norm of their difference.
 */
 TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVecTensorRank1)
 {

--- a/tests/unit/evaluators/scatterScalarResponse.cpp
+++ b/tests/unit/evaluators/scatterScalarResponse.cpp
@@ -45,7 +45,15 @@ PHX_EXTENT(R)
 #include "Albany_DistributedParameterLibrary.hpp"
 #include <stk_mesh/base/CoordinateSystems.hpp>
 
-TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVec)
+/**
+* separableScatterScalarResponseHessianVecTensorRank0 test
+* 
+* This unit test is used to test the scatter of a scalar response with AD for the computation of
+* Hessian-vector products with rank 0 solution.
+*
+* The xx, xp, px, and pp contributions are tested.
+*/
+TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVecTensorRank0)
 {
   using namespace std;
   using namespace Teuchos;
@@ -57,44 +65,55 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
   PHAL::Setup phxSetup;
   PHAL::Workset phxWorkset;
 
-  const int x_size = 27;
-  const int numCells = 8;
+  const int numCells_per_direction = 2;
   const int nodes_per_element = 8;
   const int neq = 1;
 
-  RCP<Tpetra_Map> cell_map, overlapped_node_map;
+  const int numCells = numCells_per_direction * numCells_per_direction * numCells_per_direction;
+
+  RCP<Tpetra_Map> cell_map, overlapped_node_map, overlapped_dof_map;
   Albany::WorksetConn wsGlobalElNodeEqID("wsGlobalElNodeEqID", numCells, nodes_per_element, neq);
+  Albany::WorksetConn wsLocalElNodeEqID("wsLocalElNodeEqID", numCells, nodes_per_element, neq);
   RCP<const Teuchos::Comm<int>> comm = rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
 
-  Albany::WorksetConn wsLocalElNodeEqID = Albany::createTestMapsAndWorksetConns(cell_map,overlapped_node_map,wsGlobalElNodeEqID,numCells,nodes_per_element,neq,x_size,comm);
+  Albany::createTestMapsAndWorksetConns(cell_map, overlapped_node_map, overlapped_dof_map, wsGlobalElNodeEqID, wsLocalElNodeEqID, numCells_per_direction, nodes_per_element, neq, comm);
 
-  RCP<const Tpetra_Map> node_map = Tpetra::createOneToOne<Tpetra_Map::local_ordinal_type,Tpetra_Map::global_ordinal_type,Tpetra_Map::node_type>(overlapped_node_map);
+  Kokkos::resize(wsLocalElNodeEqID, cell_map->getNodeNumElements(), nodes_per_element, neq);
 
-  Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_node_map);
-  Teuchos::RCP<const Thyra_VectorSpace> x_space = Albany::createThyraVectorSpace(node_map);
+  RCP<const Tpetra_Map> node_map = Tpetra::createOneToOne<Tpetra_Map::local_ordinal_type, Tpetra_Map::global_ordinal_type, Tpetra_Map::node_type>(overlapped_node_map);
+
+  RCP<const Tpetra_Map> dof_map = Tpetra::createOneToOne<Tpetra_Map::local_ordinal_type, Tpetra_Map::global_ordinal_type, Tpetra_Map::node_type>(overlapped_dof_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_dof_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> overlapped_p_space = Albany::createThyraVectorSpace(overlapped_node_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> x_space = Albany::createThyraVectorSpace(dof_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> p_space = Albany::createThyraVectorSpace(node_map);
 
   const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xx = Thyra::createMember(x_space);
   const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xp = Thyra::createMember(x_space);
-  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_px = Thyra::createMember(x_space);
-  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_pp = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_px = Thyra::createMember(p_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_pp = Thyra::createMember(p_space);
 
   const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_xx = Thyra::createMember(overlapped_x_space);
   const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_xp = Thyra::createMember(overlapped_x_space);
-  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_px = Thyra::createMember(overlapped_x_space);
-  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_pp = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_px = Thyra::createMember(overlapped_p_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_pp = Thyra::createMember(overlapped_p_space);
 
   const Teuchos::RCP<Thyra_Vector> diff_out = Thyra::createMember(x_space);
   const Teuchos::RCP<Thyra_Vector> one_out = Thyra::createMember(x_space);
 
   const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xx_out = Thyra::createMember(x_space);
   const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xp_out = Thyra::createMember(x_space);
-  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_px_out = Thyra::createMember(x_space);
-  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_pp_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_px_out = Thyra::createMember(p_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_pp_out = Thyra::createMember(p_space);
 
   const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_xx_out = Thyra::createMember(overlapped_x_space);
   const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_xp_out = Thyra::createMember(overlapped_x_space);
-  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_px_out = Thyra::createMember(overlapped_x_space);
-  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_pp_out = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_px_out = Thyra::createMember(overlapped_p_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_pp_out = Thyra::createMember(overlapped_p_space);
 
   overlapped_hess_vec_prod_g_xx->assign(0.0);
   overlapped_hess_vec_prod_g_xp->assign(0.0);
@@ -113,10 +132,10 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
   auto hess_vec_prod_g_px_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_g_px_out);
   auto hess_vec_prod_g_pp_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_g_pp_out);
 
-
-  for (int cell=0; cell<cell_map->getNodeNumElements(); ++cell)
-    for(int node=0; node<nodes_per_element; ++node) {
-      size_t id = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell),node,0));
+  for (int cell = 0; cell < cell_map->getNodeNumElements(); ++cell)
+    for (int node = 0; node < nodes_per_element; ++node)
+    {
+      size_t id = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell), node, 0));
       hess_vec_prod_g_xx_out_array[id] += 0.5;
       hess_vec_prod_g_xp_out_array[id] += 0.5;
       hess_vec_prod_g_px_out_array[id] += 0.5;
@@ -130,7 +149,7 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
   x_cas_manager->combine(overlapped_hess_vec_prod_g_pp_out, hess_vec_prod_g_pp_out, Albany::CombineMode::ADD);
 
   RCP<Teuchos::FancyOStream>
-    out_test = Teuchos::VerboseObjectBase::getDefaultOStream();
+      out_test = Teuchos::VerboseObjectBase::getDefaultOStream();
 
   Teuchos::EVerbosityLevel verbLevel = Teuchos::VERB_EXTREME;
 
@@ -146,17 +165,16 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
   for (std::size_t i = 0; i < numBucks; i++)
     wsElNodeEqID_ID_raw[i].resize(buck_size * nodes_per_element * neq);
 
-
-  for (int cell=0; cell<cell_map->getNodeNumElements(); ++cell)
-    for(int node=0; node<nodes_per_element; ++node)
-      wsElNodeEqID_ID_raw[0][cell*nodes_per_element+node] = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell),node,0));
+  for (int cell = 0; cell < cell_map->getNodeNumElements(); ++cell)
+    for (int node = 0; node < nodes_per_element; ++node)
+      wsElNodeEqID_ID_raw[0][cell * nodes_per_element * neq + node * neq] = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell), node, 0) / neq);
 
   for (std::size_t i = 0; i < numBucks; i++)
     wsElNodeEqID_ID[i].assign<stk::mesh::Cartesian, stk::mesh::Cartesian, stk::mesh::Cartesian>(
-          wsElNodeEqID_ID_raw[i].data(),
-          buck_size,
-          nodes_per_element,
-          neq);
+        wsElNodeEqID_ID_raw[i].data(),
+        buck_size,
+        nodes_per_element,
+        neq);
 
   Kokkos::fence();
 
@@ -168,8 +186,8 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
 
   // Need dl->node_scalar, dl->node_qp_scalar, dl->qp_scalar for this evaluator (PHAL_DOFInterpolation_Def.hpp line 20)
   RCP<Albany::Layouts> dl;
-  RCP<PHAL::ComputeBasisFunctions<EvalType,PHAL::AlbanyTraits>> FEBasis =
-     Albany::createTestLayoutAndBasis<EvalType,PHAL::AlbanyTraits>(dl, phxWorkset.numCells, cubature_degree, num_dim);
+  RCP<PHAL::ComputeBasisFunctions<EvalType, PHAL::AlbanyTraits>> FEBasis =
+      Albany::createTestLayoutAndBasis<EvalType, PHAL::AlbanyTraits>(dl, phxWorkset.numCells, cubature_degree, num_dim);
 
   std::string field_name = "Temperature";
 
@@ -187,16 +205,15 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
   p.set("Local Response Field Tag", local_response_tag);
   p.set("Global Response Field Tag", global_response_tag);
 
-  ParameterList* plist = new ParameterList("Parameter List");
-  p.set<ParameterList*>("Parameter List",plist);
+  ParameterList *plist = new ParameterList("Parameter List");
+  p.set<ParameterList *>("Parameter List", plist);
 
   // Same as DOFInterpolationBase<EvalType,AlbanyTraits,Evalt::ScalarT>
-  RCP<PHAL::SeparableScatterScalarResponse<EvalType,PHAL::AlbanyTraits>> SeparableScatterScalarResponse =
-        rcp(new PHAL::SeparableScatterScalarResponse<EvalType,PHAL::AlbanyTraits>(p, dl));
-
+  RCP<PHAL::SeparableScatterScalarResponse<EvalType, PHAL::AlbanyTraits>> SeparableScatterScalarResponse =
+      rcp(new PHAL::SeparableScatterScalarResponse<EvalType, PHAL::AlbanyTraits>(p, dl));
 
   std::vector<PHX::index_size_type> derivative_dimensions;
-  derivative_dimensions.push_back(8);
+  derivative_dimensions.push_back(nodes_per_element * neq);
 
   typedef typename Sacado::ScalarType<Scalar>::type scalarType;
   const scalarType tol = 1000.0 * std::numeric_limits<scalarType>::epsilon();
@@ -208,7 +225,7 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
       overlapped_x_space));
 
   parameter->set_workset_elem_dofs(Teuchos::rcpFromRef(wsElNodeEqID_ID));
-  const Albany::IDArray& wsElDofs = parameter->workset_elem_dofs()[0];
+  const Albany::IDArray &wsElDofs = parameter->workset_elem_dofs()[0];
   Teuchos::RCP<Thyra_Vector> dist_param = parameter->vector();
   dist_param->assign(6.0);
   parameter->scatter();
@@ -221,13 +238,16 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
   phxWorkset.hessianWorkset.dist_param_deriv_direction_name = param_name;
 
   MDField<Scalar, Dim> global_response = allocateUnmanagedMDField<Scalar, Dim>(global_response_name, global_response_layout, derivative_dimensions);
-  MDField<Scalar,Cell, Dim> local_response = allocateUnmanagedMDField<Scalar,Cell, Dim>(local_response_name, local_response_layout, derivative_dimensions);
+  MDField<Scalar, Cell, Dim> local_response = allocateUnmanagedMDField<Scalar, Cell, Dim>(local_response_name, local_response_layout, derivative_dimensions);
   local_response.deep_copy(0.0);
 
-  for (std::size_t cell=0; cell < static_cast<int>(local_response.extent(0)); ++cell) {
-    for (std::size_t dim=0; dim < static_cast<int>(local_response.extent(1)); ++dim) {
-      for(int node=0; node<nodes_per_element; ++node) {
-        local_response(cell,dim).fastAccessDx(node).fastAccessDx(0) = 0.5;
+  for (std::size_t cell = 0; cell < static_cast<int>(local_response.extent(0)); ++cell)
+  {
+    for (std::size_t dim = 0; dim < static_cast<int>(local_response.extent(1)); ++dim)
+    {
+      for (int node = 0; node < nodes_per_element; ++node)
+      {
+        local_response(cell, dim).fastAccessDx(node).fastAccessDx(0) = 0.5;
       }
     }
   }
@@ -252,50 +272,42 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
     Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_g_xx);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_g_xx_out", *one_out,
-      "hess_vec_prod_g_xx", *diff_out,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_xx_out", *one_out,
+            "hess_vec_prod_g_xx", *diff_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
 
     Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_g_xp);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_g_xp_out", *one_out,
-      "hess_vec_prod_g_xp", *diff_out,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_xp_out", *one_out,
+            "hess_vec_prod_g_xp", *diff_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
 
     Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_g_px);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_g_px_out", *one_out,
-      "hess_vec_prod_g_px", *diff_out,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_px_out", *one_out,
+            "hess_vec_prod_g_px", *diff_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
 
     Thyra::V_VmV(diff_out.ptr(), *one_out, *hess_vec_prod_g_pp);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_g_pp_out", *one_out,
-      "hess_vec_prod_g_pp", *diff_out,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_pp_out", *one_out,
+            "hess_vec_prod_g_pp", *diff_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
   }
   // Test hess_vec_prod_g_xx
   {
@@ -314,14 +326,12 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
     x_cas_manager->combine(overlapped_hess_vec_prod_g_xx, hess_vec_prod_g_xx, Albany::CombineMode::ADD);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_g_xx_out", *hess_vec_prod_g_xx_out,
-      "hess_vec_prod_g_xx", *hess_vec_prod_g_xx,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_xx_out", *hess_vec_prod_g_xx_out,
+            "hess_vec_prod_g_xx", *hess_vec_prod_g_xx,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
 
     phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_xx = Teuchos::null;
   }
@@ -342,14 +352,12 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
     x_cas_manager->combine(overlapped_hess_vec_prod_g_xp, hess_vec_prod_g_xp, Albany::CombineMode::ADD);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_g_xp_out", *hess_vec_prod_g_xp_out,
-      "hess_vec_prod_g_xp", *hess_vec_prod_g_xp,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_xp_out", *hess_vec_prod_g_xp_out,
+            "hess_vec_prod_g_xp", *hess_vec_prod_g_xp,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
 
     phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_xp = Teuchos::null;
   }
@@ -370,14 +378,12 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
     x_cas_manager->combine(overlapped_hess_vec_prod_g_px, hess_vec_prod_g_px, Albany::CombineMode::ADD);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_g_px_out", *hess_vec_prod_g_px_out,
-      "hess_vec_prod_g_px", *hess_vec_prod_g_px,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_px_out", *hess_vec_prod_g_px_out,
+            "hess_vec_prod_g_px", *hess_vec_prod_g_px,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
 
     phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_px = Teuchos::null;
   }
@@ -398,14 +404,391 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
     x_cas_manager->combine(overlapped_hess_vec_prod_g_pp, hess_vec_prod_g_pp, Albany::CombineMode::ADD);
 
     TEUCHOS_TEST_FOR_EXCEPT(
-      !Thyra::testRelNormDiffErr(
-      "hess_vec_prod_g_pp_out", *hess_vec_prod_g_pp_out,
-      "hess_vec_prod_g_pp", *hess_vec_prod_g_pp,
-      "maxSensError", tol,
-      "warningTol", 1.0, // Don't warn
-      &*out_test, verbLevel
-      )
-    );
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_pp_out", *hess_vec_prod_g_pp_out,
+            "hess_vec_prod_g_pp", *hess_vec_prod_g_pp,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_pp = Teuchos::null;
+  }
+}
+
+/**
+* separableScatterScalarResponseHessianVecTensorRank1 test
+* 
+* This unit test is used to test the scatter of a scalar response with AD for the computation of
+* Hessian-vector products with rank 1 solution.
+*
+* The xx, xp, px, and pp contributions are tested.
+*/
+TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVecTensorRank1)
+{
+  using namespace std;
+  using namespace Teuchos;
+  using namespace PHX;
+
+  using EvalType = PHAL::AlbanyTraits::HessianVec;
+  using Scalar = EvalType::ScalarT;
+
+  PHAL::Setup phxSetup;
+  PHAL::Workset phxWorkset;
+
+  const int numCells_per_direction = 2;
+  const int nodes_per_element = 8;
+  const int neq = 3;
+
+  const int numCells = numCells_per_direction * numCells_per_direction * numCells_per_direction;
+
+  RCP<Tpetra_Map> cell_map, overlapped_node_map, overlapped_dof_map;
+  Albany::WorksetConn wsGlobalElNodeEqID("wsGlobalElNodeEqID", numCells, nodes_per_element, neq);
+  Albany::WorksetConn wsLocalElNodeEqID("wsLocalElNodeEqID", numCells, nodes_per_element, neq);
+  RCP<const Teuchos::Comm<int>> comm = rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
+
+  Albany::createTestMapsAndWorksetConns(cell_map, overlapped_node_map, overlapped_dof_map, wsGlobalElNodeEqID, wsLocalElNodeEqID, numCells_per_direction, nodes_per_element, neq, comm);
+
+  Kokkos::resize(wsLocalElNodeEqID, cell_map->getNodeNumElements(), nodes_per_element, neq);
+
+  RCP<const Tpetra_Map> node_map = Tpetra::createOneToOne<Tpetra_Map::local_ordinal_type, Tpetra_Map::global_ordinal_type, Tpetra_Map::node_type>(overlapped_node_map);
+
+  RCP<const Tpetra_Map> dof_map = Tpetra::createOneToOne<Tpetra_Map::local_ordinal_type, Tpetra_Map::global_ordinal_type, Tpetra_Map::node_type>(overlapped_dof_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> overlapped_x_space = Albany::createThyraVectorSpace(overlapped_dof_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> overlapped_p_space = Albany::createThyraVectorSpace(overlapped_node_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> x_space = Albany::createThyraVectorSpace(dof_map);
+
+  Teuchos::RCP<const Thyra_VectorSpace> p_space = Albany::createThyraVectorSpace(node_map);
+
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xx = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xp = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_px = Thyra::createMember(p_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_pp = Thyra::createMember(p_space);
+
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_xx = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_xp = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_px = Thyra::createMember(overlapped_p_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_pp = Thyra::createMember(overlapped_p_space);
+
+  const Teuchos::RCP<Thyra_Vector> diff_x_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> diff_p_out = Thyra::createMember(p_space);
+  const Teuchos::RCP<Thyra_Vector> one_x_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> one_p_out = Thyra::createMember(p_space);
+
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xx_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_xp_out = Thyra::createMember(x_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_px_out = Thyra::createMember(p_space);
+  const Teuchos::RCP<Thyra_Vector> hess_vec_prod_g_pp_out = Thyra::createMember(p_space);
+
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_xx_out = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_xp_out = Thyra::createMember(overlapped_x_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_px_out = Thyra::createMember(overlapped_p_space);
+  const Teuchos::RCP<Thyra_Vector> overlapped_hess_vec_prod_g_pp_out = Thyra::createMember(overlapped_p_space);
+
+  overlapped_hess_vec_prod_g_xx->assign(0.0);
+  overlapped_hess_vec_prod_g_xp->assign(0.0);
+  overlapped_hess_vec_prod_g_px->assign(0.0);
+  overlapped_hess_vec_prod_g_pp->assign(0.0);
+
+  one_x_out->assign(1.0);
+  one_p_out->assign(1.0);
+
+  overlapped_hess_vec_prod_g_xx_out->assign(0.0);
+  overlapped_hess_vec_prod_g_xp_out->assign(0.0);
+  overlapped_hess_vec_prod_g_px_out->assign(0.0);
+  overlapped_hess_vec_prod_g_pp_out->assign(0.0);
+
+  auto hess_vec_prod_g_xx_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_g_xx_out);
+  auto hess_vec_prod_g_xp_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_g_xp_out);
+  auto hess_vec_prod_g_px_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_g_px_out);
+  auto hess_vec_prod_g_pp_out_array = Albany::getNonconstLocalData(overlapped_hess_vec_prod_g_pp_out);
+
+  for (int cell = 0; cell < cell_map->getNodeNumElements(); ++cell)
+    for (int node = 0; node < nodes_per_element; ++node)
+    {
+      for (int eq = 0; eq < neq; ++eq)
+      {
+        size_t id = overlapped_dof_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell), node, eq));
+        hess_vec_prod_g_xx_out_array[id] += 0.5;
+        hess_vec_prod_g_xp_out_array[id] += 0.5;
+      }
+      size_t id = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell), node, 0) / neq);
+      hess_vec_prod_g_px_out_array[id] += 0.5;
+      hess_vec_prod_g_pp_out_array[id] += 0.5;
+    }
+
+  RCP<Albany::CombineAndScatterManager> x_cas_manager = Albany::createCombineAndScatterManager(x_space, overlapped_x_space);
+  RCP<Albany::CombineAndScatterManager> p_cas_manager = Albany::createCombineAndScatterManager(p_space, overlapped_p_space);
+
+  x_cas_manager->combine(overlapped_hess_vec_prod_g_xx_out, hess_vec_prod_g_xx_out, Albany::CombineMode::ADD);
+  x_cas_manager->combine(overlapped_hess_vec_prod_g_xp_out, hess_vec_prod_g_xp_out, Albany::CombineMode::ADD);
+  p_cas_manager->combine(overlapped_hess_vec_prod_g_px_out, hess_vec_prod_g_px_out, Albany::CombineMode::ADD);
+  p_cas_manager->combine(overlapped_hess_vec_prod_g_pp_out, hess_vec_prod_g_pp_out, Albany::CombineMode::ADD);
+
+  RCP<Teuchos::FancyOStream>
+      out_test = Teuchos::VerboseObjectBase::getDefaultOStream();
+
+  Teuchos::EVerbosityLevel verbLevel = Teuchos::VERB_EXTREME;
+
+  std::vector<Albany::IDArray> wsElNodeEqID_ID;
+
+  std::vector<std::vector<int>> wsElNodeEqID_ID_raw;
+
+  const int buck_size = cell_map->getNodeNumElements();
+  const int numBucks = 1;
+
+  wsElNodeEqID_ID.resize(numBucks);
+  wsElNodeEqID_ID_raw.resize(numBucks);
+  for (std::size_t i = 0; i < numBucks; i++)
+    wsElNodeEqID_ID_raw[i].resize(buck_size * nodes_per_element * neq);
+
+  for (int cell = 0; cell < cell_map->getNodeNumElements(); ++cell)
+    for (int node = 0; node < nodes_per_element; ++node)
+      wsElNodeEqID_ID_raw[0][cell * nodes_per_element * neq + node * neq] = overlapped_node_map->getLocalElement(wsGlobalElNodeEqID(cell_map->getGlobalElement(cell), node, 0) / neq);
+
+  for (std::size_t i = 0; i < numBucks; i++)
+    wsElNodeEqID_ID[i].assign<stk::mesh::Cartesian, stk::mesh::Cartesian, stk::mesh::Cartesian>(
+        wsElNodeEqID_ID_raw[i].data(),
+        buck_size,
+        nodes_per_element,
+        neq);
+
+  Kokkos::fence();
+
+  phxWorkset.numCells = cell_map->getNodeNumElements();
+  const int cubature_degree = 2;
+  const int num_dim = 3;
+
+  std::string param_name("Thermal conductivity");
+
+  // Need dl->node_scalar, dl->node_qp_scalar, dl->qp_scalar for this evaluator (PHAL_DOFInterpolation_Def.hpp line 20)
+  RCP<Albany::Layouts> dl;
+  RCP<PHAL::ComputeBasisFunctions<EvalType, PHAL::AlbanyTraits>> FEBasis =
+      Albany::createTestLayoutAndBasis<EvalType, PHAL::AlbanyTraits>(dl, phxWorkset.numCells, cubature_degree, num_dim);
+
+  std::string field_name = "Temperature";
+
+  ParameterList p;
+  // Setup scatter evaluator
+  p.set("Stand-alone Evaluator", true);
+  std::string local_response_name = "Local Response";
+  std::string global_response_name = "Global Response";
+  int worksetSize = dl->qp_scalar->extent(0);
+  int responseSize = 1;
+  auto local_response_layout = Teuchos::rcp(new MDALayout<Cell, Dim>(worksetSize, responseSize));
+  auto global_response_layout = Teuchos::rcp(new MDALayout<Dim>(responseSize));
+  PHX::Tag<Scalar> local_response_tag(local_response_name, local_response_layout);
+  PHX::Tag<Scalar> global_response_tag(global_response_name, global_response_layout);
+  p.set("Local Response Field Tag", local_response_tag);
+  p.set("Global Response Field Tag", global_response_tag);
+
+  ParameterList *plist = new ParameterList("Parameter List");
+  p.set<ParameterList *>("Parameter List", plist);
+
+  // Same as DOFInterpolationBase<EvalType,AlbanyTraits,Evalt::ScalarT>
+  RCP<PHAL::SeparableScatterScalarResponse<EvalType, PHAL::AlbanyTraits>> SeparableScatterScalarResponse =
+      rcp(new PHAL::SeparableScatterScalarResponse<EvalType, PHAL::AlbanyTraits>(p, dl));
+
+  std::vector<PHX::index_size_type> derivative_dimensions;
+  derivative_dimensions.push_back(nodes_per_element * neq);
+
+  typedef typename Sacado::ScalarType<Scalar>::type scalarType;
+  const scalarType tol = 1000.0 * std::numeric_limits<scalarType>::epsilon();
+
+  Teuchos::RCP<Albany::DistributedParameterLibrary> distParamLib = rcp(new Albany::DistributedParameterLibrary);
+  Teuchos::RCP<Albany::DistributedParameter> parameter(new Albany::DistributedParameter(
+      param_name,
+      overlapped_x_space,
+      overlapped_x_space));
+
+  parameter->set_workset_elem_dofs(Teuchos::rcpFromRef(wsElNodeEqID_ID));
+  const Albany::IDArray &wsElDofs = parameter->workset_elem_dofs()[0];
+  Teuchos::RCP<Thyra_Vector> dist_param = parameter->vector();
+  dist_param->assign(6.0);
+  parameter->scatter();
+  distParamLib->add(param_name, parameter);
+
+  phxWorkset.distParamLib = distParamLib;
+  phxWorkset.wsIndex = 0;
+  phxWorkset.wsElNodeEqID = wsLocalElNodeEqID;
+  phxWorkset.dist_param_deriv_name = param_name;
+  phxWorkset.hessianWorkset.dist_param_deriv_direction_name = param_name;
+
+  MDField<Scalar, Dim> global_response = allocateUnmanagedMDField<Scalar, Dim>(global_response_name, global_response_layout, derivative_dimensions);
+  MDField<Scalar, Cell, Dim> local_response = allocateUnmanagedMDField<Scalar, Cell, Dim>(local_response_name, local_response_layout, derivative_dimensions);
+  local_response.deep_copy(0.0);
+
+  for (std::size_t cell = 0; cell < static_cast<int>(local_response.extent(0)); ++cell)
+  {
+    for (std::size_t dim = 0; dim < static_cast<int>(local_response.extent(1)); ++dim)
+    {
+      for (int i = 0; i < nodes_per_element * neq; ++i)
+      {
+        local_response(cell, dim).fastAccessDx(i).fastAccessDx(0) = 0.5;
+      }
+    }
+  }
+
+  // Test without setting hess_vec_prod_g_**
+  {
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(SeparableScatterScalarResponse);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(global_response);
+    tester.setDependentFieldValues(local_response);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_g_xx, hess_vec_prod_g_xx, Albany::CombineMode::ADD);
+    x_cas_manager->combine(overlapped_hess_vec_prod_g_xp, hess_vec_prod_g_xp, Albany::CombineMode::ADD);
+    p_cas_manager->combine(overlapped_hess_vec_prod_g_px, hess_vec_prod_g_px, Albany::CombineMode::ADD);
+    p_cas_manager->combine(overlapped_hess_vec_prod_g_pp, hess_vec_prod_g_pp, Albany::CombineMode::ADD);
+
+    Thyra::V_VmV(diff_x_out.ptr(), *one_x_out, *hess_vec_prod_g_xx);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_xx_out", *one_x_out,
+            "hess_vec_prod_g_xx", *diff_x_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    Thyra::V_VmV(diff_x_out.ptr(), *one_x_out, *hess_vec_prod_g_xp);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_xp_out", *one_x_out,
+            "hess_vec_prod_g_xp", *diff_x_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    Thyra::V_VmV(diff_p_out.ptr(), *one_p_out, *hess_vec_prod_g_px);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_px_out", *one_p_out,
+            "hess_vec_prod_g_px", *diff_p_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    Thyra::V_VmV(diff_p_out.ptr(), *one_p_out, *hess_vec_prod_g_pp);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_pp_out", *one_p_out,
+            "hess_vec_prod_g_pp", *diff_p_out,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+  }
+  // Test hess_vec_prod_g_xx
+  {
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_xx = overlapped_hess_vec_prod_g_xx;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(SeparableScatterScalarResponse);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(global_response);
+    tester.setDependentFieldValues(local_response);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_g_xx, hess_vec_prod_g_xx, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_xx_out", *hess_vec_prod_g_xx_out,
+            "hess_vec_prod_g_xx", *hess_vec_prod_g_xx,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_xx = Teuchos::null;
+  }
+  // Test hess_vec_prod_g_xp
+  {
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_xp = overlapped_hess_vec_prod_g_xp;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(SeparableScatterScalarResponse);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(global_response);
+    tester.setDependentFieldValues(local_response);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    x_cas_manager->combine(overlapped_hess_vec_prod_g_xp, hess_vec_prod_g_xp, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_xp_out", *hess_vec_prod_g_xp_out,
+            "hess_vec_prod_g_xp", *hess_vec_prod_g_xp,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_xp = Teuchos::null;
+  }
+  // Test hess_vec_prod_g_px
+  {
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_px = overlapped_hess_vec_prod_g_px;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(SeparableScatterScalarResponse);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(global_response);
+    tester.setDependentFieldValues(local_response);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    p_cas_manager->combine(overlapped_hess_vec_prod_g_px, hess_vec_prod_g_px, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_px_out", *hess_vec_prod_g_px_out,
+            "hess_vec_prod_g_px", *hess_vec_prod_g_px,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
+
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_px = Teuchos::null;
+  }
+  // Test hess_vec_prod_g_pp
+  {
+    phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_pp = overlapped_hess_vec_prod_g_pp;
+
+    // Build a proper instance of the tester (see $TRILINOS_DIR/includes/Phalanx_Evaluator_UnitTester.hpp)
+    PHX::EvaluatorUnitTester<EvalType, PHAL::AlbanyTraits> tester;
+    tester.setEvaluatorToTest(SeparableScatterScalarResponse);
+    tester.setKokkosExtendedDataTypeDimensions(derivative_dimensions);
+    tester.setDependentFieldValues(global_response);
+    tester.setDependentFieldValues(local_response);
+    tester.testEvaluator(phxSetup, phxWorkset, phxWorkset, phxWorkset);
+
+    Kokkos::fence();
+
+    p_cas_manager->combine(overlapped_hess_vec_prod_g_pp, hess_vec_prod_g_pp, Albany::CombineMode::ADD);
+
+    TEUCHOS_TEST_FOR_EXCEPT(
+        !Thyra::testRelNormDiffErr(
+            "hess_vec_prod_g_pp_out", *hess_vec_prod_g_pp_out,
+            "hess_vec_prod_g_pp", *hess_vec_prod_g_pp,
+            "maxSensError", tol,
+            "warningTol", 1.0, // Don't warn
+            &*out_test, verbLevel));
 
     phxWorkset.hessianWorkset.overlapped_hess_vec_prod_g_pp = Teuchos::null;
   }


### PR DESCRIPTION
This PR follows and is based on Albany [PR 634](https://github.com/SNLComputation/Albany/pull/634) and  [PR 637](https://github.com/SNLComputation/Albany/pull/637).

This PR adds UnitTests for `scatterScalarResponse` and `scatterResidual` with the `HessianVec EvaluationType`.

The added tests rely on:
- the construction of stand-alone scatter evaluators,
- setting the required dependent fields,
- evaluating the evaluators,
- the comparison of the output Thyra vectors with the expected vectors computing the norm of their difference.