### PR TITLE
Add more doxygen documentation for Hessian-vector product computations

### DIFF
--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -1061,6 +1061,55 @@ FORMULA_FONTSIZE       = 10
 
 FORMULA_TRANSPARENT    = YES
 
+# Enable the USE_MATHJAX option to render LaTeX formulas using MathJax (see
+# http://www.mathjax.org) which uses client side Javascript for the rendering
+# instead of using pre-rendered bitmaps. Use this if you do not have LaTeX
+# installed or if you want to formulas look prettier in the HTML output. When
+# enabled you may also need to install MathJax separately and configure the path
+# to it using the MATHJAX_RELPATH option.
+# The default value is: NO.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+USE_MATHJAX            = YES
+
+# When MathJax is enabled you can set the default output format to be used for
+# the MathJax output. See the MathJax site (see:
+# http://docs.mathjax.org/en/latest/output.html) for more details.
+# Possible values are: HTML-CSS (which is slower, but has the best
+# compatibility), NativeMML (i.e. MathML) and SVG.
+# The default value is: HTML-CSS.
+# This tag requires that the tag USE_MATHJAX is set to YES.
+
+MATHJAX_FORMAT         = HTML-CSS
+
+# When MathJax is enabled you need to specify the location relative to the HTML
+# output directory using the MATHJAX_RELPATH option. The destination directory
+# should contain the MathJax.js script. For instance, if the mathjax directory
+# is located at the same level as the HTML output directory, then
+# MATHJAX_RELPATH should be ../mathjax. The default value points to the MathJax
+# Content Delivery Network so you can quickly see the result without installing
+# MathJax. However, it is strongly recommended to install a local copy of
+# MathJax from http://www.mathjax.org before deployment.
+# The default value is: http://cdn.mathjax.org/mathjax/latest.
+# This tag requires that the tag USE_MATHJAX is set to YES.
+
+MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+
+# The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
+# extension names that should be enabled during MathJax rendering. For example
+# MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
+# This tag requires that the tag USE_MATHJAX is set to YES.
+
+MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
+
+# The MATHJAX_CODEFILE tag can be used to specify a file with javascript pieces
+# of code that will be used on startup of the MathJax code. See the MathJax site
+# (see: http://docs.mathjax.org/en/latest/output.html) for more details. For an
+# example see the documentation.
+# This tag requires that the tag USE_MATHJAX is set to YES.
+
+MATHJAX_CODEFILE       = 
+
 # When the SEARCHENGINE tag is enabled doxygen will generate a search box
 # for the HTML output. The underlying search engine uses javascript
 # and DHTML and should work on any modern browser. Note that when using

--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -812,6 +812,8 @@ HTML_FOOTER            =
 
 HTML_STYLESHEET        =
 
+HTML_EXTRA_STYLESHEET  = extra_style.css
+
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output.
 # Doxygen will adjust the colors in the stylesheet and background images
 # according to this color. Hue is specified as an angle on a colorwheel,

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -814,6 +814,8 @@ HTML_FOOTER            =
 
 HTML_STYLESHEET        =
 
+HTML_EXTRA_STYLESHEET  = extra_style.css
+
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output.
 # Doxygen will adjust the colors in the stylesheet and background images
 # according to this color. Hue is specified as an angle on a colorwheel,

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -1063,6 +1063,55 @@ FORMULA_FONTSIZE       = 10
 
 FORMULA_TRANSPARENT    = YES
 
+# Enable the USE_MATHJAX option to render LaTeX formulas using MathJax (see
+# http://www.mathjax.org) which uses client side Javascript for the rendering
+# instead of using pre-rendered bitmaps. Use this if you do not have LaTeX
+# installed or if you want to formulas look prettier in the HTML output. When
+# enabled you may also need to install MathJax separately and configure the path
+# to it using the MATHJAX_RELPATH option.
+# The default value is: NO.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+USE_MATHJAX            = YES
+
+# When MathJax is enabled you can set the default output format to be used for
+# the MathJax output. See the MathJax site (see:
+# http://docs.mathjax.org/en/latest/output.html) for more details.
+# Possible values are: HTML-CSS (which is slower, but has the best
+# compatibility), NativeMML (i.e. MathML) and SVG.
+# The default value is: HTML-CSS.
+# This tag requires that the tag USE_MATHJAX is set to YES.
+
+MATHJAX_FORMAT         = HTML-CSS
+
+# When MathJax is enabled you need to specify the location relative to the HTML
+# output directory using the MATHJAX_RELPATH option. The destination directory
+# should contain the MathJax.js script. For instance, if the mathjax directory
+# is located at the same level as the HTML output directory, then
+# MATHJAX_RELPATH should be ../mathjax. The default value points to the MathJax
+# Content Delivery Network so you can quickly see the result without installing
+# MathJax. However, it is strongly recommended to install a local copy of
+# MathJax from http://www.mathjax.org before deployment.
+# The default value is: http://cdn.mathjax.org/mathjax/latest.
+# This tag requires that the tag USE_MATHJAX is set to YES.
+
+MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+
+# The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
+# extension names that should be enabled during MathJax rendering. For example
+# MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
+# This tag requires that the tag USE_MATHJAX is set to YES.
+
+MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
+
+# The MATHJAX_CODEFILE tag can be used to specify a file with javascript pieces
+# of code that will be used on startup of the MathJax code. See the MathJax site
+# (see: http://docs.mathjax.org/en/latest/output.html) for more details. For an
+# example see the documentation.
+# This tag requires that the tag USE_MATHJAX is set to YES.
+
+MATHJAX_CODEFILE       = 
+
 # When the SEARCHENGINE tag is enabled doxygen will generate a search box
 # for the HTML output. The underlying search engine uses javascript
 # and DHTML and should work on any modern browser. Note that when using

--- a/doc/doxygen/extra_style.css
+++ b/doc/doxygen/extra_style.css
@@ -1,0 +1,42 @@
+.background {
+  width: 200px;
+  height: 100px;
+  padding: 0;
+  margin: 0;
+}
+
+.cell {
+  width: 100px;
+  height: 100px;
+  padding: 0;
+  margin: 0;
+}
+
+.line {
+  width: 188px;
+  height: 94px;
+  border-bottom: 1px solid black;
+  transform: translateY(-40px) rotate(27deg);
+  position: absolute;
+  z-index: 1;
+}
+
+.background>div {
+  position: relative;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+}
+
+.bottom {
+  position: absolute;
+  bottom: 1px;
+  left: 1px;
+}
+
+.top {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+}

--- a/src/Albany_Application.hpp
+++ b/src/Albany_Application.hpp
@@ -365,6 +365,61 @@ public:
       const std::string&                      dist_param_name,
       const Teuchos::RCP<Thyra_MultiVector>&  dg_dp);
 
+  /**
+   * \brief evaluateResponseDistParamHessVecProd_xx function
+   * 
+   * This function is used to compute contributions of the application of the Hessian \f$\boldsymbol{H}(g)\f$ of the <tt>response[response_index]</tt> 
+   * (i.e. the response_index-th response) to a direction vector \f$\boldsymbol{v}\f$.
+   * 
+   * Representing the Hessian \f$\boldsymbol{H}(g)\f$ as a block matrix:
+   * \f[
+   *   \boldsymbol{H}(g) := 
+   *   \begin{bmatrix} 
+   *     \frac{\partial^{2} g}{\partial \boldsymbol{x}^{2}} & \frac{\partial^{2} g}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} g}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{n}} \\
+   *     \frac{\partial^{2} g}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{x}} & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{1}^{2}} & \cdots & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{p}_{n}} \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \frac{\partial^{2} g}{\partial \boldsymbol{p}_{n} \partial \boldsymbol{x}} & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{n}\partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{n}^{2}}
+   *   \end{bmatrix} =
+   *   \begin{bmatrix} 
+   *     \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(g) & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(g) & \cdots & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_n}(g) \\ 
+   *     \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{x}}(g) & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_1}(g) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_n}(g) \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{x}}(g) & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_1}(g) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_n}(g) 
+   *   \end{bmatrix},
+   * \f]
+   * where \f$g\f$ is the response, \f$\boldsymbol{x}\f$ is the solution vector, \f$\boldsymbol{p}_1\f$ is a first (distributed) parameter, \f$\ldots\f$, and \f$\boldsymbol{p}_n\f$ is the \f$n\f$-th 
+   * (distributed) parameter, this function computes the contribution:
+   * \f[
+   *   \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}.
+   * \f]
+   * 
+   * This function can currently compute only one block contribution at a time; for one function call \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}\f$
+   * can be computed only for one fixed response index at a time.
+   * 
+   * \param response_index [in] Response index of the response which the Hessian is computed.
+   * 
+   * \param current_time [in] Current time at which the Hessian is computed for transient simulations.
+   * 
+   * \param v [in] Direction vector on which the Hessian is applied: \f$\boldsymbol{v}_{\boldsymbol{x}}\f$.
+   * 
+   * \param x [in] Solution vector for the current time step: \f$\boldsymbol{x}\f$.
+   * 
+   * \param xdot [in] Velocity vector for the current time step.
+   * 
+   * \param xdotdot [in] Acceleration vector for the current time step.
+   * 
+   * \param param_array [in] Array of the parameters vectors.
+   * 
+   * \param Hv_g_xx [out] the output of the computation: \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}\f$.
+   * 
+   * This implementation relies on:
+   * <ul>
+   *  <li> PHAL::GatherSolution<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarExtruded2DNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::SeparableScatterScalarResponse<PHAL::AlbanyTraits::HessianVec,Traits>.
+   * </ul>
+   */
   void
   evaluateResponseDistParamHessVecProd_xx(
       int                                     response_index,
@@ -376,6 +431,64 @@ public:
       const Teuchos::Array<ParamVec>&         param_array,
       const Teuchos::RCP<Thyra_MultiVector>&  Hv_g_xx);
 
+  /**
+   * \brief evaluateResponseDistParamHessVecProd_xp function
+   * 
+   * This function is used to compute contributions of the application of the Hessian \f$\boldsymbol{H}(g)\f$ of the <tt>response[response_index]</tt> 
+   * (i.e. the response_index-th response) to a direction vector \f$\boldsymbol{v}\f$.
+   * 
+   * Representing the Hessian \f$\boldsymbol{H}(g)\f$ as a block matrix:
+   * \f[
+   *   \boldsymbol{H}(g) := 
+   *   \begin{bmatrix} 
+   *     \frac{\partial^{2} g}{\partial \boldsymbol{x}^{2}} & \frac{\partial^{2} g}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} g}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{n}} \\
+   *     \frac{\partial^{2} g}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{x}} & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{1}^{2}} & \cdots & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{p}_{n}} \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \frac{\partial^{2} g}{\partial \boldsymbol{p}_{n} \partial \boldsymbol{x}} & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{n}\partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{n}^{2}}
+   *   \end{bmatrix} =
+   *   \begin{bmatrix} 
+   *     \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(g) & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(g) & \cdots & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_n}(g) \\ 
+   *     \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{x}}(g) & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_1}(g) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_n}(g) \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{x}}(g) & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_1}(g) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_n}(g) 
+   *   \end{bmatrix},
+   * \f]
+   * where \f$g\f$ is the response, \f$\boldsymbol{x}\f$ is the solution vector, \f$\boldsymbol{p}_1\f$ is a first (distributed) parameter, \f$\ldots\f$, and \f$\boldsymbol{p}_n\f$ is the \f$n\f$-th 
+   * (distributed) parameter, this function computes the contribution:
+   * \f[
+   *   \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_j}(g)\boldsymbol{v}_{\boldsymbol{p}_j},
+   * \f]
+   * where \f$i\f$ and \f$j\f$ are 2 (potentially different) indices included in the range \f$\left[1,n\right]\f$.
+   * 
+   * This function can currently compute only one block contribution at a time; for one function call \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_j}(g)\boldsymbol{v}_{\boldsymbol{p}_j}\f$
+   * can be computed only for one fixed \f$j\f$ and one fixed response index at a time.
+   * 
+   * \param response_index [in] Response index of the response which the Hessian is computed.
+   * 
+   * \param current_time [in] Current time at which the Hessian is computed for transient simulations.
+   * 
+   * \param v [in] Direction vector on which the Hessian is applied: \f$\boldsymbol{v}_{\boldsymbol{p}_j}\f$.
+   * 
+   * \param x [in] Solution vector for the current time step: \f$\boldsymbol{x}\f$.
+   * 
+   * \param xdot [in] Velocity vector for the current time step.
+   * 
+   * \param xdotdot [in] Acceleration vector for the current time step.
+   * 
+   * \param param_array [in] Array of the parameters vectors.
+   * 
+   * \param dist_param_direction_name [in] Name of the parameter used for the second differentiation: \f$\boldsymbol{p}_j\f$.
+   * 
+   * \param Hv_g_xp [out] the output of the computation: \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_j}(g)\boldsymbol{v}_{\boldsymbol{p}_j}\f$.
+   * 
+   * This implementation relies on:
+   * <ul>
+   *  <li> PHAL::GatherSolution<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarExtruded2DNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::SeparableScatterScalarResponse<PHAL::AlbanyTraits::HessianVec,Traits>.
+   * </ul>
+   */
   void
   evaluateResponseDistParamHessVecProd_xp(
       int                                     response_index,
@@ -388,6 +501,64 @@ public:
       const std::string&                      dist_param_name,
       const Teuchos::RCP<Thyra_MultiVector>&  Hv_g_xp);
 
+  /**
+   * \brief evaluateResponseDistParamHessVecProd_px function
+   * 
+   * This function is used to compute contributions of the application of the Hessian \f$\boldsymbol{H}(g)\f$ of the <tt>response[response_index]</tt> 
+   * (i.e. the response_index-th response) to a direction vector \f$\boldsymbol{v}\f$.
+   * 
+   * Representing the Hessian \f$\boldsymbol{H}(g)\f$ as a block matrix:
+   * \f[
+   *   \boldsymbol{H}(g) := 
+   *   \begin{bmatrix} 
+   *     \frac{\partial^{2} g}{\partial \boldsymbol{x}^{2}} & \frac{\partial^{2} g}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} g}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{n}} \\
+   *     \frac{\partial^{2} g}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{x}} & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{1}^{2}} & \cdots & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{p}_{n}} \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \frac{\partial^{2} g}{\partial \boldsymbol{p}_{n} \partial \boldsymbol{x}} & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{n}\partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{n}^{2}}
+   *   \end{bmatrix} =
+   *   \begin{bmatrix} 
+   *     \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(g) & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(g) & \cdots & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_n}(g) \\ 
+   *     \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{x}}(g) & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_1}(g) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_n}(g) \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{x}}(g) & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_1}(g) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_n}(g) 
+   *   \end{bmatrix},
+   * \f]
+   * where \f$g\f$ is the response, \f$\boldsymbol{x}\f$ is the solution vector, \f$\boldsymbol{p}_1\f$ is a first (distributed) parameter, \f$\ldots\f$, and \f$\boldsymbol{p}_n\f$ is the \f$n\f$-th 
+   * (distributed) parameter, this function computes the contribution:
+   * \f[
+   *   \boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}},
+   * \f]
+   * where \f$i\f$ is an index included in the range \f$\left[1,n\right]\f$.
+   * 
+   * This function can currently compute only one block contribution at a time; for one function call \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}\f$
+   * can be computed only for one fixed \f$i\f$ and one fixed response index at a time.
+   * 
+   * \param response_index [in] Response index of the response which the Hessian is computed.
+   * 
+   * \param current_time [in] Current time at which the Hessian is computed for transient simulations.
+   * 
+   * \param v [in] Direction vector on which the Hessian is applied: \f$\boldsymbol{v}_{\boldsymbol{x}}\f$
+   * 
+   * \param x [in] Solution vector for the current time step: \f$\boldsymbol{x}\f$
+   * 
+   * \param xdot [in] Velocity vector for the current time step.
+   * 
+   * \param xdotdot [in] Acceleration vector for the current time step.
+   * 
+   * \param param_array [in] Array of the parameters vectors.
+   * 
+   * \param dist_param_name [in] Name of the parameter used for the first differentiation: \f$\boldsymbol{p}_i\f$.
+   * 
+   * \param Hv_g_px [out] the output of the computation: \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}\f$.
+   * 
+   * This implementation relies on:
+   * <ul>
+   *  <li> PHAL::GatherSolution<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarExtruded2DNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::SeparableScatterScalarResponse<PHAL::AlbanyTraits::HessianVec,Traits>.
+   * </ul>
+   */
   void
   evaluateResponseDistParamHessVecProd_px(
       int                                     response_index,
@@ -400,6 +571,66 @@ public:
       const std::string&                      dist_param_name,
       const Teuchos::RCP<Thyra_MultiVector>&  Hv_g_px);
 
+  /**
+   * \brief evaluateResponseDistParamHessVecProd_pp function
+   * 
+   * This function is used to compute contributions of the application of the Hessian \f$\boldsymbol{H}(g)\f$ of the <tt>response[response_index]</tt> 
+   * (i.e. the response_index-th response) to a direction vector \f$\boldsymbol{v}\f$.
+   * 
+   * Representing the Hessian \f$\boldsymbol{H}(g)\f$ as a block matrix:
+   * \f[
+   *   \boldsymbol{H}(g) := 
+   *   \begin{bmatrix} 
+   *     \frac{\partial^{2} g}{\partial \boldsymbol{x}^{2}} & \frac{\partial^{2} g}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} g}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{n}} \\
+   *     \frac{\partial^{2} g}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{x}} & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{1}^{2}} & \cdots & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{p}_{n}} \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \frac{\partial^{2} g}{\partial \boldsymbol{p}_{n} \partial \boldsymbol{x}} & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{n}\partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} g}{\partial \boldsymbol{p}_{n}^{2}}
+   *   \end{bmatrix} =
+   *   \begin{bmatrix} 
+   *     \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(g) & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(g) & \cdots & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_n}(g) \\ 
+   *     \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{x}}(g) & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_1}(g) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_n}(g) \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{x}}(g) & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_1}(g) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_n}(g) 
+   *   \end{bmatrix},
+   * \f]
+   * where \f$g\f$ is the response, \f$\boldsymbol{x}\f$ is the solution vector, \f$\boldsymbol{p}_1\f$ is a first (distributed) parameter, \f$\ldots\f$, and \f$\boldsymbol{p}_n\f$ is the \f$n\f$-th 
+   * (distributed) parameter, this function computes the contribution:
+   * \f[
+   *   \boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_j}(g)\boldsymbol{v}_{\boldsymbol{p}_j},
+   * \f]
+   * where \f$i\f$ and \f$j\f$ are 2 (potentially different) indices included in the range \f$\left[1,n\right]\f$.
+   * 
+   * This function can currently compute only one block contribution at a time; for one function call \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_j}(g)\boldsymbol{v}_{\boldsymbol{p}_j}\f$
+   * can be computed only for one fixed \f$i\f$, one fixed \f$j\f$, and one fixed response index at a time.
+   * 
+   * \param response_index [in] Response index of the response which the Hessian is computed.
+   * 
+   * \param current_time [in] Current time at which the Hessian is computed for transient simulations.
+   * 
+   * \param v [in] Direction vector on which the Hessian is applied: \f$\boldsymbol{v}_{\boldsymbol{p}_j}\f$.
+   * 
+   * \param x [in] Solution vector for the current time step: \f$\boldsymbol{x}\f$.
+   * 
+   * \param xdot [in] Velocity vector for the current time step.
+   * 
+   * \param xdotdot [in] Acceleration vector for the current time step.
+   * 
+   * \param param_array [in] Array of the parameters vectors.
+   * 
+   * \param dist_param_name [in] Name of the parameter used for the first differentiation: \f$\boldsymbol{p}_i\f$.
+   * 
+   * \param dist_param_direction_name [in] Name of the parameter used for the second differentiation: \f$\boldsymbol{p}_j\f$.
+   * 
+   * \param Hv_g_pp [out] the output of the computation: \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_j}(g)\boldsymbol{v}_{\boldsymbol{p}_j}\f$.
+   * 
+   * This implementation relies on:
+   * <ul>
+   *  <li> PHAL::GatherSolution<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarExtruded2DNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::SeparableScatterScalarResponse<PHAL::AlbanyTraits::HessianVec,Traits>.
+   * </ul>
+   */
   void
   evaluateResponseDistParamHessVecProd_pp(
       int                                     response_index,
@@ -413,6 +644,59 @@ public:
       const std::string&                      dist_param_direction_name,
       const Teuchos::RCP<Thyra_MultiVector>&  Hv_g_pp);
 
+  /**
+   * \brief evaluateResidual_HessVecProd_xx function
+   * 
+   * This function is used to compute contributions of the application of the Hessian \f$\boldsymbol{H}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\f$ of the inner product of the residual vector \f$\boldsymbol{f}\f$
+   * and a Lagrange multiplier vector \f$\boldsymbol{z}\f$ to a direction vector \f$\boldsymbol{v}\f$.
+   * 
+   * Representing the Hessian \f$\boldsymbol{H}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\f$ as a block matrix:
+   * \f[
+   *   \boldsymbol{H}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) := 
+   *   \begin{bmatrix} 
+   *     \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{x}^{2}} & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{n}} \\
+   *     \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{x}} & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{1}^{2}} & \cdots & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{p}_{n}} \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{n} \partial \boldsymbol{x}} & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{n}\partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{n}^{2}}
+   *   \end{bmatrix} =
+   *   \begin{bmatrix} 
+   *     \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \cdots & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_n}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) \\ 
+   *     \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_n}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_n}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) 
+   *   \end{bmatrix},
+   * \f]
+   * where \f$\boldsymbol{x}\f$ is the solution vector, \f$\boldsymbol{p}_1\f$ is a first (distributed) parameter, \f$\ldots\f$, and \f$\boldsymbol{p}_n\f$ is the \f$n\f$-th 
+   * (distributed) parameter, this function computes the contribution:
+   * \f[
+   *   \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}.
+   * \f]
+   * 
+   * \param current_time [in] Current time at which the Hessian is computed for transient simulations.
+   * 
+   * \param v [in] Direction vector on which the Hessian is applied: \f$\boldsymbol{v}_{\boldsymbol{x}}\f$.
+   * 
+   * \param z [in] Lagrange multiplier vector: \f$\boldsymbol{z}\f$.
+   * 
+   * \param x [in] Solution vector for the current time step: \f$\boldsymbol{x}\f$.
+   * 
+   * \param xdot [in] Velocity vector for the current time step.
+   * 
+   * \param xdotdot [in] Acceleration vector for the current time step.
+   * 
+   * \param param_array [in] Array of the parameters vectors.
+   * 
+   * \param Hv_f_xx [out] the output of the computation: \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}\f$.
+   * 
+   * This implementation relies on:
+   * <ul>
+   *  <li> PHAL::GatherSolution<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarExtruded2DNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::ScatterResidual<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::ScatterResidualWithExtrudedParams<PHAL::AlbanyTraits::HessianVec,Traits>.
+   * </ul>
+   */
 void
   evaluateResidual_HessVecProd_xx(
       const double                            current_time,
@@ -424,6 +708,65 @@ void
       const Teuchos::Array<ParamVec>&         param_array,
       const Teuchos::RCP<Thyra_MultiVector>&  Hv_f_xx);
 
+  /**
+   * \brief evaluateResidual_HessVecProd_xp function
+   * 
+   * This function is used to compute contributions of the application of the Hessian \f$\boldsymbol{H}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\f$ of the inner product of the residual vector \f$\boldsymbol{f}\f$
+   * and a Lagrange multiplier vector \f$\boldsymbol{z}\f$ to a direction vector \f$\boldsymbol{v}\f$.
+   * 
+   * Representing the Hessian \f$\boldsymbol{H}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\f$ as a block matrix:
+   * \f[
+   *   \boldsymbol{H}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) := 
+   *   \begin{bmatrix} 
+   *     \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{x}^{2}} & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{n}} \\
+   *     \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{x}} & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{1}^{2}} & \cdots & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{p}_{n}} \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{n} \partial \boldsymbol{x}} & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{n}\partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{n}^{2}}
+   *   \end{bmatrix} =
+   *   \begin{bmatrix} 
+   *     \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \cdots & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_n}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) \\ 
+   *     \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_n}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_n}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) 
+   *   \end{bmatrix},
+   * \f]
+   * where \f$\boldsymbol{x}\f$ is the solution vector, \f$\boldsymbol{p}_1\f$ is a first (distributed) parameter, \f$\ldots\f$, and \f$\boldsymbol{p}_n\f$ is the \f$n\f$-th 
+   * (distributed) parameter, this function computes the contribution:
+   * \f[
+   *   \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_j}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_j},
+   * \f]
+   * where \f$j\f$ is an index included in the range \f$\left[1,n\right]\f$.
+   * 
+   * This function can currently compute only one block contribution at a time; for one function call \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_j}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_j}\f$
+   * can be computed for only one fixed \f$j\f$ at a time.
+   * 
+   * \param current_time [in] Current time at which the Hessian is computed for transient simulations.
+   * 
+   * \param v [in] Direction vector on which the Hessian is applied: \f$\boldsymbol{v}_{\boldsymbol{p}_j}\f$.
+   * 
+   * \param z [in] Lagrange multiplier vector: \f$\boldsymbol{z}\f$.
+   * 
+   * \param x [in] Solution vector for the current time step: \f$\boldsymbol{x}\f$.
+   * 
+   * \param xdot [in] Velocity vector for the current time step.
+   * 
+   * \param xdotdot [in] Acceleration vector for the current time step.
+   * 
+   * \param param_array [in] Array of the parameters vectors.
+   * 
+   * \param dist_param_direction_name [in] Name of the parameter used for the second differentiation: \f$\boldsymbol{p}_j\f$.
+   * 
+   * \param Hv_f_xp [out] the output of the computation: \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_j}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_j}\f$.
+   * 
+   * This implementation relies on:
+   * <ul>
+   *  <li> PHAL::GatherSolution<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarExtruded2DNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::ScatterResidual<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::ScatterResidualWithExtrudedParams<PHAL::AlbanyTraits::HessianVec,Traits>.
+   * </ul>
+   */
   void
   evaluateResidual_HessVecProd_xp(
       const double                            current_time,
@@ -433,9 +776,68 @@ void
       const Teuchos::RCP<const Thyra_Vector>& xdot,
       const Teuchos::RCP<const Thyra_Vector>& xdotdot,
       const Teuchos::Array<ParamVec>&         param_array,
-      const std::string&                      dist_param_name,
+      const std::string&                      dist_param_direction_name,
       const Teuchos::RCP<Thyra_MultiVector>&  Hv_f_xp);
 
+  /**
+   * \brief evaluateResidual_HessVecProd_px function
+   * 
+   * This function is used to compute contributions of the application of the Hessian \f$\boldsymbol{H}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\f$ of the inner product of the residual vector \f$\boldsymbol{f}\f$
+   * and a Lagrange multiplier vector \f$\boldsymbol{z}\f$ to a direction vector \f$\boldsymbol{v}\f$.
+   * 
+   * Representing the Hessian \f$\boldsymbol{H}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\f$ as a block matrix:
+   * \f[
+   *   \boldsymbol{H}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) := 
+   *   \begin{bmatrix} 
+   *     \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{x}^{2}} & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{n}} \\
+   *     \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{x}} & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{1}^{2}} & \cdots & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{p}_{n}} \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{n} \partial \boldsymbol{x}} & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{n}\partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{n}^{2}}
+   *   \end{bmatrix} =
+   *   \begin{bmatrix} 
+   *     \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \cdots & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_n}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) \\ 
+   *     \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_n}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_n}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) 
+   *   \end{bmatrix},
+   * \f]
+   * where \f$\boldsymbol{x}\f$ is the solution vector, \f$\boldsymbol{p}_1\f$ is a first (distributed) parameter, \f$\ldots\f$, and \f$\boldsymbol{p}_n\f$ is the \f$n\f$-th 
+   * (distributed) parameter, this function computes the contribution:
+   * \f[
+   *   \boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}},
+   * \f]
+   * where \f$i\f$ is an index included in the range \f$\left[1,n\right]\f$.
+   * 
+   * This function can currently compute only one block contribution at a time; for one function call \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}\f$
+   * can be computed for only one fixed \f$i\f$ at a time.
+   * 
+   * \param current_time [in] Current time at which the Hessian is computed for transient simulations.
+   * 
+   * \param v [in] Direction vector on which the Hessian is applied: \f$\boldsymbol{v}_{\boldsymbol{x}}\f$.
+   * 
+   * \param z [in] Lagrange multiplier vector: \f$\boldsymbol{z}\f$.
+   * 
+   * \param x [in] Solution vector for the current time step: \f$\boldsymbol{x}\f$.
+   * 
+   * \param xdot [in] Velocity vector for the current time step.
+   * 
+   * \param xdotdot [in] Acceleration vector for the current time step.
+   * 
+   * \param param_array [in] Array of the parameters vectors.
+   * 
+   * \param dist_param_name [in] Name of the parameter used for the first differentiation: \f$\boldsymbol{p}_i\f$.
+   * 
+   * \param Hv_f_px [out] the output of the computation: \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}\f$.
+   * 
+   * This implementation relies on:
+   * <ul>
+   *  <li> PHAL::GatherSolution<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarExtruded2DNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::ScatterResidual<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::ScatterResidualWithExtrudedParams<PHAL::AlbanyTraits::HessianVec,Traits>.
+   * </ul>
+   */
   void
   evaluateResidual_HessVecProd_px(
       const double                            current_time,
@@ -448,6 +850,67 @@ void
       const std::string&                      dist_param_name,
       const Teuchos::RCP<Thyra_MultiVector>&  Hv_f_px);
 
+  /**
+   * \brief evaluateResidual_HessVecProd_pp function
+   * 
+   * This function is used to compute contributions of the application of the Hessian \f$\boldsymbol{H}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\f$ of the inner product of the residual vector \f$\boldsymbol{f}\f$
+   * and a Lagrange multiplier vector \f$\boldsymbol{z}\f$ to a direction vector \f$\boldsymbol{v}\f$.
+   * 
+   * Representing the Hessian \f$\boldsymbol{H}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\f$ as a block matrix:
+   * \f[
+   *   \boldsymbol{H}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) := 
+   *   \begin{bmatrix} 
+   *     \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{x}^{2}} & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{x} \partial \boldsymbol{p}_{n}} \\
+   *     \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{x}} & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{1}^{2}} & \cdots & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{1} \partial \boldsymbol{p}_{n}} \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{n} \partial \boldsymbol{x}} & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{n}\partial \boldsymbol{p}_{1}} & \cdots & \frac{\partial^{2} \left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle}{\partial \boldsymbol{p}_{n}^{2}}
+   *   \end{bmatrix} =
+   *   \begin{bmatrix} 
+   *     \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \cdots & \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_n}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) \\ 
+   *     \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_n}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) \\
+   *     \vdots & \vdots & \ddots & \vdots\\
+   *     \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) & \cdots & \boldsymbol{H}_{\boldsymbol{p}_n\boldsymbol{p}_n}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle) 
+   *   \end{bmatrix},
+   * \f]
+   * where \f$\boldsymbol{x}\f$ is the solution vector, \f$\boldsymbol{p}_1\f$ is a first (distributed) parameter, \f$\ldots\f$, and \f$\boldsymbol{p}_n\f$ is the \f$n\f$-th 
+   * (distributed) parameter, this function computes the contribution:
+   * \f[
+   *   \boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_j}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_j},
+   * \f]
+   * where \f$i\f$ and \f$j\f$ are 2 (potentially different) indices included in the range \f$\left[1,n\right]\f$.
+   * 
+   * This function can currently compute only one block contribution at a time; for one function call \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_j}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_j}\f$
+   * can be computed for only one fixed \f$i\f$ and one fixed \f$j\f$ at a time.
+   * 
+   * \param current_time [in] Current time at which the Hessian is computed for transient simulations.
+   * 
+   * \param v [in] Direction vector on which the Hessian is applied: \f$\boldsymbol{v}_{\boldsymbol{p}_j}\f$.
+   * 
+   * \param z [in] Lagrange multiplier vector: \f$\boldsymbol{z}\f$.
+   * 
+   * \param x [in] Solution vector for the current time step: \f$\boldsymbol{x}\f$.
+   * 
+   * \param xdot [in] Velocity vector for the current time step.
+   * 
+   * \param xdotdot [in] Acceleration vector for the current time step.
+   * 
+   * \param param_array [in] Array of the parameters vectors.
+   * 
+   * \param dist_param_name [in] Name of the parameter used for the first differentiation: \f$\boldsymbol{p}_i\f$.
+   * 
+   * \param dist_param_direction_name [in] Name of the parameter used for the second differentiation: \f$\boldsymbol{p}_j\f$.
+   * 
+   * \param Hv_f_pp [out] the output of the computation: \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_j}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_j}\f$.
+   * 
+   * This implementation relies on:
+   * <ul>
+   *  <li> PHAL::GatherSolution<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::GatherScalarExtruded2DNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::ScatterResidual<PHAL::AlbanyTraits::HessianVec,Traits>,
+   *  <li> PHAL::ScatterResidualWithExtrudedParams<PHAL::AlbanyTraits::HessianVec,Traits>.
+   * </ul>
+   */
   void
   evaluateResidual_HessVecProd_pp(
       const double                            current_time,

--- a/src/evaluators/gather/PHAL_GatherScalarNodalParameter.hpp
+++ b/src/evaluators/gather/PHAL_GatherScalarNodalParameter.hpp
@@ -131,35 +131,53 @@ private:
  *
  * This specialization is used to gather the distributed parameter for the computation of:
  * <ul>
- *  <li> The @f$ H_{xp_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ contribution of the Hessian-vector product of the response function:
  *       \f[
- *         H_{xp_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} g(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2)\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2x}(g)v_{x} @f$ contribution of the Hessian-vector product of the response function:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}\f$ contribution of the Hessian-vector product of the response function:
  *       \f[
- *         H_{p_2x}(g)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x+ r\,v_{x},p_1, p_2)\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} g(\boldsymbol{x}+ r\,\boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2)\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2p_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ contribution of the Hessian-vector product of the response function:
  *       \f[
- *         H_{p_2p_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} g(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2)\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{xp_1}(f,z)v_{p_1} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{xp_1}(f,z)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} \left\langle f(x, p_1+ r\,v_{p_1}, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} \left\langle f(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2x}(f,z)v_{x} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}\f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{p_2x}(f,z)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x+ r\,v_{x},p_1, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} \left\langle f(\boldsymbol{x}+ r\,\boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2p_1}(f,z)v_{p_1} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{p_2p_1}(f,z)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x, p_1+ r\,v_{p_1}, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} \left\langle f(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
  * </ul>
  *
- *  where  @f$ x @f$  is the solution,  @f$ p_1 @f$  is a first distributed parameter,  @f$ p_2 @f$  is a potentially different second distributed parameter,
- *  @f$  g @f$  is the response function, @f$  f @f$  is the residual, @f$  z  @f$ is the Lagrange multiplier vector,  @f$ v_{x} @f$  is a direction vector
- *  with the same dimension as the vector  @f$ x @f$, and @f$ v_{p_1} @f$  is a direction vector with the same dimension as the vector  @f$ p_1 @f$.
+ *  where \f$\boldsymbol{x}\f$ is the solution, \f$\boldsymbol{p}_1\f$ is a first distributed parameter,  \f$\boldsymbol{p}_2 \f$ is a potentially different second distributed parameter,
+ *  \f$g\f$ is the response function, \f$\boldsymbol{f}\f$ is the residual, \f$\boldsymbol{z}\f$ is the Lagrange multiplier vector,  \f$\boldsymbol{v}_{\boldsymbol{x}}\f$ is a direction vector
+ *  with the same dimension as the vector  \f$\boldsymbol{x}\f$, and \f$\boldsymbol{v}_{\boldsymbol{p}_1}\f$ is a direction vector with the same dimension as the vector \f$\boldsymbol{p}_1\f$.
+ * 
+ * This gather is used when calling: 
+ * <ul>
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_xx,
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_xp,
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_px, 
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_pp,
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_xx,
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_xp,
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_px, 
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_pp.
+ * </ul>
  */
 template<typename Traits>
 class GatherScalarNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits> :
@@ -180,35 +198,53 @@ private:
  *
  * This specialization is used to gather the extruded distributed parameter for the computation of:
  * <ul>
- *  <li> The @f$ H_{xp_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ contribution of the Hessian-vector product of the response function:
  *       \f[
- *         H_{xp_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} g(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2)\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2x}(g)v_{x} @f$ contribution of the Hessian-vector product of the response function:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}\f$ contribution of the Hessian-vector product of the response function:
  *       \f[
- *         H_{p_2x}(g)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x+ r\,v_{x},p_1, p_2)\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} g(\boldsymbol{x}+ r\,\boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2)\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2p_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ contribution of the Hessian-vector product of the response function:
  *       \f[
- *         H_{p_2p_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} g(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2)\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{xp_1}(f,z)v_{p_1} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{xp_1}(f,z)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} \left\langle f(x, p_1+ r\,v_{p_1}, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} \left\langle f(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2x}(f,z)v_{x} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}\f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{p_2x}(f,z)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x+ r\,v_{x},p_1, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} \left\langle f(\boldsymbol{x}+ r\,\boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2p_1}(f,z)v_{p_1} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{p_2p_1}(f,z)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x, p_1+ r\,v_{p_1}, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} \left\langle f(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
  * </ul>
  *
- *  where  @f$ x @f$  is the solution,  @f$ p_1 @f$  is a first distributed parameter which can be extruded,  @f$ p_2 @f$  is a potentially different second distributed parameter which can be extruded too,
- *  @f$  g @f$  is the response function, @f$  f @f$  is the residual, @f$  z  @f$ is the Lagrange multiplier vector,  @f$ v_{x} @f$  is a direction vector
- *  with the same dimension as the vector  @f$ x @f$, and @f$ v_{p_1} @f$  is a direction vector with the same dimension as the vector  @f$ p_1 @f$.
+ *  where  \f$\boldsymbol{x}\f$ is the solution, \f$\boldsymbol{p}_1\f$ is a first distributed parameter which can be extruded, \f$\boldsymbol{p}_2\f$ is a potentially different second distributed parameter which can be extruded too,
+ *  \f$g\f$ is the response function, \f$\boldsymbol{f}\f$ is the residual, \f$\boldsymbol{z}\f$ is the Lagrange multiplier vector, \f$\boldsymbol{v}_{\boldsymbol{x}}\f$ is a direction vector
+ *  with the same dimension as the vector \f$\boldsymbol{x}\f$, and \f$\boldsymbol{v}_{\boldsymbol{p}_1}\f$ is a direction vector with the same dimension as the vector \f$\boldsymbol{p}_1\f$.
+ * 
+ * This gather is used when calling: 
+ * <ul>
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_xx,
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_xp,
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_px, 
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_pp,
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_xx,
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_xp,
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_px, 
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_pp.
+ * </ul>
  */
 template<typename Traits>
 class GatherScalarExtruded2DNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits> :

--- a/src/evaluators/gather/PHAL_GatherScalarNodalParameter.hpp
+++ b/src/evaluators/gather/PHAL_GatherScalarNodalParameter.hpp
@@ -187,6 +187,156 @@ public:
   GatherScalarNodalParameter(const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>& dl);
   // Old constructor, still needed by BCs that use PHX Factory
   GatherScalarNodalParameter(const Teuchos::ParameterList& p);
+
+  /**
+   * @brief Gather the parameter for the Hessian-vector product computations.
+   * 
+   * The PHAL::AlbanyTraits::HessianVec::ScalarT is a nested Sacado::FAD type with two levels of
+   * differentiation. 
+   * 
+   * This member function behaves in four different ways depending on which Hessian-vector product
+   * contribution is currently computed, for a current parameter \f$\boldsymbol{p}_1\f$:
+   * 
+   * <ol>
+   * 
+   * <li> If the contribution which is currently computed is one of the following contributions:
+   * <ul>
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}\f$,
+   * </ul>
+   * the first derivative and the second derivative are w.r.t the parameter \f$\boldsymbol{p}_1\f$ and the values of the FAD types have to be
+   * initialized for both first and second derivatives.
+   * 
+   * Such a case is illustrated in the following table; the value of the parameter, the first derivative, and the second derivative have to be set.
+   * 
+   * <table>
+   * <caption id="multi_row">Example of the initialization of a parameter</caption>
+   * <tr><th class="background">     
+   * <div><span class="bottom">First derivative</span>
+   *   <span class="top">Second derivative</span>
+   *   <div class="line"></div>
+   * </div>                    <th class="cell">val        <th class="cell">dx(0)
+   * <tr><th>val                  <td>65          <td>0.4
+   * <tr><th>dx(0)                <td>1          <td>0
+   * <tr><th>dx(1)                <td>0          <td>0
+   * <tr><th>dx(2)                <td>0          <td>0
+   * <tr><th>dx(3)                <td>0          <td>0
+   * </table>
+   * 
+   * In the implementation, this is translated as follows:
+   * <tt>
+   *  is_p_active = true;
+   *  is_p_direction_active = true;
+   * </tt>
+   * 
+   * </li>
+   * 
+   * <li> If the contribution which is currently computed is one of the following contributions:
+   * <ul>
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_j}(g)\boldsymbol{v}_{\boldsymbol{p}_j}\f$ where \f$j\neq1\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{p}_1\boldsymbol{p}_j}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_j}\f$ where \f$j\neq1\f$,
+   * </ul>
+   * only the first derivative is w.r.t the current parameter \f$\boldsymbol{p}_1\f$ and the values of the FAD types have to be
+   * initialized for the first derivatives.
+   * 
+   * Such a case is illustrated in the following table; the value of the parameter and the first derivative have to be set.
+   * 
+   * <table>
+   * <caption id="multi_row">Example of the initialization of a parameter</caption>
+   * <tr><th class="background">     
+   * <div><span class="bottom">First derivative</span>
+   *   <span class="top">Second derivative</span>
+   *   <div class="line"></div>
+   * </div>                    <th class="cell">val        <th class="cell">dx(0)
+   * <tr><th>val                  <td>65          <td>0
+   * <tr><th>dx(0)                <td>1          <td>0
+   * <tr><th>dx(1)                <td>0          <td>0
+   * <tr><th>dx(2)                <td>0          <td>0
+   * <tr><th>dx(3)                <td>0          <td>0
+   * </table>
+   * 
+   * In the implementation, this is translated as follows:
+   * <tt>
+   *  is_x_active = true;
+   *  is_x_direction_active = false;
+   * </tt>
+   * 
+   * </li>
+   * 
+   * <li> If the contribution which is currently computed is one of the following contributions:
+   * <ul>
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ where \f$i\neq1\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ where \f$i\neq1\f$,
+   * </ul>
+   * only the second derivative is w.r.t the current parameter \f$\boldsymbol{p}_1\f$ and the values of the FAD types have to be
+   * initialized for the second derivatives.
+   * 
+   * Such a case is illustrated in the following table; the value of the parameter and the second derivative have to be set.
+   * 
+   * <table>
+   * <caption id="multi_row">Example of the initialization of a parameter</caption>
+   * <tr><th class="background">     
+   * <div><span class="bottom">First derivative</span>
+   *   <span class="top">Second derivative</span>
+   *   <div class="line"></div>
+   * </div>                    <th class="cell">val        <th class="cell">dx(0)
+   * <tr><th>val                  <td>65          <td>0.4
+   * <tr><th>dx(0)                <td>0          <td>0
+   * <tr><th>dx(1)                <td>0          <td>0
+   * <tr><th>dx(2)                <td>0          <td>0
+   * <tr><th>dx(3)                <td>0          <td>0
+   * </table>
+   * 
+   * In the implementation, this is translated as follows:
+   * <tt>
+   *  is_p_active = false;
+   *  is_p_direction_active = true;
+   * </tt>
+   * 
+   * </li>
+   * 
+   * <li> If the contribution which is currently computed is one of the following contributions:
+   * <ul>
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_j}(g)\boldsymbol{v}_{\boldsymbol{p}_j}\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_j}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_j}\f$  where \f$j\neq1\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}\f$  where \f$j\neq1\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}\f$  where \f$i\neq1\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_j}(g)\boldsymbol{v}_{\boldsymbol{p}_j}\f$  where \f$i\neq1\neq j\f$,
+   *   <li> \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_j}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_j}\f$  where \f$i\neq1\neq j\f$,
+   * </ul>
+   * none of the derivative is w.r.t the current parameter \f$\boldsymbol{p}_1\f$. 
+   * The values of the derivatives of the FAD types should not be initialized during this function call.
+   * 
+   * Such a case is illustrated in the following table; only the value of the parameter has to be set.
+   * 
+   * <table>
+   * <caption id="multi_row">Example of the initialization of a parameter</caption>
+   * <tr><th class="background">     
+   * <div><span class="bottom">First derivative</span>
+   *   <span class="top">Second derivative</span>
+   *   <div class="line"></div>
+   * </div>                    <th class="cell">val        <th class="cell">dx(0)
+   * <tr><th>val                  <td>65          <td>0
+   * <tr><th>dx(0)                <td>0          <td>0
+   * <tr><th>dx(1)                <td>0          <td>0
+   * <tr><th>dx(2)                <td>0          <td>0
+   * <tr><th>dx(3)                <td>0          <td>0
+   * </table>
+   * 
+   * In the implementation, this is translated as follows:
+   * <tt> is_p_active = false;
+   *  is_p_direction_active = false;
+   * </tt>
+   * 
+   * </li>
+   * </ol>
+   */
   void evaluateFields(typename Traits::EvalData d);
 private:
   typedef typename PHAL::AlbanyTraits::HessianVec::ParamScalarT ParamScalarT;
@@ -252,6 +402,12 @@ class GatherScalarExtruded2DNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits
 
 public:
   GatherScalarExtruded2DNodalParameter(const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>& dl);
+
+  /**
+   * @brief Gather the extruded parameter for the Hessian-vector product computations.
+   * 
+   * See PHAL::GatherScalarNodalParameter<PHAL::AlbanyTraits::HessianVec,Traits> for more details on the implementation.
+   */
   void evaluateFields(typename Traits::EvalData d);
 private:
   typedef typename PHAL::AlbanyTraits::HessianVec::ParamScalarT ParamScalarT;

--- a/src/evaluators/gather/PHAL_GatherSolution.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolution.hpp
@@ -297,35 +297,53 @@ private:
  *
  * This specialization is used to gather the solution for the computation of:
  * <ul>
- *  <li> The @f$ H_{xx}(g)v_{x} @f$ contribution of the Hessian-vector product of the response function:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}\f$ contribution of the Hessian-vector product of the response function:
  *       \f[
- *         H_{xx}(g)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{x} g(x+ r\,v_{x},p_1, p_2)\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} g(\boldsymbol{x}+ r\,\boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2)\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{xp_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1} \f$ contribution of the Hessian-vector product of the response function:
  *       \f[
- *         H_{xp_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} g(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2)\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2x}(g)v_{x} @f$ contribution of the Hessian-vector product of the response function:
+ *  <li> The \f$ \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}} \f$ contribution of the Hessian-vector product of the response function:
  *       \f[
- *         H_{p_2x}(g)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x+ r\,v_{x},p_1, p_2)\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} g(\boldsymbol{x}+ r\,\boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2)\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{xx}(f,z)v_{x} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$ \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}} \f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{xx}(f,z)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{x} \left\langle f(x+ r\,v_{x},p_1, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} \left\langle \boldsymbol{f}(\boldsymbol{x}+ r\,\boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{xp_1}(f,z)v_{p_1} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1} \f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{xp_1}(f,z)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} \left\langle f(x, p_1+ r\,v_{p_1}, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} \left\langle \boldsymbol{f}(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2x}(f,z)v_{x} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}} \f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{p_2x}(f,z)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x+ r\,v_{x},p_1, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} \left\langle \boldsymbol{f}(\boldsymbol{x}+ r\,\boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
  * </ul>
  *
- *  where  @f$ x @f$  is the solution,  @f$ p_1 @f$  is a first distributed parameter,  @f$ p_2 @f$  is a potentially different second distributed parameter,
- *  @f$  g @f$  is the response function, @f$  f @f$  is the residual, @f$  z  @f$ is the Lagrange multiplier vector,  @f$ v_{x} @f$  is a direction vector
- *  with the same dimension as the vector  @f$ x @f$, and @f$ v_{p_1} @f$  is a direction vector with the same dimension as the vector  @f$ p_1 @f$.
+ *  where \f$\boldsymbol{x}\f$ is the solution, \f$\boldsymbol{p}_1\f$ is a first distributed parameter, \f$\boldsymbol{p}_2\f$ is a potentially different second distributed parameter,
+ * \f$g\f$ is the response function, \f$\boldsymbol{f}\f$ is the residual, \f$\boldsymbol{z}\f$ is the Lagrange multiplier vector, \f$\boldsymbol{v}_{\boldsymbol{x}}\f$ is a direction vector
+ *  with the same dimension as the vector \f$\boldsymbol{x}\f$, and \f$\boldsymbol{v}_{\boldsymbol{p}_1} \f$ is a direction vector with the same dimension as the vector \f$\boldsymbol{p}_1\f$.
+ * 
+ * This gather is used when calling: 
+ * <ul>
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_xx,
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_xp,
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_px, 
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_pp,
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_xx,
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_xp,
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_px, 
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_pp.
+ * </ul>
  */
 
 template<typename Traits>

--- a/src/evaluators/scatter/PHAL_ScatterResidual.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual.hpp
@@ -285,27 +285,39 @@ private:
  *
  * This specialization is used to scatter the residual for the computation of:
  * <ul>
- *  <li> The @f$ H_{xx}(f,z)v_{x} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}\f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{xx}(f,z)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{x} \left\langle f(x+ r\,v_{x},p_1, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} \left\langle \boldsymbol{f}(\boldsymbol{x}+ r\,\boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{xp_1}(f,z)v_{p_1} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{xp_1}(f,z)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} \left\langle f(x, p_1+ r\,v_{p_1}, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} \left\langle \boldsymbol{f}(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2x}(f,z)v_{x} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}\f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{p_2x}(f,z)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x+ r\,v_{x},p_1, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} \left\langle \boldsymbol{f}(\boldsymbol{x}+ r\,\boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2p_1}(f,z)v_{p_1} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{p_2p_1}(f,z)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x, p_1+ r\,v_{p_1}, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} \left\langle \boldsymbol{f}(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
  * </ul>
  *
- *  where  @f$ x @f$  is the solution,  @f$ p_1 @f$  is a first distributed parameter,  @f$ p_2 @f$  is a potentially different second distributed parameter,
- *  @f$  f @f$  is the residual, @f$  z  @f$ is the Lagrange multiplier vector,  @f$ v_{x} @f$  is a direction vector
- *  with the same dimension as the vector  @f$ x @f$, and @f$ v_{p_1} @f$  is a direction vector with the same dimension as the vector  @f$ p_1 @f$.
+ * where \f$\boldsymbol{x}\f$ is the solution, \f$\boldsymbol{p}_1\f$ is a first distributed parameter, \f$\boldsymbol{p}_2\f$ is a potentially different second distributed parameter,
+ * \f$\boldsymbol{f}\f$ is the residual, \f$\boldsymbol{z}\f$ is the Lagrange multiplier vector, \f$\boldsymbol{v}_{\boldsymbol{x}}\f$ is a direction vector
+ * with the same dimension as the vector \f$\boldsymbol{x}\f$, and \f$\boldsymbol{v}_{\boldsymbol{p}_1}\f$ is a direction vector with the same dimension as the vector \f$\boldsymbol{p}_1\f$.
+ * 
+ * This scatter is used when calling:
+ * <ul>
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_xx,
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_xp,
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_px, 
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_pp.
+ * </ul>
  */
 template<typename Traits>
 class ScatterResidual<PHAL::AlbanyTraits::HessianVec,Traits>
@@ -325,19 +337,27 @@ private:
  *
  * This specialization is used to scatter the residual for the computation of:
  * <ul>
- *  <li> The @f$ H_{p_2x}(f,z)v_{x} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}\f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{p_2x}(f,z)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x+ r\,v_{x},p_1, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{x}}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} \left\langle \boldsymbol{f}(\boldsymbol{x}+ r\,\boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2p_1}(f,z)v_{p_1} @f$ contribution of the Hessian-vector product of the residual:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ contribution of the Hessian-vector product of the residual:
  *       \f[
- *         H_{p_2p_1}(f,z)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{p_2} \left\langle f(x, p_1+ r\,v_{p_1}, p_2),z\right\rangle\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} \left\langle \boldsymbol{f}(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2),\boldsymbol{z}\right\rangle\right|_{r=0},
  *       \f]
  * </ul>
  *
- *  where  @f$ x @f$  is the solution,  @f$ p_1 @f$  is a first distributed parameter,  @f$ p_2 @f$  is a potentially different second distributed parameter
- *  which is extruded, @f$  f @f$  is the residual, @f$  z  @f$ is the Lagrange multiplier vector,  @f$ v_{x} @f$  is a direction vector
- *  with the same dimension as the vector  @f$ x @f$, and @f$ v_{p_1} @f$  is a direction vector with the same dimension as the vector  @f$ p_1 @f$.
+ *  where  \f$\boldsymbol{x}\f$  is the solution, \f$\boldsymbol{p}_1\f$  is a first distributed parameter, \f$\boldsymbol{p}_2\f$  is a potentially different second distributed parameter
+ *  which is extruded, \f$\boldsymbol{f}\f$  is the residual, \f$\boldsymbol{z}\f$ is the Lagrange multiplier vector, \f$\boldsymbol{v}_{\boldsymbol{x}}\f$ is a direction vector
+ *  with the same dimension as the vector \f$\boldsymbol{x}\f$, and \f$\boldsymbol{v}_{\boldsymbol{p}_1}\f$ is a direction vector with the same dimension as the vector \f$\boldsymbol{p}_1\f$.
+ * 
+ * This scatter is used when calling:
+ * <ul>
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_px, 
+ *   <li> Albany::Application::evaluateResidual_HessVecProd_pp.
+ * </ul>
  */
 template<typename Traits>
 class ScatterResidualWithExtrudedParams<PHAL::AlbanyTraits::HessianVec,Traits>

--- a/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse.hpp
+++ b/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse.hpp
@@ -240,27 +240,39 @@ private:
  *
  * This specialization is used to scatter the solution for the computation of:
  * <ul>
- *  <li> The @f$ H_{xx}(g)v_{x} @f$ contribution of the Hessian-vector product of the response function:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}} \f$ contribution of the Hessian-vector product of the response function:
  *       \f[
- *         H_{xx}(g)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{x} g(x+ r\,v_{x},p_1, p_2)\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} g(\boldsymbol{x}+ r\,\boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1, \boldsymbol{p}_2)\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{xp_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}\f$ contribution of the Hessian-vector product of the response function:
  *       \f[
- *         H_{xp_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{x} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{x}\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{x}} g(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2)\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2x}(g)v_{x} @f$ contribution of the Hessian-vector product of the response function:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}} \f$ contribution of the Hessian-vector product of the response function:
  *       \f[
- *         H_{p_2x}(g)v_{x}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x+ r\,v_{x},p_1, p_2)\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{x}}(g)\boldsymbol{v}_{\boldsymbol{x}}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} g(\boldsymbol{x}+ r\,\boldsymbol{v}_{\boldsymbol{x}},\boldsymbol{p}_1,\boldsymbol{p}_2)\right|_{r=0},
  *       \f]
- *  <li> The @f$ H_{p_2p_1}(g)v_{p_1} @f$ contribution of the Hessian-vector product of the response function:
+ *  <li> The \f$\boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1} \f$ contribution of the Hessian-vector product of the response function:
  *       \f[
- *         H_{p_2p_1}(g)v_{p_1}=\left.\frac{\partial}{\partial r} \nabla_{p_2} g(x, p_1+ r\,v_{p_1}, p_2)\right|_{r=0},
+ *         \boldsymbol{H}_{\boldsymbol{p}_2\boldsymbol{p}_1}(g)\boldsymbol{v}_{\boldsymbol{p}_1}=
+ *         \left.\frac{\partial}{\partial r} \nabla_{\boldsymbol{p}_2} g(\boldsymbol{x}, \boldsymbol{p}_1+ r\,\boldsymbol{v}_{\boldsymbol{p}_1}, \boldsymbol{p}_2)\right|_{r=0},
  *       \f]
  * </ul>
  *
- *  where  @f$ x @f$  is the solution,  @f$ p_1 @f$  is a first distributed parameter,  @f$ p_2 @f$  is a potentially different second distributed parameter,
- *  @f$  g @f$  is the response function,  @f$ v_{x} @f$  is a direction vector
- *  with the same dimension as the vector  @f$ x @f$, and @f$ v_{p_1} @f$  is a direction vector with the same dimension as the vector  @f$ p_1 @f$.
+ *  where  \f$\boldsymbol{x}\f$  is the solution, \f$\boldsymbol{p}_1\f$  is a first distributed parameter, \f$\boldsymbol{p}_2\f$ is a potentially different second distributed parameter,
+ *  \f$g\f$  is the response function, \f$\boldsymbol{v}_{\boldsymbol{x}}\f$  is a direction vector
+ *  with the same dimension as the vector \f$\boldsymbol{x}\f$, and \f$\boldsymbol{v}_{\boldsymbol{p}_1}\f$  is a direction vector with the same dimension as the vector \f$\boldsymbol{p}_1\f$.
+ * 
+ * This scatter is used when calling:
+ * <ul>
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_xx,
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_xp,
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_px, 
+ *   <li> Albany::Application::evaluateResponseDistParamHessVecProd_pp.
+ * </ul>
  */
 
 template<typename Traits>


### PR DESCRIPTION
This PR impacts the documentation of the Hessian-vector product computations and adds some doxygen option to support AMSmath symbols in Latex and to define custom css classes.

I verified that the Albany tests passed (they are not impacted by this PR) and verified that the documentation can be built on my computer.

@mperego could you review this PR and let me know if this is the level of detail that you wanted?

By the way, it seems that the [online doxygen](http://snlcomputation.github.io/Albany/doxygen/html/index.html) is not up-to-date; it seems to be 6 years old. How can it be updated?