### PR TITLE
WIP: Create H_pp to define a Hessian scaled dot product used by ROL

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -2386,7 +2386,10 @@ Application::evaluateResponseDistParamHessian_pp(
   Teuchos::ParameterList coloring_params;
   std::string matrixType = "Hessian";
   coloring_params.set("matrixType", matrixType);
-  coloring_params.set("symmetric", true);
+
+  // Even if the Hessian is symmetric, the distributed crs matrix
+  // is not symmetrical as the row and column map are not identical.
+  coloring_params.set("symmetric", false);
 
   // Get the crs Hessian:
   RCP<Tpetra_CrsMatrix> Ht = Albany::getTpetraMatrix(H);

--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -2385,7 +2385,8 @@ Application::evaluateResponseDistParamHessian_pp(
 {
   Teuchos::ParameterList coloring_params;
   std::string matrixType = "Hessian";
-  coloring_params.set("MatrixType", matrixType);
+  coloring_params.set("matrixType", matrixType);
+  coloring_params.set("symmetric", true);
 
   // Get the crs Hessian:
   RCP<Tpetra_CrsMatrix> Ht = Albany::getTpetraMatrix(H);

--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -31,6 +31,9 @@
 #include "PHAL_Utilities.hpp"
 #include "Albany_KokkosUtils.hpp"
 
+#include "Albany_TpetraThyraUtils.hpp"
+#include "Zoltan2_TpetraCrsColorer.hpp"
+
 //#define WRITE_TO_MATRIX_MARKET
 //#define DEBUG_OUTPUT
 
@@ -2366,6 +2369,67 @@ Application::evaluateResponseDistParamHessVecProd_pp(
     std::stringstream hessianvectorproduct_name;
     hessianvectorproduct_name << dist_param_name << "_" << dist_param_direction_name << "_Hv_g_pp";
   }
+}
+
+void
+Application::evaluateResponseDistParamHessian_pp(
+    int                                     response_index,
+    int                                     parameter_index,
+    const double                            current_time,
+    const Teuchos::RCP<const Thyra_Vector>& x,
+    const Teuchos::RCP<const Thyra_Vector>& xdot,
+    const Teuchos::RCP<const Thyra_Vector>& xdotdot,
+    const Teuchos::Array<ParamVec>&         param_array,
+    const std::string&                      dist_param_name,
+    const Teuchos::RCP<Thyra_LinearOp>&     H)
+{
+  Teuchos::ParameterList coloring_params;
+  std::string matrixType = "Hessian";
+  coloring_params.set("MatrixType", matrixType);
+
+  // Get the crs Hessian:
+  RCP<Tpetra_CrsMatrix> Ht = Albany::getTpetraMatrix(H);
+
+  // Create a colorer
+  Zoltan2::TpetraCrsColorer<Tpetra_CrsMatrix> colorer(Ht);
+
+  colorer.computeColoring(coloring_params);
+
+  // Compute seed matrix V -- this matrix is a dense
+  // matrix of 0/1 indicating the compression via coloring
+
+  const int numColors = colorer.getNumColors();
+
+  // Compute the seed matrix
+  RCP<Tpetra_MultiVector> V = rcp(new Tpetra_MultiVector(Ht->getDomainMap(), numColors));
+  colorer.computeSeedMatrix(*V);
+
+  // Apply the Hessian to all the directions
+  RCP<Tpetra_MultiVector> HV = rcp(new Tpetra_MultiVector(Ht->getDomainMap(), numColors));
+
+  for (int i = 0; i < numColors; ++i)
+  {
+    RCP<const Thyra_MultiVector> v_i = Albany::createConstThyraMultiVector(V->getVector(i));
+    RCP<Thyra_MultiVector> Hv_i = Albany::createThyraMultiVector(HV->getVectorNonConst(i));
+    evaluateResponseDistParamHessVecProd_pp(
+      response_index,
+      current_time,
+      v_i,
+      x,
+      xdot,
+      xdotdot,
+      param_array,
+      dist_param_name,
+      dist_param_name,
+      Hv_i);
+  }
+
+  // Reconstruct the Hessian matrix based on the Hessian-vector products
+  colorer.reconstructMatrix(*HV, *Ht);
+
+#ifdef WRITE_TO_MATRIX_MARKET
+  writeMatrixMarket(Ht.getConst(), "H", parameter_index);
+#endif
 }
 
 void

--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -2426,6 +2426,7 @@ Application::evaluateResponseDistParamHessian_pp(
 
   // Reconstruct the Hessian matrix based on the Hessian-vector products
   colorer.reconstructMatrix(*HV, *Ht);
+  Ht->fillComplete();
 
 #ifdef WRITE_TO_MATRIX_MARKET
   writeMatrixMarket(Ht.getConst(), "H", parameter_index);

--- a/src/Albany_Application.hpp
+++ b/src/Albany_Application.hpp
@@ -645,6 +645,21 @@ public:
       const Teuchos::RCP<Thyra_MultiVector>&  Hv_g_pp);
 
   /**
+   * \brief evaluateResponseDistParamHessian_pp function
+   */
+  void
+  evaluateResponseDistParamHessian_pp(
+      int                                     response_index,
+      int                                     parameter_index,
+      const double                            current_time,
+      const Teuchos::RCP<const Thyra_Vector>& x,
+      const Teuchos::RCP<const Thyra_Vector>& xdot,
+      const Teuchos::RCP<const Thyra_Vector>& xdotdot,
+      const Teuchos::Array<ParamVec>&         param_array,
+      const std::string&                      dist_param_name,
+      const Teuchos::RCP<Thyra_LinearOp>&     H);
+
+  /**
    * \brief evaluateResidual_HessVecProd_xx function
    * 
    * This function is used to compute contributions of the application of the Hessian \f$\boldsymbol{H}(\left\langle \boldsymbol{f},\boldsymbol{z}\right\rangle)\f$ of the inner product of the residual vector \f$\boldsymbol{f}\f$

--- a/src/Albany_Application.hpp
+++ b/src/Albany_Application.hpp
@@ -646,6 +646,27 @@ public:
 
   /**
    * \brief evaluateResponseDistParamHessian_pp function
+   *
+   * This function is used to compute the Hessian \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_i}(g)\f$ of the <tt>response[response_index]</tt> 
+   * (i.e. the response_index-th response) where \f$g\f$ is the response and \f$\boldsymbol{p}_i\f$ is a distributed parameter.
+   *
+   * \param response_index [in] Response index of the response which the Hessian is computed.
+   *
+   * \param parameter_index [in] Parameter index of the distributed parameter.
+   *
+   * \param current_time [in] Current time at which the Hessian is computed for transient simulations.
+   *
+   * \param x [in] Solution vector for the current time step: \f$\boldsymbol{x}\f$.
+   *
+   * \param xdot [in] Velocity vector for the current time step.
+   *
+   * \param xdotdot [in] Acceleration vector for the current time step.
+   *
+   * \param param_array [in] Array of the parameters vectors.
+   *
+   * \param dist_param_name [in] Name of the distributed parameter.
+   *
+   * \param H [out] the output of the computation: \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_i}(g)\f$.
    */
   void
   evaluateResponseDistParamHessian_pp(

--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -464,10 +464,10 @@ ModelEvaluator::create_hess_g_pp( int j, int l1, int l2 ) const
     distParamLib->get(dist_param_names[l1 - num_param_vecs])->get_cas_manager()->getOverlappedVectorSpace());
   Teuchos::RCP<const Tpetra_Map> p_owned_map = Albany::getTpetraMap(
     distParamLib->get(dist_param_names[l1 - num_param_vecs])->get_cas_manager()->getOwnedVectorSpace());
-  const Albany::IDArray&  wsElDofs =
-    distParamLib->get(dist_param_names[l1 - num_param_vecs])->workset_elem_dofs()[0];
+  std::vector<IDArray> vElDofs =
+    distParamLib->get(dist_param_names[l1 - num_param_vecs])->workset_elem_dofs();
 
-  Teuchos::RCP<Tpetra_CrsGraph> Hgraph = Albany::createHessianCrsGraph(p_owned_map, p_overlapped_map, wsElDofs);
+  Teuchos::RCP<Tpetra_CrsGraph> Hgraph = Albany::createHessianCrsGraph(p_owned_map, p_overlapped_map, vElDofs);
   Teuchos::RCP<Tpetra_CrsMatrix> Ht = Teuchos::rcp(new Tpetra_CrsMatrix(Hgraph));
 
   return Albany::createThyraLinearOp(Ht);

--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -621,8 +621,14 @@ Thyra_OutArgs ModelEvaluator::createOutArgsImpl() const
     const bool aDHessVec = parameterParams.isParameter("Hessian-vector products use AD") ?
         parameterParams.get<bool>("Hessian-vector products use AD") : true;
 
-    const bool reconstructHpp = parameterParams.isParameter("Reconstruct H_pp") ?
+    bool reconstructHpp = parameterParams.isParameter("Reconstruct H_pp") ?
         parameterParams.get<bool>("Reconstruct H_pp") : false;
+    
+    if (reconstructHpp == false) {
+      auto& analysisParams = appParams->sublist("Piro").sublist("Analysis");
+      if(analysisParams.isSublist("ROL"))
+        reconstructHpp = analysisParams.sublist("ROL").get("Hessian Dot Product", false);
+    }
 
     bool hess_vec_prod_g_xx_support = aDHessVec;
     bool hess_vec_prod_g_xp_support = aDHessVec;

--- a/src/Albany_ModelEvaluator.hpp
+++ b/src/Albany_ModelEvaluator.hpp
@@ -65,6 +65,8 @@ public:
 
   Teuchos::RCP<const Thyra_LOWS_Factory>  get_W_factory() const;
 
+  Teuchos::RCP<Thyra_LinearOp>  create_hess_g_pp( int j, int l1, int l2 ) const;
+
   //! Create InArgs
   Thyra_InArgs createInArgs() const;
 

--- a/src/Albany_ModelEvaluator.hpp
+++ b/src/Albany_ModelEvaluator.hpp
@@ -65,6 +65,7 @@ public:
 
   Teuchos::RCP<const Thyra_LOWS_Factory>  get_W_factory() const;
 
+  //! Create Hessian operator
   Teuchos::RCP<Thyra_LinearOp>  create_hess_g_pp( int j, int l1, int l2 ) const;
 
   //! Create InArgs

--- a/src/Albany_Utils.cpp
+++ b/src/Albany_Utils.cpp
@@ -479,6 +479,31 @@ writeMatrixMarket<const Tpetra_CrsMatrix>(
   Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile(filename, A);
 }
 
+//
+//
+//
+template <>
+void
+writeMatrixMarket<const Tpetra_CrsGraph>(
+    const Teuchos::RCP<const Tpetra_CrsGraph>& A,
+    const std::string&                          prefix,
+    int const                                   counter)
+{
+  if (A.is_null()) { return; }
+
+  std::ostringstream oss;
+
+  oss << prefix;
+  if (counter >= 0) {
+    oss << '-' << std::setfill('0') << std::setw(3) << counter;
+  }
+  oss << ".mm";
+
+  const std::string& filename = oss.str();
+
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseGraphFile(filename, A);
+}
+
 CmdLineArgs::CmdLineArgs(
     const std::string& default_yaml_filename,
     const std::string& default_yaml_filename2,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,6 +141,7 @@ list (APPEND SOURCES
   utility/Albany_CommUtils.cpp
   utility/Albany_Gather.cpp
   utility/Albany_GlobalLocalIndexer.cpp
+  utility/Albany_Hessian.cpp
   utility/Albany_ThyraCrsMatrixFactory.cpp
   utility/Albany_ThyraBlockedCrsMatrixFactory.cpp
   utility/Albany_ThyraUtils.cpp
@@ -163,6 +164,7 @@ list (APPEND HEADERS
   utility/Albany_Gather.hpp
   utility/Albany_GlobalLocalIndexer.hpp
   utility/Albany_GlobalLocalIndexerTpetra.hpp
+  utility/Albany_Hessian.hpp
   utility/Albany_ThyraCrsMatrixFactory.hpp
   utility/Albany_ThyraBlockedCrsMatrixFactory.hpp
   utility/Albany_ThyraUtils.hpp

--- a/src/LandIce/interface_with_mpas/Albany_MpasSTKMeshStruct.cpp
+++ b/src/LandIce/interface_with_mpas/Albany_MpasSTKMeshStruct.cpp
@@ -541,7 +541,7 @@ MpasSTKMeshStruct::setBdFacesOnPrism (const std::vector<std::vector<std::vector<
   facePos.assign(numTriaFaces,-1);
 
 
-  for (int iTetra (0), k (0); (iTetra < 3 && k < numTriaFaces); iTetra++)
+  for (unsigned int iTetra (0), k (0); (iTetra < 3 && k < numTriaFaces); iTetra++)
   {
     bool found;
     for (int jFaceLocalId = 0; jFaceLocalId < 4; jFaceLocalId++ )

--- a/src/utility/Albany_Hessian.cpp
+++ b/src/utility/Albany_Hessian.cpp
@@ -47,7 +47,7 @@ Teuchos::RCP<Tpetra_CrsGraph> Albany::createHessianCrsGraph(
     Kokkos::parallel_for(
         num_elem,
         KOKKOS_LAMBDA(const Tpetra_LO ielem) {
-            for (auto i = 0; i < NN; ++i)
+            for (std::size_t i = 0; i < NN; ++i)
             {
                 const Tpetra_LO lcl_overlapped_node1 = wsElDofs((int)ielem, (int)i, 0);
                 if (lcl_overlapped_node1 < 0)
@@ -55,7 +55,7 @@ Teuchos::RCP<Tpetra_CrsGraph> Albany::createHessianCrsGraph(
 
                 const Tpetra_GO global_overlapped_node1 = p_overlapped_map->getGlobalElement(lcl_overlapped_node1);
 
-                for (auto j = i; j < NN; ++j)
+                for (std::size_t j = i; j < NN; ++j)
                 {
                     const Tpetra_LO lcl_overlapped_node2 = wsElDofs((int)ielem, (int)j, 0);
                     if (lcl_overlapped_node2 < 0)

--- a/src/utility/Albany_Hessian.cpp
+++ b/src/utility/Albany_Hessian.cpp
@@ -1,0 +1,159 @@
+
+#include <Teuchos_RCP.hpp>
+#include "Albany_TpetraTypes.hpp"
+#include "Albany_StateInfoStruct.hpp"
+#include "Albany_Hessian.hpp"
+
+#include <Kokkos_UnorderedMap.hpp>
+#include <Kokkos_Sort.hpp>
+
+int min(int a, int b)
+{
+    return (a <= b) ? a : b;
+}
+
+int max(int a, int b)
+{
+    return (a >= b) ? a : b;
+}
+
+Teuchos::RCP<Tpetra_CrsGraph> Albany::createHessianCrsGraph(
+    Teuchos::RCP<const Tpetra_Map> p_owned_map,
+    Teuchos::RCP<const Tpetra_Map> p_overlapped_map,
+    const Albany::IDArray &wsElDofs)
+{
+    /*
+        Implemented using:
+
+        Hoemmen, M. F., & Edwards, H. C. (2014). Threaded construction and
+        fill of Tpetra sparse linear system using Kokkos (No. SAND2014-19125C).
+        Sandia National Lab.(SNL-NM), Albuquerque, NM (United States).        
+    */
+    using std::pair;
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+
+    const std::size_t num_elem = wsElDofs.dimension(0);
+    const std::size_t NN = wsElDofs.dimension(1);
+
+    const int num_rows = p_owned_map->getNodeNumElements();
+
+    Kokkos::View<size_t *> rowCounts("row counts", num_rows);
+
+    const int max_connections = 30;
+    Kokkos::UnorderedMap<pair<Tpetra_GO, Tpetra_GO>, bool> nodenode(num_rows * max_connections);
+
+    // Generate elements’ unique node-node pairs
+    Kokkos::parallel_for(
+        num_elem,
+        KOKKOS_LAMBDA(const Tpetra_LO ielem) {
+            for (auto i = 0; i < NN; ++i)
+            {
+                const Tpetra_LO lcl_overlapped_node1 = wsElDofs((int)ielem, (int)i, 0);
+                if (lcl_overlapped_node1 < 0)
+                    continue;
+
+                const Tpetra_GO global_overlapped_node1 = p_overlapped_map->getGlobalElement(lcl_overlapped_node1);
+
+                for (auto j = i; j < NN; ++j)
+                {
+                    const Tpetra_LO lcl_overlapped_node2 = wsElDofs((int)ielem, (int)j, 0);
+                    if (lcl_overlapped_node2 < 0)
+                        continue;
+
+                    const Tpetra_GO global_overlapped_node2 = p_overlapped_map->getGlobalElement(lcl_overlapped_node2);
+
+                    const Tpetra_GO globalNode1 = min(global_overlapped_node1, global_overlapped_node2);
+                    const Tpetra_GO globalNode2 = max(global_overlapped_node1, global_overlapped_node2);
+
+                    const pair<Tpetra_GO, Tpetra_GO> key(globalNode1, globalNode2);
+                    auto result = nodenode.insert(key);
+
+                    if (result.success())
+                    {
+                        const bool isDiffNodes = (globalNode1 != globalNode2);
+                        const bool isLocalNode1 = p_owned_map->isNodeGlobalElement(globalNode1);
+                        const bool isLocalNode2 = p_owned_map->isNodeGlobalElement(globalNode2);
+
+                        const Tpetra_LO lclNode1 = p_owned_map->getLocalElement(globalNode1);
+                        const Tpetra_LO lclNode2 = p_owned_map->getLocalElement(globalNode2);
+
+                        if (isLocalNode1)
+                            Kokkos::atomic_fetch_add(&rowCounts(lclNode1), 1);
+                        if (isDiffNodes && isLocalNode2)
+                            Kokkos::atomic_fetch_add(&rowCounts(lclNode2), 1);
+                    }
+                }
+            }
+        });
+
+    Kokkos::View<size_t *> rowOffsets("row offsets", num_rows + 1);
+
+    // Parallel prefix-sum row counts and allocate column index array
+    Kokkos::parallel_scan(
+        num_rows,
+        KOKKOS_LAMBDA(int irow, int &update, bool final) {
+            // parallel scan is a multi-pass parallel pattern
+            // In the ‘final’ pass ‘update’ has the prefix value
+            if (final)
+                rowOffsets(irow) = update;
+            update += rowCounts(irow);
+            if (final && num_rows == irow + 1)
+                rowOffsets(irow + 1) = update; // total non-zeros
+        });
+
+    Kokkos::deep_copy(rowCounts, static_cast<size_t>(0));
+    Kokkos::View<Tpetra_LO *> colIndices("column indices", rowOffsets(num_rows));
+
+    // Fill column index array with rows in non-deterministic order
+    Kokkos::parallel_for(
+        nodenode.capacity(),
+        KOKKOS_LAMBDA(int ientry) {
+            if (nodenode.valid_at(ientry))
+            {
+                const pair<Tpetra_GO, Tpetra_GO> key = nodenode.key_at(ientry);
+                const Tpetra_GO globalNode1 = key.first;
+                const Tpetra_GO globalNode2 = key.second;
+
+                const bool isDiffNodes = (globalNode1 != globalNode2);
+                const bool isLocalNode1 = p_owned_map->isNodeGlobalElement(globalNode1);
+                const bool isLocalNode2 = p_owned_map->isNodeGlobalElement(globalNode2);
+
+                const Tpetra_LO lclNode1 = p_owned_map->getLocalElement(globalNode1);
+                const Tpetra_LO lclNode2 = p_owned_map->getLocalElement(globalNode2);
+
+                const Tpetra_LO lclNodeWO1 = p_overlapped_map->getLocalElement(globalNode1);
+                const Tpetra_LO lclNodeWO2 = p_overlapped_map->getLocalElement(globalNode2);
+
+                if (isLocalNode1)
+                {
+                    const Tpetra_LO lclRow = lclNode1;
+                    const Tpetra_LO lclCol = lclNodeWO2;
+
+                    const size_t count = Kokkos::atomic_fetch_add(&rowCounts(lclRow), 1);
+                    colIndices(rowOffsets(lclRow) + count) = lclCol;
+                }
+                if (isDiffNodes && isLocalNode2)
+                {
+                    const Tpetra_LO lclRow = lclNode2;
+                    const Tpetra_LO lclCol = lclNodeWO1;
+
+                    const size_t count = Kokkos::atomic_fetch_add(&rowCounts(lclRow), 1);
+                    colIndices(rowOffsets(lclRow) + count) = lclCol;
+                }
+            }
+        });
+
+    // Sort eacch row of column index array
+    Kokkos::parallel_for(
+        num_rows,
+        KOKKOS_LAMBDA(int lclRow) {
+            auto currentColIndices = subview(colIndices, Kokkos::make_pair(rowOffsets(lclRow), rowOffsets(lclRow + 1)));
+            Tpetra_LO *const lclColIndsRaw = currentColIndices.data();
+            std::sort(lclColIndsRaw, lclColIndsRaw + rowOffsets(lclRow + 1) - rowOffsets(lclRow));
+        });
+
+    RCP<Tpetra_CrsGraph> Hgraph = rcp(new Tpetra_CrsGraph(p_owned_map, p_overlapped_map, rowOffsets, colIndices));
+    Hgraph->fillComplete(p_owned_map, p_owned_map);
+    return Hgraph;
+}

--- a/src/utility/Albany_Hessian.hpp
+++ b/src/utility/Albany_Hessian.hpp
@@ -3,6 +3,18 @@
 
 namespace Albany
 {
+    /**
+     * \brief createHessianCrsGraph function
+     *
+     * This function computes the Tpetra::CrsGraph associated to
+     * the Hessian w.r.t a distributed parameter.
+     *
+     * \param p_owned_map [in] Tpetra::Map which specifies the owned entries of the current distributed parameter.
+     *
+     * \param p_overlapped_map [in] Tpetra::Map which specifies the overlapped entries of the current distributed parameter.
+     *
+     * \param wsElDofs [in] Vector of IDArray associated to the mesh used.
+     */
     Teuchos::RCP<Tpetra_CrsGraph> createHessianCrsGraph(
         Teuchos::RCP<const Tpetra_Map> p_owned_map,
         Teuchos::RCP<const Tpetra_Map> p_overlapped_map,

--- a/src/utility/Albany_Hessian.hpp
+++ b/src/utility/Albany_Hessian.hpp
@@ -1,0 +1,13 @@
+#ifndef ALBANY_HESSIAN_HPP
+#define ALBANY_HESSIAN_HPP
+
+namespace Albany
+{
+    Teuchos::RCP<Tpetra_CrsGraph> createHessianCrsGraph(
+        Teuchos::RCP<const Tpetra_Map> p_owned_map,
+        Teuchos::RCP<const Tpetra_Map> p_overlapped_map,
+        const Albany::IDArray &wsElDofs);
+
+} // namespace Albany
+
+#endif // ALBANY_HESSIAN_HPP

--- a/src/utility/Albany_Hessian.hpp
+++ b/src/utility/Albany_Hessian.hpp
@@ -6,7 +6,7 @@ namespace Albany
     Teuchos::RCP<Tpetra_CrsGraph> createHessianCrsGraph(
         Teuchos::RCP<const Tpetra_Map> p_owned_map,
         Teuchos::RCP<const Tpetra_Map> p_overlapped_map,
-        const Albany::IDArray &wsElDofs);
+        const std::vector<IDArray> wsElDofs);
 
 } // namespace Albany
 

--- a/tests/small/LandIce/Enthalpy/input_enthalpy_humboldt.yaml
+++ b/tests/small/LandIce/Enthalpy/input_enthalpy_humboldt.yaml
@@ -196,6 +196,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: true
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/CMakeLists.txt
+++ b/tests/small/LandIce/FO_GIS/CMakeLists.txt
@@ -278,6 +278,12 @@ if (ALBANY_IFPACK2)
                    ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_analysis_beta_memT.yaml)
     add_test(${testName} ${AlbanyAnalysis.exe} input_fo_gis_analysis_beta_memT.yaml)
     set_tests_properties(${testName} PROPERTIES LABELS "LandIce;Tpetra;Analysis;ROL")
+
+    set (testName ${testNameRoot}_Analysis_BasalFriction_Hessian)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_analysis_beta_hessianT.yaml
+                   ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_analysis_beta_hessianT.yaml)
+    add_test(${testName} ${AlbanyAnalysis.exe} input_fo_gis_analysis_beta_hessianT.yaml)
+    set_tests_properties(${testName} PROPERTIES LABELS "LandIce;Tpetra;Analysis;ROL")
   endif()
 endif()
 

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
@@ -166,6 +166,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: false
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
@@ -13,21 +13,14 @@ ANONYMOUS:
     Surface Side Name: upperside
     Equation Set:
       Type: LandIce
-      Num Equations: 3
+      Num Equations: 2
     Response Functions:
       Number Of Responses: 1
       Response 0:
-        Type: Sum Of Responses
-        Number Of Responses: 2
-        Response 1:
-          Scaling Coefficient: 5.88239999999999978e-07
-          Asinh Scaling: 1.00000000000000000e+01
-          Name: Surface Velocity Mismatch
-          Regularization Coefficient: 0.00000000000000000e+00
-        Response 0:
-          Scaling Coefficient: 5.88239999999999978e-05
-          Name: Boundary Squared L2 Norm
-          Field Name: L2 Projected Boundary Laplacian
+        Scaling Coefficient: 5.88239999999999978e-07
+        Asinh Scaling: 1.00000000000000000e+01
+        Name: Surface Velocity Mismatch
+        Regularization Coefficient: 1.00000000000000000e+01
     Dirichlet BCs: {}
     LandIce BCs:
       Number: 2
@@ -166,9 +159,30 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
-        Hessian Dot Product: false
         Use NOX Solver: false
 
+        Hessian Dot Product: true
+        Remove Mean Of The Right-hand Side: true
+        Hessian Diagonal Inverse:
+          Block solver type 0: Belos
+          Block 0:
+            Linear Solver Type: Belos
+            Linear Solver Types:
+              Belos:
+                Solver Type: Pseudo Block GMRES
+                Solver Types:
+                  Pseudo Block GMRES:
+                    Maximum Iterations: 1000
+                    Convergence Tolerance: 1e-4
+                    Num Blocks: 1000
+                    Output Frequency: 200
+                    Verbosity: 33
+                VerboseObject:
+                  Verbosity Level: medium
+            Preconditioner Type: Ifpack2
+            Preconditioner Types:
+              Ifpack2:
+                Prec Type: ILUT
         ROL Options:
           General:
             Variable Objective Function: false

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
@@ -166,7 +166,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
-        Hessian Dot Product: true
+        Hessian Dot Product: false
         Use NOX Solver: false
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
@@ -13,21 +13,14 @@ ANONYMOUS:
     Surface Side Name: upperside
     Equation Set:
       Type: LandIce
-      Num Equations: 3
+      Num Equations: 2
     Response Functions:
       Number Of Responses: 1
       Response 0:
-        Type: Sum Of Responses
-        Number Of Responses: 2
-        Response 1:
-          Scaling Coefficient: 5.88239999999999978e-07
-          Asinh Scaling: 1.00000000000000000e+01
-          Name: Surface Velocity Mismatch
-          Regularization Coefficient: 0.00000000000000000e+00
-        Response 0:
-          Scaling Coefficient: 5.88239999999999978e-05
-          Name: Boundary Squared L2 Norm
-          Field Name: L2 Projected Boundary Laplacian
+        Scaling Coefficient: 5.88239999999999978e-07
+        Asinh Scaling: 1.00000000000000000e+01
+        Name: Surface Velocity Mismatch
+        Regularization Coefficient: 1.00000000000000000e+01
     Dirichlet BCs: {}
     LandIce BCs:
       Number: 2
@@ -168,7 +161,28 @@ ANONYMOUS:
         Full Space: false
         Use NOX Solver: false
 
-        Hessian Dot Product: false
+        Hessian Dot Product: true
+        Remove Mean Of The Right-hand Side: true
+        Hessian Diagonal Inverse:
+          Block solver type 0: Belos
+          Block 0:
+            Linear Solver Type: Belos
+            Linear Solver Types:
+              Belos:
+                Solver Type: Pseudo Block GMRES
+                Solver Types:
+                  Pseudo Block GMRES:
+                    Maximum Iterations: 1000
+                    Convergence Tolerance: 1e-4
+                    Num Blocks: 1000
+                    Output Frequency: 200
+                    Verbosity: 33
+                VerboseObject:
+                  Verbosity Level: medium
+            Preconditioner Type: Ifpack2
+            Preconditioner Types:
+              Ifpack2:
+                Prec Type: ILUT
         ROL Options:
           General:
             Variable Objective Function: false

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
@@ -168,6 +168,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: false
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
@@ -168,7 +168,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
-        Hessian Dot Product: true
+        Hessian Dot Product: false
         Use NOX Solver: false
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
@@ -179,7 +179,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
-        Hessian Dot Product: true
+        Hessian Dot Product: false
         Use NOX Solver: true
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
@@ -179,6 +179,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: true
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening_memT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening_memT.yaml
@@ -180,7 +180,7 @@ ANONYMOUS:
         bound_eps: 1.00000000000000005e-01
 
         Full Space: false
-        Hessian Dot Product: true
+        Hessian Dot Product: false
         Use NOX Solver: false
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening_memT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening_memT.yaml
@@ -180,6 +180,7 @@ ANONYMOUS:
         bound_eps: 1.00000000000000005e-01
 
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: false
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch.yaml
@@ -255,6 +255,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: true
 
         ROL Options:

--- a/tests/small/LandIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
+++ b/tests/small/LandIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
@@ -292,6 +292,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: true
 
         ROL Options:

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param.yaml
@@ -65,6 +65,7 @@ ANONYMOUS:
         
         Use Old Reduced Space Interface: true
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: false
         
         ROL Options: 

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_paramT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_paramT.yaml
@@ -68,6 +68,7 @@ ANONYMOUS:
        
 
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: true
  
 

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restart.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restart.yaml
@@ -66,6 +66,7 @@ ANONYMOUS:
         
         Use Old Reduced Space Interface: true
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: false
         
         ROL Options: 

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restartT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restartT.yaml
@@ -66,6 +66,7 @@ ANONYMOUS:
         
         Use Old Reduced Space Interface: false
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: true
         
         ROL Options: 

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_paramT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_paramT.yaml
@@ -58,6 +58,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: true        
         
         Step Method: "Line Search"

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_paramT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_paramT.yaml
@@ -58,7 +58,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
-        Hessian Dot Product: true
+        Hessian Dot Product: false
         Use NOX Solver: true        
         
         Step Method: "Line Search"

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_params.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_params.yaml
@@ -62,7 +62,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: true
         Full Space: false
-        Hessian Dot Product: true
+        Hessian Dot Product: false
         Use NOX Solver: false
         
         Step Method: "Line Search"

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_params.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_params.yaml
@@ -62,6 +62,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: true
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: false
         
         Step Method: "Line Search"

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
@@ -65,7 +65,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
-        Hessian Dot Product: true
+        Hessian Dot Product: false
         Use NOX Solver: true
         
         Step Method: "Line Search"

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
@@ -65,6 +65,7 @@ ANONYMOUS:
 
         Use Old Reduced Space Interface: false
         Full Space: false
+        Hessian Dot Product: true
         Use NOX Solver: true
         
         Step Method: "Line Search"


### PR DESCRIPTION
*** This PR is labeled as WIP as it is using capabilities of [PR 8584](https://github.com/trilinos/Trilinos/pull/8584) which is not merged yet. ***

In this PR, the Hessian matrix w.r.t distributed parameters <img src="https://render.githubusercontent.com/render/math?math=\boldsymbol{H}_{\boldsymbol{p}\boldsymbol{p}}"> is constructed using the previously implemented Hessian-vector product and the Zoltan capability to reconstruct a matrix based on seed vectors <img src="https://render.githubusercontent.com/render/math?math=\boldsymbol{V}"> and the application of the matrix to these vectors <img src="https://render.githubusercontent.com/render/math?math=\boldsymbol{H}_{\boldsymbol{p}\boldsymbol{p}}\boldsymbol{V}">.

The work included in this PR is the following:
- The construction of the graph of <img src="https://render.githubusercontent.com/render/math?math=\boldsymbol{H}_{\boldsymbol{p}\boldsymbol{p}}"> in the file `src/utility/Albany_Hessian.cpp`.
- This graph construction is called from the file ` src/Albany_ModelEvaluator.cpp`.
- The evaluation of <img src="https://render.githubusercontent.com/render/math?math=\boldsymbol{H}_{\boldsymbol{p}\boldsymbol{p}}"> in file `src/Albany_Application.cpp` as follows:
  - the previously computed graph and the Zoltan colorer are used to compute a number of colors associated to the graph and a seed vector per color,
  - the Hessian-vector product is called sequentially for every seed vector one by one,
  - Zoltan is then used to reconstruct the crs matrix.
- The tests are then updated to enable or disable the new ROL options in files `tests/*`
- File `src/Albany_Utils.cpp` has been updated to support `writeMatrixMarket<const Tpetra_CrsGraph>`.
- File `src/LandIce/interface_with_mpas/Albany_MpasSTKMeshStruct.cpp` has been updated; a warning was reported as an error when building against a warning-free Trilinos build.

@mperego 