### PR TITLE
Solve a bug which prevents from computing the Hess-vec of the residual w.r.t extruded parameters with MPI

### DIFF
--- a/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
@@ -1022,7 +1022,7 @@ evaluate2DFieldsDerivativesDueToExtrudedParams(typename Traits::EvalData workset
   Teuchos::RCP<Thyra_MultiVector> hess_vec_prod_f_px = workset.hessianWorkset.overlapped_hess_vec_prod_f_px;
   Teuchos::RCP<Thyra_MultiVector> hess_vec_prod_f_pp = workset.hessianWorkset.overlapped_hess_vec_prod_f_pp;
 
-  Teuchos::RCP<Thyra_Vector> f_multiplier = workset.hessianWorkset.f_multiplier;
+  Teuchos::RCP<Thyra_Vector> f_multiplier = workset.hessianWorkset.overlapped_f_multiplier;
 
   if (!f_px_is_active && !f_pp_is_active)
     return;


### PR DESCRIPTION
This PR solves a bug which prevented from computing the Hessian-vector product of the residual w.r.t extruded parameters with MPI.

@mperego 