### PR TITLE
Update some test files to correct the format and output values

### DIFF
--- a/src/evaluators/utility/PHAL_SharedParameter.hpp
+++ b/src/evaluators/utility/PHAL_SharedParameter.hpp
@@ -91,7 +91,7 @@ setNominalValue (const Teuchos::ParameterList& p, double default_value)
         break; // Pointless to check the remaining parameters as they are all distributed
 
       if (parameterType == "Scalar") {
-        if (!pvi.isParameter("Nominal Values"))
+        if (!pvi.isParameter("Nominal Value"))
           continue; // Pointless to check the parameter names, since we don't have nominal values
         if (pvi.get<std::string>("Name")==param_name)
         {
@@ -106,7 +106,7 @@ setNominalValue (const Teuchos::ParameterList& p, double default_value)
         for (int j=0; j<m; ++j)
         {
           const Teuchos::ParameterList& pj = pvi.sublist(Albany::strint("Scalar",j));
-          if (!pj.isParameter("Nominal Values"))
+          if (!pj.isParameter("Nominal Value"))
             continue; // Pointless to check the parameter names, since we don't have nominal values
           if (pj.get<std::string>("Name")==param_name)
           {

--- a/src/evaluators/utility/PHAL_SharedParameter.hpp
+++ b/src/evaluators/utility/PHAL_SharedParameter.hpp
@@ -105,9 +105,12 @@ setNominalValue (const Teuchos::ParameterList& p, double default_value)
         int m = pvi.get<int>("Dimension");
         for (int j=0; j<m; ++j)
         {
-          if (pvi.sublist(Albany::strint("Scalar",j)).get<std::string>("Name")==param_name)
+          const Teuchos::ParameterList& pj = pvi.sublist(Albany::strint("Scalar",j));
+          if (!pj.isParameter("Nominal Values"))
+            continue; // Pointless to check the parameter names, since we don't have nominal values
+          if (pj.get<std::string>("Name")==param_name)
           {
-            double nom_val = pvi.get<double>("Nominal Value");
+            double nom_val = pj.get<double>("Nominal Value");
             value = nom_val;
             found = true;
             break;

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
@@ -47,7 +47,7 @@ ANONYMOUS:
       Test Value: 6.39756401689000054e-02
     Number of Piro Analysis Comparisons: 1
     Piro Analysis Test Two Norm: true
-    Piro Analysis Test Values: [0.716192]
+    Piro Analysis Test Values: [20.3598]
   Piro: 
     Sensitivity Method: Adjoint
     Analysis: 

--- a/tests/small/Thermal1D/input_with_source.yaml
+++ b/tests/small/Thermal1D/input_with_source.yaml
@@ -27,7 +27,6 @@ ALBANY:
       Parameter 0:
         Type: Scalar
         Name: 'kappa_x Parameter'
-        Number: 1
   Discretization:
     1D Elements: 20
     1D Scale: 1.00000000000000000e+00

--- a/tests/small/Thermal2D/input_be_with_source.yaml
+++ b/tests/small/Thermal2D/input_be_with_source.yaml
@@ -27,10 +27,12 @@ ALBANY:
     Parameters:
       Number Of Parameters: 1
       Parameter 0:
-        Parameter 1: 'kappa_y Parameter'
-        Type: Scalar
-        Name: 'kappa_x Parameter'
-        Number: 2
+        Type: Vector
+        Dimension: 2
+        Scalar 0:
+          Name: 'kappa_x Parameter'
+        Scalar 1:
+          Name: 'kappa_y Parameter'
   Discretization:
     1D Elements: 10
     2D Elements: 10

--- a/tests/small/Thermal2D/input_fe_with_source.yaml
+++ b/tests/small/Thermal2D/input_fe_with_source.yaml
@@ -27,10 +27,12 @@ ALBANY:
     Parameters:
       Number Of Parameters: 1
       Parameter 0:
-        Parameter 1: 'kappa_y Parameter'
-        Type: Scalar
-        Name: 'kappa_x Parameter'
-        Number: 2
+        Type: Vector
+        Dimension: 2
+        Scalar 0:
+          Name: 'kappa_x Parameter'
+        Scalar 1:
+          Name: 'kappa_y Parameter'
   Discretization:
     1D Elements: 10
     2D Elements: 10


### PR DESCRIPTION
This small PR is linked to Trilinos PR [#8692](https://github.com/trilinos/Trilinos/pull/8692).

This PR updates 4 yaml files:

- `tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml` is updated to use the correct Piro analysis test value,
- Thermal tests are updated to use the `Type: Vector` parameter type; this required a modification of `src/evaluators/utility/PHAL_SharedParameter.hpp` not to require the `"Nominal Values"`.

All the tests passed on Blake.