### PR TITLE
Remove Use Old Reduced Space Interface and add observeResponse

### DIFF
--- a/PyAlbany/examples/large/LandIce/FO_GIS/input_fo_gis_analysis_beta_smbT.yaml
+++ b/PyAlbany/examples/large/LandIce/FO_GIS/input_fo_gis_analysis_beta_smbT.yaml
@@ -195,7 +195,6 @@ ANONYMOUS:
         Step Method: "Trust Region"
         #Step Method: "Line Search"
 
-        Use Old Reduced Space Interface: false
         Full Space: false
         Use NOX Solver: true
 

--- a/PyAlbany/examples/performanceAnalysis/input_conductivity_dist_paramT.yaml
+++ b/PyAlbany/examples/performanceAnalysis/input_conductivity_dist_paramT.yaml
@@ -61,7 +61,6 @@ ANONYMOUS:
         Min And Max Of Random Parameter Guess: [-1.0e+00, 2.0e+00]
         Bound Constrained: true
 
-        Use Old Reduced Space Interface: false
         Step Method: "Line Search"
         bound_eps: 1.0e-01
         Max Iterations: 10

--- a/PyAlbany/examples/tutorial/input_conductivity_dist_paramT.yaml
+++ b/PyAlbany/examples/tutorial/input_conductivity_dist_paramT.yaml
@@ -61,7 +61,6 @@ ANONYMOUS:
         Min And Max Of Random Parameter Guess: [-1.0e+00, 2.0e+00]
         Bound Constrained: true
 
-        Use Old Reduced Space Interface: false
         Step Method: "Line Search"
         bound_eps: 1.0e-01
         Max Iterations: 10

--- a/PyAlbany/tests/small/IO/input.yaml
+++ b/PyAlbany/tests/small/IO/input.yaml
@@ -61,7 +61,6 @@ ANONYMOUS:
         Min And Max Of Random Parameter Guess: [-1.0e+00, 2.0e+00]
         Bound Constrained: true
 
-        Use Old Reduced Space Interface: false
         Step Method: "Line Search"
         bound_eps: 1.0e-01
         Max Iterations: 10

--- a/PyAlbany/tests/small/SteadyHeat/input_conductivity_dist_paramT.yaml
+++ b/PyAlbany/tests/small/SteadyHeat/input_conductivity_dist_paramT.yaml
@@ -61,7 +61,6 @@ ANONYMOUS:
         Min And Max Of Random Parameter Guess: [-1.0e+00, 2.0e+00]
         Bound Constrained: true
 
-        Use Old Reduced Space Interface: false
         Step Method: "Line Search"
         bound_eps: 1.0e-01
         Max Iterations: 10

--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -999,7 +999,7 @@ evalModelImpl(const Thyra_InArgs&  inArgs,
 
     // When using the Old Reduced Space ROL Interface, the solution printing is 
     // handled in Piro using observers. Otherwise we take care of printing here.
-    if(analysisParams.isSublist("ROL") && !analysisParams.sublist("ROL").get("Use Old Reduced Space Interface", false)) {
+    if(analysisParams.isSublist("ROL")) {
       int iter = opt_paramList.get("Optimizer Iteration Number", -1);
       static int iteration = -1;
       int write_interval = analysisParams.get("Write Interval",1);

--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -997,8 +997,6 @@ evalModelImpl(const Thyra_InArgs&  inArgs,
       opt_paramList.set("Optimization Variables Changed", false);
     }
 
-    // When using the Old Reduced Space ROL Interface, the solution printing is 
-    // handled in Piro using observers. Otherwise we take care of printing here.
     if(analysisParams.isSublist("ROL")) {
       int iter = opt_paramList.get("Optimizer Iteration Number", -1);
       static int iteration = -1;
@@ -1008,6 +1006,7 @@ evalModelImpl(const Thyra_InArgs&  inArgs,
         Teuchos::TimeMonitor timer(*Teuchos::TimeMonitor::getNewTimer("Albany: Output to File"));
         const Teuchos::RCP<const Thyra_Vector> x = inArgs.get_x();
         observer.observeSolution(iter, *x, Teuchos::null, Teuchos::null, Teuchos::null);
+        observer.observeResponse(iter);
         iteration = iter;
       }
     }

--- a/src/Albany_ObserverImpl.cpp
+++ b/src/Albany_ObserverImpl.cpp
@@ -75,7 +75,7 @@ observeResponse(int iter)
 {
   auto out = Teuchos::VerboseObjectBase::getDefaultOStream();
   for (int j = 0; j < app_->getNumResponses(); ++j) {
-    *out << "Iteration " << iter << " response " << j << ":";
+    *out << "Optimization Iteration " << iter << ", response " << j << ":";
     app_->getResponse(j)->printResponse(out);
     *out << std::endl;
   }

--- a/src/Albany_ObserverImpl.cpp
+++ b/src/Albany_ObserverImpl.cpp
@@ -70,4 +70,15 @@ parameterChanged(const std::string& param)
   app_->getPhxSetup()->init_unsaved_param(param);
 }
 
+void ObserverImpl::
+observeResponse(int iter)
+{
+  auto out = Teuchos::VerboseObjectBase::getDefaultOStream();
+  for (int j = 0; j < app_->getNumResponses(); ++j) {
+    *out << "Iteration " << iter << " response " << j << ":";
+    app_->getResponse(j)->printResponse(out);
+    *out << std::endl;
+  }
+}
+
 } // namespace Albany

--- a/src/Albany_ObserverImpl.hpp
+++ b/src/Albany_ObserverImpl.hpp
@@ -34,6 +34,8 @@ public:
 
   void parameterChanged(
       const std::string& param);
+  
+  void observeResponse(int iter);
 };
 
 } // namespace Albany

--- a/src/responses/Albany_AbstractResponseFunction.hpp
+++ b/src/responses/Albany_AbstractResponseFunction.hpp
@@ -142,6 +142,9 @@ namespace Albany {
       const Teuchos::RCP<Thyra_MultiVector>& Hv_dp) = 0;
     //@}
 
+    virtual void printResponse(
+      Teuchos::RCP<Teuchos::FancyOStream> out
+    ) = 0;
   private:
 
     //! Private to prohibit copying

--- a/src/responses/Albany_CumulativeScalarResponseFunction.hpp
+++ b/src/responses/Albany_CumulativeScalarResponseFunction.hpp
@@ -79,6 +79,9 @@ namespace Albany {
 		  const Teuchos::RCP<Thyra_MultiVector>& dg_dxdotdot,
 		  const Teuchos::RCP<Thyra_MultiVector>& dg_dp);
 
+    virtual void
+    printResponse(Teuchos::RCP<Teuchos::FancyOStream> out);
+
   private:
 
     //! Evaluate Multi Vector distributed derivative dg_dp
@@ -143,6 +146,8 @@ namespace Albany {
     
     //! Private to prohibit copying
     CumulativeScalarResponseFunction& operator=(const CumulativeScalarResponseFunction&);
+
+    Teuchos::RCP<Thyra_Vector> g_;
 
   protected:
 

--- a/src/responses/Albany_FieldManagerScalarResponseFunction.cpp
+++ b/src/responses/Albany_FieldManagerScalarResponseFunction.cpp
@@ -15,6 +15,7 @@
 
 #include "Albany_Hessian.hpp"
 #include "Albany_ThyraUtils.hpp"
+#include "Thyra_VectorStdOps.hpp"
 
 namespace Albany
 {
@@ -254,6 +255,11 @@ evaluateResponse(const double current_time,
 
   // Perform fill via field manager
   evaluate<PHAL::AlbanyTraits::Residual>(workset);
+
+  if (g_.is_null())
+    g_ = Thyra::createMember(g->space());
+
+  g_->assign(*g);
 }
 
 void FieldManagerScalarResponseFunction::
@@ -658,5 +664,19 @@ evaluate_HessVecProd_pp(
     workset.hessianWorkset.hess_vec_prod_g_pp = Hv_dp;
     evaluate<PHAL::AlbanyTraits::HessianVec>(workset);
   }
+}
+
+void
+FieldManagerScalarResponseFunction::
+printResponse(Teuchos::RCP<Teuchos::FancyOStream> out)
+{
+  if (g_.is_null()) {
+    *out << " the response has not been evaluated yet!";
+    return;
+  }
+
+  std::size_t precision = 8;
+  std::size_t value_width = precision + 4;
+  *out << std::setw(value_width) << Thyra::get_ele(*g_,0);
 }
 } // namespace Albany

--- a/src/responses/Albany_FieldManagerScalarResponseFunction.hpp
+++ b/src/responses/Albany_FieldManagerScalarResponseFunction.hpp
@@ -131,6 +131,8 @@ public:
     const std::string& dist_param_direction_name,
     const Teuchos::RCP<Thyra_MultiVector>& Hv_dp);
 
+  void printResponse(Teuchos::RCP<Teuchos::FancyOStream> out);
+
 protected:
 
   //! Constructor for derived classes
@@ -196,6 +198,8 @@ private:
   int element_block_index;
 
   bool performedPostRegSetup;
+
+  Teuchos::RCP<Thyra_Vector> g_;
 };
 
 } // namespace Albany

--- a/src/responses/Albany_KLResponseFunction.cpp
+++ b/src/responses/Albany_KLResponseFunction.cpp
@@ -142,4 +142,10 @@ evaluateDerivative(const double current_time,
                                g, dg_dx, dg_dxdot, dg_dxdotdot, dg_dp);
 }
 
+void
+KLResponseFunction::
+printResponse(Teuchos::RCP<Teuchos::FancyOStream> out){
+  response->printResponse(out);
+}
+
 } // namespace Albany

--- a/src/responses/Albany_KLResponseFunction.hpp
+++ b/src/responses/Albany_KLResponseFunction.hpp
@@ -151,6 +151,8 @@ public:
     const Thyra::ModelEvaluatorBase::Derivative<ST>& dg_dp) override;
   //@}
 
+  void printResponse(Teuchos::RCP<Teuchos::FancyOStream> out);
+
 protected:
 
   //! Response function we work with

--- a/src/responses/Albany_ScalarResponseFunction.cpp
+++ b/src/responses/Albany_ScalarResponseFunction.cpp
@@ -47,4 +47,10 @@ void ScalarResponseFunction::evaluateDerivative(
     dg_dxdotdot.getMultiVector(), dg_dp.getMultiVector());
 }
 
+void
+ScalarResponseFunction::
+printResponse(Teuchos::RCP<Teuchos::FancyOStream> out)
+{
+}
+
 } // namespace Albany

--- a/src/responses/Albany_ScalarResponseFunction.hpp
+++ b/src/responses/Albany_ScalarResponseFunction.hpp
@@ -95,6 +95,8 @@ public:
     const Thyra::ModelEvaluatorBase::Derivative<ST>& dg_dxdotdot,
     const Thyra::ModelEvaluatorBase::Derivative<ST>& dg_dp) override;
 
+  void printResponse(Teuchos::RCP<Teuchos::FancyOStream> out);
+
 protected:
 
   //! Comm for forming response map

--- a/src/responses/Albany_SolutionAverageResponseFunction.cpp
+++ b/src/responses/Albany_SolutionAverageResponseFunction.cpp
@@ -8,6 +8,7 @@
 #include "Albany_SolutionAverageResponseFunction.hpp"
 
 #include "Albany_ThyraUtils.hpp"
+#include "Thyra_VectorStdOps.hpp"
 
 namespace Albany
 {
@@ -28,6 +29,11 @@ evaluateResponse(const double /*current_time*/,
 		const Teuchos::RCP<Thyra_Vector>& g)
 {
   evaluateResponseImpl(*x,*g);
+
+  if (g_.is_null())
+    g_ = Thyra::createMember(g->space());
+
+  g_->assign(*g);
 }
 
 void SolutionAverageResponseFunction::
@@ -214,6 +220,26 @@ evaluateResponseImpl (
   }
   const ST mean = one->dot(x) / x.space()->dim();
   g.assign(mean);
+}
+
+void
+SolutionAverageResponseFunction::
+printResponse(Teuchos::RCP<Teuchos::FancyOStream> out)
+{
+  if (g_.is_null()) {
+    *out << " the response has not been evaluated yet!";
+    return;
+  }
+
+  std::size_t precision = 8;
+  std::size_t value_width = precision + 4;
+  int gsize = g_->space()->dim();
+
+  for (int j = 0; j < gsize; j++) {
+    *out << std::setw(value_width) << Thyra::get_ele(*g_,j);
+    if (j < gsize-1)
+      *out << ", ";
+  }
 }
 
 } // namespace Albany

--- a/src/responses/Albany_SolutionAverageResponseFunction.hpp
+++ b/src/responses/Albany_SolutionAverageResponseFunction.hpp
@@ -117,6 +117,8 @@ public:
     const std::string& dist_param_direction_name,
     const Teuchos::RCP<Thyra_MultiVector>& Hv_dp);
 
+  void printResponse(Teuchos::RCP<Teuchos::FancyOStream> out);
+
 private:
 
   void evaluateResponseImpl (const Thyra_Vector& x,
@@ -125,6 +127,7 @@ private:
   Teuchos::RCP<Thyra_Vector>      one;
   Teuchos::RCP<Thyra_MultiVector> ones;
 
+  Teuchos::RCP<Thyra_Vector> g_;
 };
 
 } // namespace Albany

--- a/src/responses/Albany_SolutionFileResponseFunction.hpp
+++ b/src/responses/Albany_SolutionFileResponseFunction.hpp
@@ -128,6 +128,8 @@ public:
     const std::string& dist_param_direction_name,
     const Teuchos::RCP<Thyra_MultiVector>& Hv_dp);
 
+  void printResponse(Teuchos::RCP<Teuchos::FancyOStream> out);
+
 private:
 
   int MatrixMarketFile (const char *filename, const Teuchos::RCP<Thyra_MultiVector>& mv);
@@ -139,6 +141,8 @@ private:
   Teuchos::RCP<Thyra_Vector> diff;
 
   bool solutionLoaded;
+
+  Teuchos::RCP<Thyra_Vector> g_;
 };
 
 struct NormTwo {

--- a/src/responses/Albany_SolutionFileResponseFunction_Def.hpp
+++ b/src/responses/Albany_SolutionFileResponseFunction_Def.hpp
@@ -9,6 +9,7 @@
 #include "Albany_GlobalLocalIndexer.hpp"
 
 #include "Teuchos_CommHelpers.hpp"
+#include "Thyra_VectorStdOps.hpp"
 
 namespace Albany
 {
@@ -64,6 +65,11 @@ evaluateResponse(const double /*current_time*/,
 
   // Get the norm
   g->assign(Norm::Norm(*diff));
+
+  if (g_.is_null())
+    g_ = Thyra::createMember(g->space());
+
+  g_->assign(*g);
 }
 
 template<class Norm>
@@ -355,6 +361,26 @@ MatrixMarketFile (const char *filename, const Teuchos::RCP<Thyra_MultiVector>& m
   }
 
   return 0;
+}
+
+template<class Norm>
+void SolutionFileResponseFunction<Norm>::
+printResponse(Teuchos::RCP<Teuchos::FancyOStream> out)
+{
+  if (g_.is_null()) {
+    *out << " the response has not been evaluated yet!";
+    return;
+  }
+
+  std::size_t precision = 8;
+  std::size_t value_width = precision + 4;
+  int gsize = g_->space()->dim();
+
+  for (int j = 0; j < gsize; j++) {
+    *out << std::setw(value_width) << Thyra::get_ele(*g_,j);
+    if (j < gsize-1)
+      *out << ", ";
+  }
 }
 
 } // namespace Albany

--- a/src/responses/Albany_SolutionMaxValueResponseFunction.hpp
+++ b/src/responses/Albany_SolutionMaxValueResponseFunction.hpp
@@ -120,6 +120,8 @@ public:
     const std::string& dist_param_direction_name,
     const Teuchos::RCP<Thyra_MultiVector>& Hv_dp);
 
+  void printResponse(Teuchos::RCP<Teuchos::FancyOStream> out);
+
 protected:
 
   //! Number of equations per node
@@ -135,6 +137,8 @@ protected:
 
   //! Compute max value
   void computeMaxValue(const Teuchos::RCP<const Thyra_Vector>& x, ST& val);
+
+  Teuchos::RCP<Thyra_Vector> g_;
 };
 
 } // namespace Albany

--- a/src/responses/Albany_SolutionMinValueResponseFunction.cpp
+++ b/src/responses/Albany_SolutionMinValueResponseFunction.cpp
@@ -9,6 +9,7 @@
 
 #include "Teuchos_CommHelpers.hpp"
 #include "Thyra_SpmdVectorBase.hpp"
+#include "Thyra_VectorStdOps.hpp"
 
 namespace Albany
 {
@@ -35,6 +36,11 @@ evaluateResponse(const double /*current_time*/,
 {
   Teuchos::ArrayRCP<ST> g_nonconstView = getNonconstLocalData(g);
   computeMinValue(x, g_nonconstView[0]);
+
+  if (g_.is_null())
+    g_ = Thyra::createMember(g->space());
+
+  g_->assign(*g);
 }
 
 
@@ -243,6 +249,26 @@ computeMinValue(const Teuchos::RCP<const Thyra_Vector>& x, ST& global_min)
 
   // Get max value across all proc's
   Teuchos::reduceAll(*comm_, Teuchos::REDUCE_MIN, 1, &my_min, &global_min);
+}
+
+void
+SolutionMinValueResponseFunction::
+printResponse(Teuchos::RCP<Teuchos::FancyOStream> out)
+{
+  if (g_.is_null()) {
+    *out << " the response has not been evaluated yet!";
+    return;
+  }
+
+  std::size_t precision = 8;
+  std::size_t value_width = precision + 4;
+  int gsize = g_->space()->dim();
+
+  for (int j = 0; j < gsize; j++) {
+    *out << std::setw(value_width) << Thyra::get_ele(*g_,j);
+    if (j < gsize-1)
+      *out << ", ";
+  }
 }
 
 } // namespace Albany

--- a/src/responses/Albany_SolutionMinValueResponseFunction.hpp
+++ b/src/responses/Albany_SolutionMinValueResponseFunction.hpp
@@ -119,6 +119,8 @@ public:
     const std::string& dist_param_direction_name,
     const Teuchos::RCP<Thyra_MultiVector>& Hv_dp);
 
+  void printResponse(Teuchos::RCP<Teuchos::FancyOStream> out);
+
 protected:
 
   //! Compute min value
@@ -134,6 +136,8 @@ protected:
 
   //! Flag for interleaved verus blocked unknown ordering
   DiscType interleavedOrdering;
+
+  Teuchos::RCP<Thyra_Vector> g_;
 };
 
 } // namespace Albany

--- a/src/responses/Albany_SolutionResponseFunction.hpp
+++ b/src/responses/Albany_SolutionResponseFunction.hpp
@@ -136,6 +136,8 @@ public:
     const Teuchos::RCP<Thyra_MultiVector>& Hv_dp) override;
   //@}
 
+  void printResponse(Teuchos::RCP<Teuchos::FancyOStream> out);
+
 protected:
   
   void cullSolution(const Teuchos::RCP<const Thyra_MultiVector>& x, 
@@ -154,6 +156,8 @@ protected:
 
   //! Factory for the culling operator
   Teuchos::RCP<ThyraCrsMatrixFactory> cull_op_factory;
+
+  Teuchos::RCP<Thyra_Vector> g_;
 };
 
 } // namespace Albany

--- a/src/responses/Albany_SolutionTwoNormResponseFunction.cpp
+++ b/src/responses/Albany_SolutionTwoNormResponseFunction.cpp
@@ -37,6 +37,11 @@ evaluateResponse(const double /*current_time*/,
 {
   Teuchos::ScalarTraits<ST>::magnitudeType twonorm = x->norm_2();
   g->assign(twonorm);
+
+  if (g_.is_null())
+    g_ = Thyra::createMember(g->space());
+
+  g_->assign(*g);
 }
 
 void
@@ -221,5 +226,25 @@ evaluate_HessVecProd_pp(
 {
   if (!Hv_dp.is_null()) {
     Hv_dp->assign(0.0);
+  }
+}
+
+void
+Albany::SolutionTwoNormResponseFunction::
+printResponse(Teuchos::RCP<Teuchos::FancyOStream> out)
+{
+  if (g_.is_null()) {
+    *out << " the response has not been evaluated yet!";
+    return;
+  }
+
+  std::size_t precision = 8;
+  std::size_t value_width = precision + 4;
+  int gsize = g_->space()->dim();
+
+  for (int j = 0; j < gsize; j++) {
+    *out << std::setw(value_width) << Thyra::get_ele(*g_,j);
+    if (j < gsize-1)
+      *out << ", ";
   }
 }

--- a/src/responses/Albany_SolutionTwoNormResponseFunction.hpp
+++ b/src/responses/Albany_SolutionTwoNormResponseFunction.hpp
@@ -72,6 +72,8 @@ namespace Albany {
       const Teuchos::RCP<Thyra_MultiVector>& dg_dxdotdot,
       const Teuchos::RCP<Thyra_MultiVector>& dg_dp);
 
+  void printResponse(Teuchos::RCP<Teuchos::FancyOStream> out);
+
   private:
 
     //! Evaluate distributed parameter derivative = dg/dp
@@ -136,6 +138,7 @@ namespace Albany {
     
     SolutionTwoNormResponseFunction& operator=(const SolutionTwoNormResponseFunction&);
 
+    Teuchos::RCP<Thyra_Vector> g_;
   };
 
 } // namespace Albany

--- a/src/responses/Albany_SolutionValuesResponseFunction.hpp
+++ b/src/responses/Albany_SolutionValuesResponseFunction.hpp
@@ -126,6 +126,9 @@ public:
     const std::string& dist_param_direction_name,
     const Teuchos::RCP<Thyra_MultiVector>& Hv_dp);
 
+    virtual void
+    printResponse(Teuchos::RCP<Teuchos::FancyOStream> out);
+
 private:
 
   Teuchos::RCP<const Application> app_;
@@ -139,6 +142,8 @@ private:
   Teuchos::RCP<SolutionPrinter> sol_printer_;
 
   void updateCASManager();
+
+  Teuchos::RCP<Thyra_Vector> g_;
 };
 
 } // namespace Albany

--- a/tests/small/LandIce/Enthalpy/input_enthalpy_humboldt.yaml
+++ b/tests/small/LandIce/Enthalpy/input_enthalpy_humboldt.yaml
@@ -194,7 +194,6 @@ ANONYMOUS:
 
         Step Method: "Trust Region"
 
-        Use Old Reduced Space Interface: false
         Full Space: false
         Hessian Dot Product: false
         Use NOX Solver: true

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
@@ -164,7 +164,6 @@ ANONYMOUS:
         Bound Constrained: true
         bound_eps: 1.00000000000000005e-01
 
-        Use Old Reduced Space Interface: false
         Full Space: false
         Use NOX Solver: false
 

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
@@ -157,7 +157,6 @@ ANONYMOUS:
         Bound Constrained: true
         bound_eps: 1.00000000000000005e-01
 
-        Use Old Reduced Space Interface: false
         Full Space: false
         Use NOX Solver: false
 

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
@@ -166,7 +166,6 @@ ANONYMOUS:
         Bound Constrained: true
         bound_eps: 1.00000000000000005e-01
 
-        Use Old Reduced Space Interface: false
         Full Space: false
         Hessian Dot Product: false
         Use NOX Solver: false

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
@@ -177,7 +177,6 @@ ANONYMOUS:
         Bound Constrained: true
         bound_eps: 1.00000000000000005e-01
 
-        Use Old Reduced Space Interface: false
         Full Space: false
         Hessian Dot Product: false
         Use NOX Solver: true

--- a/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch.yaml
@@ -253,7 +253,6 @@ ANONYMOUS:
 
         Step Method: "Trust Region"
 
-        Use Old Reduced Space Interface: false
         Full Space: false
         Hessian Dot Product: true
         Use NOX Solver: true

--- a/tests/small/LandIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
+++ b/tests/small/LandIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
@@ -290,7 +290,6 @@ ANONYMOUS:
 
         Step Method: "Trust Region"
 
-        Use Old Reduced Space Interface: false
         Full Space: false
         Hessian Dot Product: true
         Use NOX Solver: true

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param.yaml
@@ -62,8 +62,7 @@ ANONYMOUS:
         Min And Max Of Random Parameter Guess: [-1.00000000000000000e+00, 2.00000000000000000e+00]
         Bound Constrained: true
         bound_eps: 1.00000000000000006e-01
-        
-        Use Old Reduced Space Interface: true
+
         Full Space: false
         Hessian Dot Product: true
         Use NOX Solver: false

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_paramT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_paramT.yaml
@@ -61,7 +61,6 @@ ANONYMOUS:
         Min And Max Of Random Parameter Guess: [-1.0e+00, 2.0e+00]
         Bound Constrained: true
 
-        Use Old Reduced Space Interface: false
         Step Method: "Line Search"
         bound_eps: 1.0e-01
         Max Iterations: 10

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restart.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restart.yaml
@@ -63,8 +63,7 @@ ANONYMOUS:
         Min And Max Of Random Parameter Guess: [-1.00000000000000000e+00, 2.00000000000000000e+00]
         Bound Constrained: true
         bound_eps: 1.00000000000000006e-01
-        
-        Use Old Reduced Space Interface: true
+
         Full Space: false
         Hessian Dot Product: true
         Use NOX Solver: false

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restartT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restartT.yaml
@@ -63,8 +63,7 @@ ANONYMOUS:
         Min And Max Of Random Parameter Guess: [-1.00000000000000000e+00, 2.00000000000000000e+00]
         Bound Constrained: true
         bound_eps: 1.00000000000000006e-01
-        
-        Use Old Reduced Space Interface: false
+
         Full Space: false
         Hessian Dot Product: true
         Use NOX Solver: true

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_param.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_param.yaml
@@ -53,8 +53,6 @@ ANONYMOUS:
         Bound Constrained: true
         bound_eps: 1.00000000000000006e-01
         
-        Use Old Reduced Space Interface: true    
-        
         ROL Options: 
           General: 
             Variable Objective Function: false

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_paramT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_paramT.yaml
@@ -57,7 +57,6 @@ ANONYMOUS:
         Min And Max Of Random Parameter Guess: [-1.00000000000000000e+00, 2.00000000000000000e+00]
         Bound Constrained: true
 
-        Use Old Reduced Space Interface: false
         Full Space: false
         Hessian Dot Product: false
         Use NOX Solver: true        

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_params.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_params.yaml
@@ -70,7 +70,6 @@ ANONYMOUS:
         Min And Max Of Random Parameter Guess: [-1.0e+00, 2.0e+00]
         Bound Constrained: true
 
-        Use Old Reduced Space Interface: true
         Full Space: false
         Hessian Dot Product: false
         Use NOX Solver: false

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
@@ -73,7 +73,6 @@ ANONYMOUS:
         Min And Max Of Random Parameter Guess: [-1.0e+00, 2.0e+00]
         Bound Constrained: true
 
-        Use Old Reduced Space Interface: false
         Full Space: false
         Hessian Dot Product: false
         Use NOX Solver: true

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_paramT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_paramT.yaml
@@ -81,7 +81,6 @@ ANONYMOUS:
         Min And Max Of Random Parameter Guess: [-1.0e+00, 2.0e+00]
         Bound Constrained: true
 
-        Use Old Reduced Space Interface: false
         Step Method: "Line Search"
         bound_eps: 1.0e-01
         Max Iterations: 10


### PR DESCRIPTION
This PR removes the deprecated `Use Old Reduced Space Interface` option and allows to print the response values during the optimization solve.
In particular, `CumulativeScalarResponseFunction` responses are printed such that both the value of the sum and the value of all the terms are printed.

The tests passed on Blake and the code built warning free.

@mperego 