### PR TITLE
Use PHX::print<Entity>() to get Entity name

### DIFF
--- a/src/Albany_StateManager.cpp
+++ b/src/Albany_StateManager.cpp
@@ -5,6 +5,7 @@
 //*****************************************************************//
 #include "Albany_StateManager.hpp"
 #include "Albany_Utils.hpp"
+#include "PHAL_Dimension.hpp"
 #include "Teuchos_TestForException.hpp"
 #include "Teuchos_VerboseObject.hpp"
 
@@ -204,16 +205,16 @@ Albany::StateManager::registerStateVariable(
   else if (dl->rank() == 1 && dl->size() == 1)
     mfe_type = StateStruct::WorksetValue;  // One value for the whole workset
                                            // (i.e., time)
-  else if (dl->rank() == 1 && dl->name(0) == "Cell")
+  else if (dl->rank() == 1 && dl->name(0) == PHX::print<Cell>())
     mfe_type = StateStruct::ElemData;
-  else if (dl->rank() >= 1 && dl->name(0) == "Node")  // Nodal data
+  else if (dl->rank() >= 1 && dl->name(0) == PHX::print<Node>())  // Nodal data
     mfe_type = StateStruct::NodalData;
-  else if (dl->rank() >= 1 && dl->name(0) == "Cell") {  // Element QP or node
+  else if (dl->rank() >= 1 && dl->name(0) == PHX::print<Cell>()) {  // Element QP or node
                                                         // data
-    if (dl->rank() > 1 && dl->name(1) == "Node")        // Element node data
+    if (dl->rank() > 1 && dl->name(1) == PHX::print<Node>())        // Element node data
       mfe_type = StateStruct::ElemNode;  // One value for the whole workset
                                          // (i.e., time)
-    else if (dl->rank() > 1 && dl->name(1) == "QuadPoint")  // Element node data
+    else if (dl->rank() > 1 && dl->name(1) == PHX::print<QuadPoint>())  // Element node data
       mfe_type = StateStruct::QuadPoint;  // One value for the whole workset
                                           // (i.e., time)
     else
@@ -316,14 +317,14 @@ Albany::StateManager::registerNodalVectorStateVariable(
   if (dl->rank() == 1 && dl->size() == 1)
     mfe_type = StateStruct::WorksetValue;  // One value for the whole workset
                                            // (i.e., time)
-  else if (dl->rank() >= 1 && dl->name(0) == "Node")  // Nodal data
+  else if (dl->rank() >= 1 && dl->name(0) == PHX::print<Node>())  // Nodal data
     mfe_type = StateStruct::NodalData;
-  else if (dl->rank() >= 1 && dl->name(0) == "Cell") {  // Element QP or node
+  else if (dl->rank() >= 1 && dl->name(0) == PHX::print<Cell>()) {  // Element QP or node
                                                         // data
-    if (dl->rank() > 1 && dl->name(1) == "Node")        // Element node data
+    if (dl->rank() > 1 && dl->name(1) == PHX::print<Node>())        // Element node data
       mfe_type = StateStruct::ElemNode;  // One value for the whole workset
                                          // (i.e., time)
-    else if (dl->rank() > 1 && dl->name(1) == "QuadPoint")  // Element node data
+    else if (dl->rank() > 1 && dl->name(1) == PHX::print<QuadPoint>())  // Element node data
       mfe_type = StateStruct::QuadPoint;  // One value for the whole workset
                                           // (i.e., time)
     else
@@ -512,18 +513,18 @@ Albany::StateManager::registerSideSetStateVariable_collapsed(
   StateStruct::MeshFieldEntity mfe_type;
   if (fieldEntity) {
     mfe_type = *fieldEntity;
-  } else if (dl->rank() >= 1 && dl->name(0) == "Node")  // Nodal data
+  } else if (dl->rank() >= 1 && dl->name(0) == PHX::print<Node>())  // Nodal data
   {
     mfe_type = StateStruct::NodalData;                  // One value per node
-  } else if (dl->rank() == 1 && dl->name(1) == "Side")  // Element data
+  } else if (dl->rank() == 1 && dl->name(1) == PHX::print<Side>())  // Element data
   {
     mfe_type = StateStruct::ElemData;  // One value per element
   } else if (dl->rank() > 1) {
     if (dl->name(1) == "Dim")
       mfe_type = StateStruct::ElemData;   // One vector/tensor per element
-    else if (dl->name(1) == "Node")       // Element node data
+    else if (dl->name(1) == PHX::print<Node>())       // Element node data
       mfe_type = StateStruct::ElemNode;   // One value per side node
-    else if (dl->name(1) == "QuadPoint")  // Quad point data
+    else if (dl->name(1) == PHX::print<QuadPoint>())  // Quad point data
       mfe_type = StateStruct::QuadPoint;  // One value per side quad point
     else
       TEUCHOS_TEST_FOR_EXCEPTION(
@@ -541,7 +542,7 @@ Albany::StateManager::registerSideSetStateVariable_collapsed(
 
   if (stateRef.entity == StateStruct::NodalData) {
     TEUCHOS_TEST_FOR_EXCEPTION(
-        dl->name(0) == "Node",
+        dl->name(0) == PHX::print<Node>(),
         std::logic_error,
         "Error! NodalData states should have dl <Node,...>.\n");
 
@@ -665,18 +666,18 @@ Albany::StateManager::registerSideSetStateVariable(
   StateStruct::MeshFieldEntity mfe_type;
   if (fieldEntity) {
     mfe_type = *fieldEntity;
-  } else if (dl->rank() >= 1 && dl->name(0) == "Node")  // Nodal data
+  } else if (dl->rank() >= 1 && dl->name(0) == PHX::print<Node>())  // Nodal data
   {
     mfe_type = StateStruct::NodalData;                  // One value per node
-  } else if (dl->rank() == 2 && dl->name(1) == "Side")  // Element data
+  } else if (dl->rank() == 2 && dl->name(1) == PHX::print<Side>())  // Element data
   {
     mfe_type = StateStruct::ElemData;  // One value per element
   } else if (dl->rank() > 2) {
     if (dl->name(2) == "Dim")
       mfe_type = StateStruct::ElemData;   // One vector/tensor per element
-    else if (dl->name(2) == "Node")       // Element node data
+    else if (dl->name(2) == PHX::print<Node>())       // Element node data
       mfe_type = StateStruct::ElemNode;   // One value per side node
-    else if (dl->name(2) == "QuadPoint")  // Quad point data
+    else if (dl->name(2) == PHX::print<QuadPoint>())  // Quad point data
       mfe_type = StateStruct::QuadPoint;  // One value per side quad point
     else
       TEUCHOS_TEST_FOR_EXCEPTION(
@@ -694,7 +695,7 @@ Albany::StateManager::registerSideSetStateVariable(
 
   if (stateRef.entity == StateStruct::NodalData) {
     TEUCHOS_TEST_FOR_EXCEPTION(
-        dl->name(0) == "Node",
+        dl->name(0) == PHX::print<Node>(),
         std::logic_error,
         "Error! NodalData states should have dl <Node,...>.\n");
 

--- a/src/PHAL_Dimension.cpp
+++ b/src/PHAL_Dimension.cpp
@@ -8,52 +8,97 @@
 
 #include "PHAL_Dimension.hpp"
 
+namespace PHX {
+  template<> std::string print<Dim>(){return "Dim";}
+  template<> std::string print<VecDim>(){return "VecDim";}
+  template<> std::string print<LayerDim>(){return "LayerDim";}
+  template<> std::string print<QuadPoint>(){return "QuadPoint";}
+  template<> std::string print<Node>(){return "Node";}
+  template<> std::string print<Vertex>(){return "Vertex";}
+  template<> std::string print<Point>(){return "Point";}
+  template<> std::string print<Cell>(){return "Cell";}
+  template<> std::string print<Side>(){return "Side";}
+  template<> std::string print<Dummy>(){return "";}
+}
+
 const char * Dim::name() const
-{ static const char n[] = "Dim" ; return n ; }
+{
+  static auto s = PHX::print<Dim>();
+  return s.c_str() ;
+}
 const Dim & Dim::tag()
 { static const Dim myself ; return myself ; }
 
 const char * VecDim::name() const
-{ static const char n[] = "VecDim" ; return n ; }
+{
+  static auto s = PHX::print<VecDim>();
+  return s.c_str() ;
+}
 const VecDim & VecDim::tag()
 { static const VecDim myself ; return myself ; }
 
 const char * LayerDim::name() const
-{ static const char n[] = "LayerDim" ; return n ; }
+{
+  static auto s = PHX::print<LayerDim>();
+  return s.c_str() ;
+}
 const LayerDim & LayerDim::tag()
 { static const LayerDim myself ; return myself ; }
 
 const char * QuadPoint::name() const
-{ static const char n[] = "QuadPoint" ; return n ; }
+{
+  static auto s = PHX::print<QuadPoint>();
+  return s.c_str() ;
+}
+
 const QuadPoint & QuadPoint::tag()
 { static const QuadPoint myself ; return myself ; }
 
 const char * Node::name() const
-{ static const char n[] = "Node" ; return n ; }
+{
+  static auto s = PHX::print<Node>();
+  return s.c_str() ;
+}
 const Node & Node::tag()
 { static const Node myself ; return myself ; }
 
 const char * Vertex::name() const
-{ static const char n[] = "Vertex" ; return n ; }
+{
+  static auto s = PHX::print<Vertex>();
+  return s.c_str() ;
+}
 const Vertex & Vertex::tag()
 { static const Vertex myself ; return myself ; }
 
 const char * Point::name() const
-{ static const char n[] = "Point" ; return n ; }
+{
+  static auto s = PHX::print<Point>();
+  return s.c_str() ;
+}
 const Point & Point::tag()
 { static const Point myself ; return myself ; }
 
 const char * Cell::name() const
-{ static const char n[] = "Cell" ; return n ; }
+{
+  static auto s = PHX::print<Cell>();
+  return s.c_str() ;
+}
 const Cell & Cell::tag()
 { static const Cell myself ; return myself ; }
 
 const char * Side::name() const
-{ static const char n[] = "Side" ; return n; }
+{
+  static auto s = PHX::print<Side>();
+  return s.c_str() ;
+}
 const Side & Side::tag()
 {static const Side myself ; return myself; }
 
 const char * Dummy::name() const
-{ static const char n[] = "Dummy" ; return n ; }
+{
+  static auto s = PHX::print<Dummy>();
+  return s.c_str() ;
+}
 const Dummy & Dummy::tag()
 { static const Dummy myself ; return myself ; }
+

--- a/src/evaluators/state/PHAL_LoadSideSetStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_LoadSideSetStateField_Def.hpp
@@ -99,7 +99,7 @@ evaluateFields(typename Traits::EvalData workset)
   int size = dims.size();
   // Check the tag of the first extent after (cell,side,) to determine if field is nodal
   const std::string& leading_field_tag = size>2 ? field.fieldTag().dataLayout().name(2) : "";
-  TEUCHOS_TEST_FOR_EXCEPTION (size>2 && leading_field_tag!="Node" && leading_field_tag!="Dim" && leading_field_tag!="VecDim", std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (size>2 && leading_field_tag!=PHX::print<Node>() && leading_field_tag!=PHX::print<Dim>() && leading_field_tag!=PHX::print<VecDim>(), std::logic_error,
                               "Error! Invalid field layout in LoadSideSetStateField.\n");
 
   // For collapsed layouts, the tag to check is of the first extent after (side,) to determine if field is nodal
@@ -149,7 +149,7 @@ evaluateFields(typename Traits::EvalData workset)
           break;
 
         case 2:
-          if (leading_field_tag_sideset=="Node")
+          if (leading_field_tag_sideset==PHX::print<Node>())
           {
             // side set node scalar
             for (unsigned int node=0; node<dims[1]; ++node)
@@ -168,7 +168,7 @@ evaluateFields(typename Traits::EvalData workset)
           break;
 
         case 3:
-          if (leading_field_tag_sideset=="Node")
+          if (leading_field_tag_sideset==PHX::print<Node>())
           {
             // side set node vector/gradient
             for (unsigned int node=0; node<dims[1]; ++node)
@@ -201,7 +201,7 @@ evaluateFields(typename Traits::EvalData workset)
           break;
 
         case 3:
-          if (leading_field_tag=="Node")
+          if (leading_field_tag==PHX::print<Node>())
           {
             // side set node scalar
             for (unsigned int node=0; node<dims[2]; ++node)
@@ -220,7 +220,7 @@ evaluateFields(typename Traits::EvalData workset)
           break;
 
         case 4:
-          if (leading_field_tag=="Node")
+          if (leading_field_tag==PHX::print<Node>())
           {
             // side set node vector/gradient
             for (unsigned int node=0; node<dims[2]; ++node)

--- a/src/evaluators/state/PHAL_SaveSideSetStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_SaveSideSetStateField_Def.hpp
@@ -66,7 +66,7 @@ SaveSideSetStateField (const Teuchos::ParameterList& p,
   {
     TEUCHOS_TEST_FOR_EXCEPTION(field.fieldTag().dataLayout().size()<3, Teuchos::Exceptions::InvalidParameter,
                                 "Error! To save a side-set nodal state, pass the cell-side-based version of it (<Cell,Side,Node,...>).\n");
-    TEUCHOS_TEST_FOR_EXCEPTION(field.fieldTag().dataLayout().name(2)!="Node", Teuchos::Exceptions::InvalidParameter,
+    TEUCHOS_TEST_FOR_EXCEPTION(field.fieldTag().dataLayout().name(2)!=PHX::print<Node>(), Teuchos::Exceptions::InvalidParameter,
                                 "Error! To save a side-set nodal state, the third tag of the layout MUST be 'Node'.\n");
 
     Teuchos::RCP<shards::CellTopology> cellType;
@@ -161,7 +161,7 @@ saveElemState(typename Traits::EvalData workset)
   std::vector<PHX::DataLayout::size_type> dims;
   field.dimensions(dims);
   const std::string& tag2 = dims.size()>2 ? field.fieldTag().dataLayout().name(2) : "";
-  TEUCHOS_TEST_FOR_EXCEPTION (dims.size()>2 && tag2!="Node" && tag2!="Dim" && tag2!="VecDim", std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (dims.size()>2 && tag2!=PHX::print<Node>() && tag2!=PHX::print<Dim>() && tag2!=PHX::print<VecDim>(), std::logic_error,
                               "Error! Invalid field layout in SaveSideSetStateField.\n");
 
   // Loop on the sides of this sideSet that are in this workset
@@ -209,7 +209,7 @@ saveElemState(typename Traits::EvalData workset)
         break;
 
       case 3:
-        if (tag2=="Node")
+        if (tag2==PHX::print<Node>())
         {
           // side set node scalar
           for (unsigned int node=0; node<dims[2]; ++node)
@@ -226,7 +226,7 @@ saveElemState(typename Traits::EvalData workset)
         break;
 
       case 4:
-        if (tag2=="Node")
+        if (tag2==PHX::print<Node>())
         {
           // side set node vector/gradient
           for (unsigned int node=0; node<dims[2]; ++node)

--- a/src/evaluators/state/PHAL_SaveStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_SaveStateField_Def.hpp
@@ -50,7 +50,7 @@ SaveStateField(const Teuchos::ParameterList& p)
   Teuchos::RCP<PHX::DataLayout> layout = p.get<Teuchos::RCP<PHX::DataLayout> >("State Field Layout");
   field = decltype(field)(fieldName, layout );
 
-  if (layout->name(0) != "Cell" && layout->name(0) != "Node")
+  if (layout->name(0) != PHX::print<Cell>() && layout->name(0) != PHX::print<Node>())
   {
     worksetState = true;
     nodalState = false;
@@ -83,7 +83,7 @@ postRegistrationSetup(typename Traits::SetupData d,
   {
     TEUCHOS_TEST_FOR_EXCEPTION (field.fieldTag().dataLayout().size()<2, Teuchos::Exceptions::InvalidParameter,
                                 "Error! To save a nodal state, pass the cell-based version of it (<Cell,Node,...>).\n");
-    TEUCHOS_TEST_FOR_EXCEPTION (field.fieldTag().dataLayout().name(1)!="Node", Teuchos::Exceptions::InvalidParameter,
+    TEUCHOS_TEST_FOR_EXCEPTION (field.fieldTag().dataLayout().name(1)!=PHX::print<Node>(), Teuchos::Exceptions::InvalidParameter,
                                 "Error! To save a nodal state, the second tag of the layout MUST be 'Node'.\n");
   }
   d.fill_field_dependencies(this->dependentFields(),this->evaluatedFields());


### PR DESCRIPTION
In parts of the code we use the strings `Node`, `Cell`, etc. for comparisons with the `layout` names. However the `layout` names  are based on the implementation of `typeid` that depends on the compiler. In particular   `PHX::print<Node>()` returns `Node` when compiled with gcc and `4Node` when compiled with intel. In order to fix this, we replace the string `Node` with   `PHX::print<Node>()` throughout the code. We also change `Albany` implementation of `Node::name()` to return  `PHX::print<Node>()`, for consistency. Moreover, following Panzer, we overload `PHX::print<Node>()` to return `Node`, so that the value does not change using different compilers.
Thanks @bartgol for figuring out what the issue was.