### PR TITLE
Add cmake options to choose the AD type for Hessian-vector product computations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -657,6 +657,26 @@ ELSE()
   Options: SFad, SLFad, DFad")
 ENDIF()
 
+# Set FAD data type for Hessian
+SET(ENABLE_HES_VEC_FAD_TYPE "DFad" CACHE STRING "Sacado forward mode automatic differentiation data type for Hessian-vector product")
+IF(ENABLE_HES_VEC_FAD_TYPE STREQUAL "SFad")
+  SET(ALBANY_HES_VEC_FAD_TYPE_SFAD TRUE)
+  SET(ALBANY_HES_VEC_SFAD_SIZE 32 CACHE INT "Number of derivative components chosen at compile-time for Hessian-vector AD")
+  MESSAGE("-- HES_VEC_FAD_TYPE is SFad, ALBANY_HES_VEC_SFAD_SIZE=${ALBANY_HES_VEC_SFAD_SIZE}")
+  MESSAGE("---> WARNING: problems with elemental DOFs > ${ALBANY_HES_VEC_SFAD_SIZE} will fail")
+ELSEIF(ENABLE_HES_VEC_FAD_TYPE STREQUAL "SLFad")
+  SET(ALBANY_HES_VEC_FAD_TYPE_SLFAD TRUE)
+  SET(ALBANY_HES_VEC_SLFAD_SIZE 32 CACHE INT "Maximum number of derivative components chosen at compile-time for Hessian-vector AD")
+  MESSAGE("-- HES_VEC_FAD_TYPE is SLFad, ALBANY_HES_VEC_SLFAD_SIZE=${ALBANY_HES_VEC_SLFAD_SIZE}")
+  MESSAGE("---> WARNING: problems with elemental DOFs > ${ALBANY_HES_VEC_SLFAD_SIZE} will fail")
+ELSEIF(ENABLE_HES_VEC_FAD_TYPE STREQUAL "DFad")
+  MESSAGE("-- HES_VEC_FAD_TYPE is DFad (default)")
+ELSE()
+  MESSAGE(FATAL_ERROR
+  "\nError: ENABLE_HES_VEC_FAD_TYPE = ${ENABLE_HES_VEC_FAD_TYPE} is not recognized!
+  Options: SFad, SLFad, DFad")
+ENDIF()
+
 # Check if FAD data type is the same
 IF(ENABLE_FAD_TYPE STREQUAL ENABLE_TAN_FAD_TYPE)
   IF(ALBANY_FAD_TYPE_SFAD AND NOT ALBANY_SFAD_SIZE EQUAL ALBANY_TAN_SFAD_SIZE)

--- a/src/Albany_SacadoTypes.hpp
+++ b/src/Albany_SacadoTypes.hpp
@@ -59,17 +59,6 @@ typedef Sacado::Fad::SLFad<HessianVecInnerFad, ALBANY_HES_VEC_SLFAD_SIZE> Hessia
 typedef Sacado::Fad::DFad<HessianVecInnerFad> HessianVecFad;
 #endif
 
-#if defined(ALBANY_HES_FAD_TYPE_SFAD)
-typedef Sacado::Fad::SFad<RealType, ALBANY_HES_SFAD_SIZE> HessianInnerFad;
-typedef Sacado::Fad::SFad<HessianInnerFad, ALBANY_HES_SFAD_SIZE> HessianFad;
-#elif defined(ALBANY_HES_FAD_TYPE_SLFAD)
-typedef Sacado::Fad::SLFad<RealType, ALBANY_HES_SLFAD_SIZE> HessianInnerFad;
-typedef Sacado::Fad::SLFad<HessianInnerFad, ALBANY_HES_SLFAD_SIZE> HessianFad;
-#else
-typedef Sacado::Fad::DFad<RealType> HessianInnerFad;
-typedef Sacado::Fad::DFad<HessianInnerFad> HessianFad;
-#endif
-
 struct SPL_Traits {
   template <class T> struct apply {
     typedef typename T::ScalarT type;

--- a/src/Albany_config.h.in
+++ b/src/Albany_config.h.in
@@ -85,6 +85,10 @@
 #cmakedefine ALBANY_TAN_SFAD_SIZE ${ALBANY_TAN_SFAD_SIZE}
 #cmakedefine ALBANY_TAN_FAD_TYPE_SLFAD
 #cmakedefine ALBANY_TAN_SLFAD_SIZE ${ALBANY_TAN_SLFAD_SIZE}
+#cmakedefine ALBANY_HES_VEC_FAD_TYPE_SFAD
+#cmakedefine ALBANY_HES_VEC_SFAD_SIZE ${ALBANY_HES_VEC_SFAD_SIZE}
+#cmakedefine ALBANY_HES_VEC_FAD_TYPE_SLFAD
+#cmakedefine ALBANY_HES_VEC_SLFAD_SIZE ${ALBANY_HES_VEC_SLFAD_SIZE}
 #cmakedefine ALBANY_FADTYPE_NOTEQUAL_TANFADTYPE
 
 // ================ Package-specific macros ================= //

--- a/src/PHAL_AlbanyTraits.hpp
+++ b/src/PHAL_AlbanyTraits.hpp
@@ -67,14 +67,6 @@ namespace PHAL {
     struct Jacobian : EvaluationType<FadType,  RealType, RealType> {};
 #endif
 
-#if defined(ALBANY_MESH_DEPENDS_ON_SOLUTION)
-    struct Hessian : EvaluationType<HessianFad,  HessianFad, HessianFad> {};
-#elif defined(ALBANY_PARAMETERS_DEPEND_ON_SOLUTION)
-    struct Hessian : EvaluationType<HessianFad,  RealType, HessianFad> {};
-#else
-    struct Hessian : EvaluationType<HessianFad,  RealType, RealType> {};
-#endif
-
 #if defined(ALBANY_MESH_DEPENDS_ON_PARAMETERS) || defined(ALBANY_MESH_DEPENDS_ON_SOLUTION)
     struct Tangent  : EvaluationType<TanFadType,TanFadType, TanFadType> {};
 #else


### PR DESCRIPTION
This PR is intended to add the plumbing work to configure the AD type used during the Hessian-vector product computations.

Moreover, this PR removes the definition of the Hessian types (i.e. the types which were intended to be used for the explicit computation of the matrix); those types were never used and will not be used as another strategy will be used to reconstruct the Hessian matrix.

This PR has been tested both with SFad and DFad and passed in both cases.