### PR TITLE
Update Albany to use Piro observers

### DIFF
--- a/src/Albany_ObserverImpl.cpp
+++ b/src/Albany_ObserverImpl.cpp
@@ -114,7 +114,7 @@ observeResponse(int iter)
 {
   auto out = Teuchos::VerboseObjectBase::getDefaultOStream();
   for (int j = 0; j < app_->getNumResponses(); ++j) {
-    *out << "Optimization Iteration " << iter << ", response " << j << ":";
+    *out << "Optimization Iteration " << iter << ", response " << j << ": ";
     app_->getResponse(j)->printResponse(out);
     *out << std::endl;
   }

--- a/src/Albany_ObserverImpl.hpp
+++ b/src/Albany_ObserverImpl.hpp
@@ -9,10 +9,11 @@
 #include <string>
 
 #include "Albany_StatelessObserverImpl.hpp"
+#include "Piro_ROL_ObserverBase.hpp"
 
 namespace Albany {
 
-class ObserverImpl : public StatelessObserverImpl {
+class ObserverImpl : public StatelessObserverImpl, public Piro::ROL_ObserverBase<ST> {
 public:
   explicit ObserverImpl(const Teuchos::RCP<Application>& app);
 
@@ -34,6 +35,8 @@ public:
 
   void parameterChanged(
       const std::string& param);
+
+  void parametersChanged();
   
   void observeResponse(int iter);
 };

--- a/src/Main_Analysis.cpp
+++ b/src/Main_Analysis.cpp
@@ -88,7 +88,7 @@ int main(int argc, char *argv[]) {
 
     // If no analysis section set in input file, default to simple "Solve"
     std::string analysisPackage = slvrfctry.getAnalysisParameters().get("Analysis Package","Solve");
-    status = Piro::PerformAnalysis(*fwd_solver, slvrfctry.getAnalysisParameters(), p, observer);
+    status = Piro::PerformAnalysis(*fwd_solver, slvrfctry.getParameters()->sublist("Piro"), p, observer);
 
     Albany::RegressionTests regression(slvrfctry.getParameters());
     status = regression.checkAnalysisTestResults(0, p);

--- a/src/Main_Analysis.cpp
+++ b/src/Main_Analysis.cpp
@@ -10,6 +10,7 @@
 #include "Albany_CommUtils.hpp"
 #include "Albany_SolverFactory.hpp"
 #include "Albany_RegressionTests.hpp"
+#include "Albany_ObserverImpl.hpp"
 
 #include "Albany_FactoriesHelpers.hpp"
 
@@ -83,9 +84,11 @@ int main(int argc, char *argv[]) {
 
     Teuchos::RCP< Thyra::VectorBase<double> > p;
 
+    Teuchos::RCP<Albany::ObserverImpl> observer = Teuchos::rcp( new Albany::ObserverImpl(albanyApp));
+
     // If no analysis section set in input file, default to simple "Solve"
     std::string analysisPackage = slvrfctry.getAnalysisParameters().get("Analysis Package","Solve");
-    status = Piro::PerformAnalysis(*fwd_solver, slvrfctry.getAnalysisParameters(), p);
+    status = Piro::PerformAnalysis(*fwd_solver, slvrfctry.getAnalysisParameters(), p, observer);
 
     Albany::RegressionTests regression(slvrfctry.getParameters());
     status = regression.checkAnalysisTestResults(0, p);

--- a/src/responses/Albany_CumulativeScalarResponseFunction.cpp
+++ b/src/responses/Albany_CumulativeScalarResponseFunction.cpp
@@ -426,7 +426,7 @@ printResponse(Teuchos::RCP<Teuchos::FancyOStream> out)
   std::size_t precision = 8;
   std::size_t value_width = precision + 4;
   
-  *out << std::setw(value_width) << Thyra::get_ele(*g_,0) << " sum of [";
+  *out << std::setw(value_width) << Thyra::get_ele(*g_,0) << "sum of [";
   for (unsigned int i=0; i<responses.size(); i++) {
     responses[i]->printResponse(out);
     if (i<(responses.size()-1))


### PR DESCRIPTION
This PR updates Albany to be consistent with [Trilinos PR #8849](https://github.com/trilinos/Trilinos/pull/8849).
This PR should not be merged before the above-mentioned one.

The tests passed correctly on Blake and the branch built warning free.

@mperego 