### PR TITLE
PyAlbany: add performAnalysis and setParameter functions

### DIFF
--- a/PyAlbany/examples/UQ/.gitignore
+++ b/PyAlbany/examples/UQ/.gitignore
@@ -1,0 +1,2 @@
+steady2d*
+*.jpeg

--- a/PyAlbany/examples/UQ/MC_example.py
+++ b/PyAlbany/examples/UQ/MC_example.py
@@ -1,0 +1,73 @@
+from PyTrilinos import Tpetra
+from PyTrilinos import Teuchos
+
+from mpi4py import MPI
+import numpy as np
+from PyAlbany import Utils
+import os
+import sys
+
+try:
+    import matplotlib as mpl
+    mpl.use('Agg')
+    import matplotlib.pyplot as plt
+    printPlot = True
+except:
+    printPlot = False
+
+def main(parallelEnv):
+    comm = MPI.COMM_WORLD
+    myGlobalRank = comm.rank
+
+    # Create an Albany problem:
+    filename = "input_dirichletT.yaml"
+    parameter = Utils.createParameterList(
+        filename, parallelEnv
+    )
+
+    problem = Utils.createAlbanyProblem(parameter, parallelEnv)
+
+    parameter_map_0 = problem.getParameterMap(0)
+    parameter_0 = Tpetra.Vector(parameter_map_0, dtype="d")
+
+    N = 200
+    p_min = -2.
+    p_max = 2.
+
+    # Generate N samples randomly chosen in [p_min, p_max]:
+    p = np.random.uniform(p_min, p_max, N)
+    QoI = np.zeros((N,))
+
+    # Loop over the N samples and evaluate the quantity of interest:
+    for i in range(0, N):
+        parameter_0[0] = p[i]
+        problem.setParameter(0, parameter_0)
+
+        problem.performSolve()
+
+        response = problem.getResponse(0)
+        QoI[i] = response.getData()[0]
+
+    if myGlobalRank == 0:
+        if printPlot:
+            f, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(16,6))
+
+            ax1.hist(p)
+            ax1.set_ylabel('Counts')
+            ax1.set_xlabel('Random parameter')
+
+            ax2.scatter(p, QoI)
+            ax2.set_ylabel('Quantity of interest')
+            ax2.set_xlabel('Random parameter')
+
+            ax3.hist(QoI)
+            ax3.set_ylabel('Counts')
+            ax3.set_xlabel('Quantity of interest')
+
+            plt.savefig('UQ.jpeg', dpi=800)
+            plt.close()
+
+if __name__ == "__main__":
+    comm = Teuchos.DefaultComm.getComm()
+    parallelEnv = Utils.createDefaultParallelEnv(comm)
+    main(parallelEnv)

--- a/PyAlbany/examples/UQ/input_dirichletT.yaml
+++ b/PyAlbany/examples/UQ/input_dirichletT.yaml
@@ -1,0 +1,268 @@
+%YAML 1.1
+---
+ANONYMOUS:
+  Build Type: Tpetra
+  Problem: 
+    Name: Heat 2D
+    Compute Sensitivities: true
+    Dirichlet BCs: 
+      DBC on NS NodeSet0 for DOF T: 0.00000000000000000e+00
+      DBC on NS NodeSet1 for DOF T: -1.00000000000000000e+00
+      DBC on NS NodeSet2 for DOF T: 0.00000000000000000e+00
+      DBC on NS NodeSet3 for DOF T: 0.00000000000000000e+00
+    Parameters:
+      Number Of Parameters: 1
+      Parameter 0:
+        Type: Scalar
+        Name: DBC on NS NodeSet2 for DOF T
+        Lower Bound: -2.00000000000000000e+00
+        Upper Bound: 2.00000000000000000e+00
+    Hessian:
+      Use AD for Hessian-vector products (default): true
+      Response 0:
+        Reconstruct H_pp: false
+    Response Functions: 
+      Number Of Responses: 1
+      Response 0:
+        Type: Scalar Response
+        Name: Squared L2 Difference Source ST Target PST
+        Field Rank: Scalar
+        Source Field Name: Temperature
+        Target Value: 0.0
+  Discretization: 
+    1D Elements: 10
+    2D Elements: 10
+    Method: STK2D
+    Exodus Output File Name: steady2d.exo
+    Cubature Degree: 9
+  Regression For Response 0:
+    Test Value: 3.53554196849000024e-01
+    Relative Tolerance: 1.0e-03
+    Absolute Tolerance: 1.0e-04
+    Sensitivity For Parameter 0:
+      Test Value: -1.98119937831999993e-01
+    Sensitivity For Parameter 1:
+      Test Value: 6.39756401689000054e-02
+    Number of Piro Analysis Comparisons: 1
+    Piro Analysis Test Two Norm: true
+    Piro Analysis Test Values: [20.3598]
+  Piro: 
+    Sensitivity Method: Adjoint
+    Analysis: 
+      Analysis Package: ROL
+      ROL: 
+        Number Of Parameters: 1
+        Check Gradient: false
+        Gradient Tolerance: 1.0e-04
+        Step Tolerance: 1.0e-04
+        Print Output: true
+        Parameter Initial Guess Type: From Model Evaluator
+        Uniform Parameter Guess: 0.0e+00
+        Min And Max Of Random Parameter Guess: [-1.0e+00, 2.0e+00]
+        Bound Constrained: true
+
+        Full Space: false
+        Hessian Dot Product: false
+        Use NOX Solver: true
+        
+        Step Method: "Line Search"
+        bound_eps: 1.0e-01
+        Max Iterations: 5
+
+        ROL Options: 
+        # ===========  SIMOPT SOLVER PARAMETER SUBLIST  =========== 
+          SimOpt:
+            Solve:
+              Absolute Residual Tolerance:   1.0e-6
+              Relative Residual Tolerance:   1.0e-1
+              Iteration Limit:               20
+              Sufficient Decrease Tolerance: 1.e-4
+              Step Tolerance:                1.e-8
+              Backtracking Factor:           0.5
+              Output Iteration History:      false
+              Zero Initial Guess:            false
+              Solver Type:                   0    
+          
+          Status Test: 
+            Gradient Tolerance: 1.0e-4
+            Constraint Tolerance: 1.0e-5
+            Step Tolerance: 1.0e-10
+            Iteration Limit: 5
+
+          General: 
+            Variable Objective Function: false
+            Scale for Epsilon Active Sets: 1.00000000000000000e+00
+            Inexact Objective Function: false
+            Inexact Gradient: false
+            Inexact Hessian-Times-A-Vector: true
+            Projected Gradient Criticality Measure: false
+            Secant: 
+              Type: Limited-Memory BFGS
+              Use as Preconditioner: false
+              Use as Hessian: true
+              Maximum Storage: 50
+              Barzilai-Borwein Type: 1
+            Krylov: 
+              Type: Conjugate Gradients
+              Absolute Tolerance: 1.00000000000000005e-04
+              Relative Tolerance: 1.00000000000000002e-02
+              Iteration Limit: 100
+
+          Step:
+            Type: "Augmented Lagrangian" #"Moreau-Yosida Penalty" 
+            Line Search: 
+              Function Evaluation Limit: 60
+              Sufficient Decrease Tolerance: 9.99999999999999945e-21
+              Initial Step Size: 1.00000000000000000e+00
+              User Defined Initial Step Size: false
+              Accept Linesearch Minimizer: false
+              Accept Last Alpha: false
+              Descent Method: 
+                Type: Quasi-Newton
+                Nonlinear CG Type: Hestenes-Stiefel
+              Curvature Condition: 
+                Type: Strong Wolfe Conditions
+                General Parameter: 9.00000000000000022e-01
+                Generalized Wolfe Parameter: 5.99999999999999978e-01
+              Line-Search Method: 
+                Type: Cubic Interpolation
+                Backtracking Rate: 5.00000000000000000e-01
+                Bracketing Tolerance: 1.00000000000000002e-08
+                Path-Based Target Level: 
+                  Target Relaxation Parameter: 1.00000000000000000e+00
+                  Upper Bound on Path Length: 1.00000000000000000e+00
+            Trust Region: 
+              Subproblem Solver: Truncated CG
+              Initial Radius: 1.00000000000000000e+01
+              Maximum Radius: 5.00000000000000000e+03
+              Step Acceptance Threshold: 5.00000000000000028e-02
+              Radius Shrinking Threshold: 5.00000000000000028e-02
+              Radius Growing Threshold: 9.00000000000000022e-01
+              Radius Shrinking Rate (Negative rho): 6.25000000000000000e-02
+              Radius Shrinking Rate (Positive rho): 2.50000000000000000e-01
+              Radius Growing Rate: 2.50000000000000000e+00
+              Safeguard Size: 1.00000000000000000e+08
+              Inexact: 
+                Value: 
+                  Tolerance Scaling: 1.00000000000000006e-01
+                  Exponent: 9.00000000000000022e-01
+                  Forcing Sequence Initial Value: 1.00000000000000000e+00
+                  Forcing Sequence Update Frequency: 10
+                  Forcing Sequence Reduction Factor: 1.00000000000000006e-01
+                Gradient: 
+                  Tolerance Scaling: 1.00000000000000006e-01
+                  Relative Tolerance: 2.00000000000000000e+00
+
+            Moreau-Yosida Penalty:
+              # ===========  PENALTY PARAMETER UPDATE  =========== 
+              Initial Penalty Parameter: 1.0e+2
+              Penalty Parameter Growth Factor: 1.0
+
+              # ===========  SUBPROBLEM SOLVER  =========== 
+              Subproblem:
+                Optimality Tolerance: 1.e-4
+                Feasibility Tolerance: 1.e-5
+                Print History: true
+                Iteration Limit: 1
+
+            # ===========  COMPOSITE STEP  =========== -->
+            Composite Step:
+              Output Level: 2
+              #Initial Radius: 1.0e+2
+              Use Constraint Hessian: false
+              
+              # ===========  OPTIMALITY SYSTEM SOLVER  =========== -->
+              Optimality System Solver:
+                Nominal Relative Tolerance: 2.0e-1
+                Fix Tolerance: true
+      
+              # ===========  TANGENTIAL SUBPROBLEM SOLVER  =========== -->
+              Tangential Subproblem Solver:
+                Iteration Limit: 100
+                Relative Tolerance: 1.0e-2
+
+            # ===========  AUGMENTED LAGRANGIAN  =========== 
+            Augmented Lagrangian:
+              Level of Hessian Approximation: 0
+              #  ===========  PROBLEM SCALING =========== 
+              Use Default Problem Scaling: false
+              Objective Scaling: 1.e+01
+              Constraint Scaling: 1.e+0
+              # ===========  PENALTY PARAMETER UPDATE  =========== 
+              Use Default Initial Penalty Parameter: true
+              Initial Penalty Parameter: 1.e+1
+              Penalty Parameter Growth Factor: 1.e+1
+              Minimum Penalty Parameter Reciprocal: 0.1
+              # ===========  OPTIMALITY TOLERANCE UPDATE  =========== 
+              Initial Optimality Tolerance: 1.0
+              Optimality Tolerance Update Exponent: 1.0
+              Optimality Tolerance Decrease Exponent: 1.0
+              # ==========  FEASIBILITY TOLERANCE UPDATE  =========== 
+              Initial Feasibility Tolerance: 1.0
+              Feasibility Tolerance Update Exponent: 0.1
+              Feasibility Tolerance Decrease Exponent: 0.9
+              # ===========  SUBPROBLEM SOLVER  =========== 
+              Print Intermediate Optimization History: false
+              Subproblem Step Type: "Trust Region"
+              Subproblem Iteration Limit: 50
+
+    LOCA: 
+      Bifurcation: { }
+      Constraints: { }
+      Predictor: 
+        First Step Predictor: { }
+        Last Step Predictor: { }
+      Step Size: { }
+      Stepper: 
+        Eigensolver: { }
+    NOX: 
+      Direction: 
+        Method: Newton
+        Newton: 
+          Forcing Term Method: Constant
+          Rescue Bad Newton Solve: true
+          Stratimikos Linear Solver: 
+            NOX Stratimikos Options: { }
+            Stratimikos: 
+              Linear Solver Type: AztecOO
+              Linear Solver Types: 
+                AztecOO: 
+                  Forward Solve: 
+                    AztecOO Settings: 
+                      Aztec Solver: GMRES
+                      Convergence Test: r0
+                      Size of Krylov Subspace: 200
+                      Output Frequency: 10
+                    Max Iterations: 200
+                    Tolerance: 1.0e-07
+                Belos: 
+                  Solver Type: Block GMRES
+                  Solver Types: 
+                    Block GMRES: 
+                      Convergence Tolerance: 9.99999999999999955e-08
+                      Output Frequency: 10
+                      Output Style: 1
+                      Verbosity: 33
+                      Maximum Iterations: 100
+                      Block Size: 1
+                      Num Blocks: 50
+                      Flexible Gmres: false
+              Preconditioner Type: Ifpack2
+              Preconditioner Types: 
+                Ifpack2: 
+                  Overlap: 1
+                  Prec Type: RILUK
+                  Ifpack2 Settings: 
+                    'fact: drop tolerance': 0.00000000000000000e+00
+                    'fact: iluk level-of-fill': 0
+      Line Search: 
+        Full Step: 
+          Full Step: 1.00000000000000000e+00
+        Method: Full Step
+      Nonlinear Solver: Line Search Based
+      Printing: 
+        Output Information: 103
+        Output Precision: 3
+      Solver Options: 
+        Status Test Check Type: Minimal
+...

--- a/PyAlbany/python/Utils.py
+++ b/PyAlbany/python/Utils.py
@@ -34,6 +34,10 @@ def createAlbanyProblem(filename, parallelEnv):
     """@brief Creates an Albany problem given a yaml file and a parallel environment."""
     return wpa.PyProblem(filename, parallelEnv)
 
+def createParameterList(filename, parallelEnv):
+    """@brief Creates a parameter list from a file."""
+    return wpa.getParameterList(filename, parallelEnv)
+
 def loadMVector(filename, n_cols, map, distributedFile = True, useBinary = True, readOnRankZero = True, dtype="d"):
     """@brief Loads distributed a multivector stored using numpy format.
     

--- a/PyAlbany/src/Albany_Interface.cpp
+++ b/PyAlbany/src/Albany_Interface.cpp
@@ -229,11 +229,20 @@ void PyProblem::setDirections(const int p_index, Teuchos::RCP<PyTrilinosMultiVec
 
 void PyProblem::setParameter(const int p_index, Teuchos::RCP<PyTrilinosVector> p)
 {
-    TEUCHOS_TEST_FOR_EXCEPTION(inverseHasBeenSolved, std::runtime_error,
-                               "Error! parameter values cannot be changed "
-                               "once the inverse problem has been solved.\n");
+    RCP<Teuchos::ParameterList> appParams = slvrfctry->getParameters();
+    if (appParams->isSublist("Piro"))
+    {
+        RCP<Teuchos::ParameterList> piroParams = Teuchos::sublist(appParams, "Piro");
+        if (piroParams->isSublist("Optimization Status"))
+        {
+            RCP<Teuchos::ParameterList> optimizationParams =
+                Teuchos::sublist(piroParams, "Optimization Status");
+            optimizationParams->set<bool>("Compute State", true);
+        }
+    }
 
     forwardHasBeenSolved = false;
+    inverseHasBeenSolved = false;
 
     for (size_t l = 0; l < solver->Np(); l++)
     {

--- a/PyAlbany/tests/small/SteadyHeat/CMakeLists.txt
+++ b/PyAlbany/tests/small/SteadyHeat/CMakeLists.txt
@@ -14,8 +14,32 @@ set_tests_properties(PyAlbany_SteadyHeat
     PROPERTIES ENVIRONMENT "${PYALBANY_PYTHONPATH}")
 
 IF(ALBANY_MPI)
-  add_test(PyAlbany_SteadyHeat_MPI "${MPIEX}" "${MPINPF}" "${ALBANY_PYTHON_N_MPI}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/steadyHeat.py")
+    add_test(PyAlbany_SteadyHeat_MPI "${MPIEX}" "${MPINPF}" "${ALBANY_PYTHON_N_MPI}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/steadyHeat.py")
 
-  set_tests_properties(PyAlbany_SteadyHeat_MPI
-      PROPERTIES ENVIRONMENT "${PYALBANY_PYTHONPATH}")
+    set_tests_properties(PyAlbany_SteadyHeat_MPI
+        PROPERTIES ENVIRONMENT "${PYALBANY_PYTHONPATH}")
+ENDIF()
+
+add_test(PyAlbany_Inv_SteadyHeat "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/inv_steadyHeat.py")
+
+set_tests_properties(PyAlbany_Inv_SteadyHeat
+    PROPERTIES ENVIRONMENT "${PYALBANY_PYTHONPATH}")
+
+IF(ALBANY_MPI)
+    add_test(PyAlbany_Inv_SteadyHeat_MPI "${MPIEX}" "${MPINPF}" "${ALBANY_PYTHON_N_MPI}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/inv_steadyHeat.py")
+
+    set_tests_properties(PyAlbany_Inv_SteadyHeat_MPI
+        PROPERTIES ENVIRONMENT "${PYALBANY_PYTHONPATH}")
+ENDIF()
+
+add_test(PyAlbany_multiple_SteadyHeat "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/inv_steadyHeat.py")
+
+set_tests_properties(PyAlbany_multiple_SteadyHeat
+    PROPERTIES ENVIRONMENT "${PYALBANY_PYTHONPATH}")
+
+IF(ALBANY_MPI)
+    add_test(PyAlbany_multiple_SteadyHeat_MPI "${MPIEX}" "${MPINPF}" "${ALBANY_PYTHON_N_MPI}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/inv_steadyHeat.py")
+
+    set_tests_properties(PyAlbany_multiple_SteadyHeat_MPI
+        PROPERTIES ENVIRONMENT "${PYALBANY_PYTHONPATH}")
 ENDIF()

--- a/PyAlbany/tests/small/SteadyHeat/input_dirichlet_mixed_paramsT.yaml
+++ b/PyAlbany/tests/small/SteadyHeat/input_dirichlet_mixed_paramsT.yaml
@@ -1,0 +1,273 @@
+%YAML 1.1
+---
+ANONYMOUS:
+  Build Type: Tpetra
+  Problem: 
+    Name: Heat 2D
+    Compute Sensitivities: true
+    Dirichlet BCs: 
+      DBC on NS NodeSet0 for DOF T prescribe Field: dirichlet_field
+      DBC on NS NodeSet2 for DOF T: 0.00000000000000000e+00
+      DBC on NS NodeSet1 for DOF T: -1.00000000000000000e+00
+    Parameters:
+      Number Of Parameters: 2
+      Parameter 0:
+        Type: Scalar
+        Name: DBC on NS NodeSet2 for DOF T
+        Lower Bound: -2.00000000000000000e+00
+        Upper Bound: 2.00000000000000000e+00
+      Parameter 1:
+        Type: Distributed
+        Name: dirichlet_field
+        Lower Bound: -1.00000000000000000e+00
+        Upper Bound: 2.00000000000000000e+00
+        Initial Uniform Value: -5.00000000000000000e-01
+    Hessian:
+      Use AD for Hessian-vector products (default): true
+      Response 0:
+        Reconstruct H_pp: false
+    Response Functions: 
+      Number Of Responses: 1
+      Response 0:
+        Type: Scalar Response
+        Name: Squared L2 Difference Source ST Target PST
+        Field Rank: Scalar
+        Source Field Name: Temperature
+        Target Value: 0.0
+  Discretization: 
+    1D Elements: 40
+    2D Elements: 40
+    Method: STK2D
+    Exodus Output File Name: steady2d.exo
+    Cubature Degree: 9
+  Regression For Response 0:
+    Test Value: 3.53554196849000024e-01
+    Relative Tolerance: 1.0e-03
+    Absolute Tolerance: 1.0e-04
+    Sensitivity For Parameter 0:
+      Test Value: -1.98119937831999993e-01
+    Sensitivity For Parameter 1:
+      Test Value: 6.39756401689000054e-02
+    Number of Piro Analysis Comparisons: 1
+    Piro Analysis Test Two Norm: true
+    Piro Analysis Test Values: [20.3598]
+  Piro: 
+    Sensitivity Method: Adjoint
+    Analysis: 
+      Analysis Package: ROL
+      ROL: 
+        Number Of Parameters: 2
+        Check Gradient: false
+        Gradient Tolerance: 1.0e-04
+        Step Tolerance: 1.0e-04
+        Print Output: true
+        Parameter Initial Guess Type: From Model Evaluator
+        Uniform Parameter Guess: 0.0e+00
+        Min And Max Of Random Parameter Guess: [-1.0e+00, 2.0e+00]
+        Bound Constrained: true
+
+        Full Space: false
+        Hessian Dot Product: false
+        Use NOX Solver: true
+        
+        Step Method: "Line Search"
+        bound_eps: 1.0e-01
+        Max Iterations: 5
+
+        ROL Options: 
+        # ===========  SIMOPT SOLVER PARAMETER SUBLIST  =========== 
+          SimOpt:
+            Solve:
+              Absolute Residual Tolerance:   1.0e-6
+              Relative Residual Tolerance:   1.0e-1
+              Iteration Limit:               20
+              Sufficient Decrease Tolerance: 1.e-4
+              Step Tolerance:                1.e-8
+              Backtracking Factor:           0.5
+              Output Iteration History:      false
+              Zero Initial Guess:            false
+              Solver Type:                   0    
+          
+          Status Test: 
+            Gradient Tolerance: 1.0e-4
+            Constraint Tolerance: 1.0e-5
+            Step Tolerance: 1.0e-10
+            Iteration Limit: 5
+
+          General: 
+            Variable Objective Function: false
+            Scale for Epsilon Active Sets: 1.00000000000000000e+00
+            Inexact Objective Function: false
+            Inexact Gradient: false
+            Inexact Hessian-Times-A-Vector: true
+            Projected Gradient Criticality Measure: false
+            Secant: 
+              Type: Limited-Memory BFGS
+              Use as Preconditioner: false
+              Use as Hessian: true
+              Maximum Storage: 50
+              Barzilai-Borwein Type: 1
+            Krylov: 
+              Type: Conjugate Gradients
+              Absolute Tolerance: 1.00000000000000005e-04
+              Relative Tolerance: 1.00000000000000002e-02
+              Iteration Limit: 100
+
+          Step:
+            Type: "Augmented Lagrangian" #"Moreau-Yosida Penalty" 
+            Line Search: 
+              Function Evaluation Limit: 60
+              Sufficient Decrease Tolerance: 9.99999999999999945e-21
+              Initial Step Size: 1.00000000000000000e+00
+              User Defined Initial Step Size: false
+              Accept Linesearch Minimizer: false
+              Accept Last Alpha: false
+              Descent Method: 
+                Type: Quasi-Newton
+                Nonlinear CG Type: Hestenes-Stiefel
+              Curvature Condition: 
+                Type: Strong Wolfe Conditions
+                General Parameter: 9.00000000000000022e-01
+                Generalized Wolfe Parameter: 5.99999999999999978e-01
+              Line-Search Method: 
+                Type: Cubic Interpolation
+                Backtracking Rate: 5.00000000000000000e-01
+                Bracketing Tolerance: 1.00000000000000002e-08
+                Path-Based Target Level: 
+                  Target Relaxation Parameter: 1.00000000000000000e+00
+                  Upper Bound on Path Length: 1.00000000000000000e+00
+            Trust Region: 
+              Subproblem Solver: Truncated CG
+              Initial Radius: 1.00000000000000000e+01
+              Maximum Radius: 5.00000000000000000e+03
+              Step Acceptance Threshold: 5.00000000000000028e-02
+              Radius Shrinking Threshold: 5.00000000000000028e-02
+              Radius Growing Threshold: 9.00000000000000022e-01
+              Radius Shrinking Rate (Negative rho): 6.25000000000000000e-02
+              Radius Shrinking Rate (Positive rho): 2.50000000000000000e-01
+              Radius Growing Rate: 2.50000000000000000e+00
+              Safeguard Size: 1.00000000000000000e+08
+              Inexact: 
+                Value: 
+                  Tolerance Scaling: 1.00000000000000006e-01
+                  Exponent: 9.00000000000000022e-01
+                  Forcing Sequence Initial Value: 1.00000000000000000e+00
+                  Forcing Sequence Update Frequency: 10
+                  Forcing Sequence Reduction Factor: 1.00000000000000006e-01
+                Gradient: 
+                  Tolerance Scaling: 1.00000000000000006e-01
+                  Relative Tolerance: 2.00000000000000000e+00
+
+            Moreau-Yosida Penalty:
+              # ===========  PENALTY PARAMETER UPDATE  =========== 
+              Initial Penalty Parameter: 1.0e+2
+              Penalty Parameter Growth Factor: 1.0
+
+              # ===========  SUBPROBLEM SOLVER  =========== 
+              Subproblem:
+                Optimality Tolerance: 1.e-4
+                Feasibility Tolerance: 1.e-5
+                Print History: true
+                Iteration Limit: 1
+
+            # ===========  COMPOSITE STEP  =========== -->
+            Composite Step:
+              Output Level: 2
+              #Initial Radius: 1.0e+2
+              Use Constraint Hessian: false
+              
+              # ===========  OPTIMALITY SYSTEM SOLVER  =========== -->
+              Optimality System Solver:
+                Nominal Relative Tolerance: 2.0e-1
+                Fix Tolerance: true
+      
+              # ===========  TANGENTIAL SUBPROBLEM SOLVER  =========== -->
+              Tangential Subproblem Solver:
+                Iteration Limit: 100
+                Relative Tolerance: 1.0e-2
+
+            # ===========  AUGMENTED LAGRANGIAN  =========== 
+            Augmented Lagrangian:
+              Level of Hessian Approximation: 0
+              #  ===========  PROBLEM SCALING =========== 
+              Use Default Problem Scaling: false
+              Objective Scaling: 1.e+01
+              Constraint Scaling: 1.e+0
+              # ===========  PENALTY PARAMETER UPDATE  =========== 
+              Use Default Initial Penalty Parameter: true
+              Initial Penalty Parameter: 1.e+1
+              Penalty Parameter Growth Factor: 1.e+1
+              Minimum Penalty Parameter Reciprocal: 0.1
+              # ===========  OPTIMALITY TOLERANCE UPDATE  =========== 
+              Initial Optimality Tolerance: 1.0
+              Optimality Tolerance Update Exponent: 1.0
+              Optimality Tolerance Decrease Exponent: 1.0
+              # ==========  FEASIBILITY TOLERANCE UPDATE  =========== 
+              Initial Feasibility Tolerance: 1.0
+              Feasibility Tolerance Update Exponent: 0.1
+              Feasibility Tolerance Decrease Exponent: 0.9
+              # ===========  SUBPROBLEM SOLVER  =========== 
+              Print Intermediate Optimization History: false
+              Subproblem Step Type: "Trust Region"
+              Subproblem Iteration Limit: 50
+
+    LOCA: 
+      Bifurcation: { }
+      Constraints: { }
+      Predictor: 
+        First Step Predictor: { }
+        Last Step Predictor: { }
+      Step Size: { }
+      Stepper: 
+        Eigensolver: { }
+    NOX: 
+      Direction: 
+        Method: Newton
+        Newton: 
+          Forcing Term Method: Constant
+          Rescue Bad Newton Solve: true
+          Stratimikos Linear Solver: 
+            NOX Stratimikos Options: { }
+            Stratimikos: 
+              Linear Solver Type: AztecOO
+              Linear Solver Types: 
+                AztecOO: 
+                  Forward Solve: 
+                    AztecOO Settings: 
+                      Aztec Solver: GMRES
+                      Convergence Test: r0
+                      Size of Krylov Subspace: 200
+                      Output Frequency: 10
+                    Max Iterations: 200
+                    Tolerance: 1.0e-07
+                Belos: 
+                  Solver Type: Block GMRES
+                  Solver Types: 
+                    Block GMRES: 
+                      Convergence Tolerance: 9.99999999999999955e-08
+                      Output Frequency: 10
+                      Output Style: 1
+                      Verbosity: 33
+                      Maximum Iterations: 100
+                      Block Size: 1
+                      Num Blocks: 50
+                      Flexible Gmres: false
+              Preconditioner Type: Ifpack2
+              Preconditioner Types: 
+                Ifpack2: 
+                  Overlap: 1
+                  Prec Type: RILUK
+                  Ifpack2 Settings: 
+                    'fact: drop tolerance': 0.00000000000000000e+00
+                    'fact: iluk level-of-fill': 0
+      Line Search: 
+        Full Step: 
+          Full Step: 1.00000000000000000e+00
+        Method: Full Step
+      Nonlinear Solver: Line Search Based
+      Printing: 
+        Output Information: 103
+        Output Precision: 3
+      Solver Options: 
+        Status Test Check Type: Minimal
+...

--- a/PyAlbany/tests/small/SteadyHeat/inv_steadyHeat.py
+++ b/PyAlbany/tests/small/SteadyHeat/inv_steadyHeat.py
@@ -36,6 +36,7 @@ class TestSteadyHeat(unittest.TestCase):
 
         g_target_before = 0.35681844
         g_target_after = 0.17388298
+        g_target_2 = 0.19570272
         p_0_target = 0.39886689
         p_1_norm_target = 5.37319376038225
         tol = 1e-8
@@ -68,6 +69,18 @@ class TestSteadyHeat(unittest.TestCase):
         if rank == 0:
             self.assertTrue(np.abs(response_before_analysis[0] - g_target_before) < tol)
             self.assertTrue(np.abs(response_after_analysis[0] - g_target_after) < tol)
+
+        parameter_map_0 = problem.getParameterMap(0)
+        para_0_new = Tpetra.Vector(parameter_map_0, dtype="d")
+        para_0_new[:] = 0.0
+        problem.setParameter(0, para_0_new)
+
+        problem.performSolve()
+
+        response = problem.getResponse(0)
+        print("Response after setParameter " + str(response.getData()))
+        if rank == 0:
+            self.assertTrue(np.abs(response[0] - g_target_2) < tol)
 
     @classmethod
     def tearDownClass(cls):

--- a/PyAlbany/tests/small/SteadyHeat/inv_steadyHeat.py
+++ b/PyAlbany/tests/small/SteadyHeat/inv_steadyHeat.py
@@ -1,0 +1,79 @@
+from PyTrilinos import Tpetra
+from PyTrilinos import Teuchos
+
+import unittest
+import numpy as np
+
+try:
+    from PyAlbany import Utils
+except:
+    import Utils
+import os
+
+
+class TestSteadyHeat(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.comm = Teuchos.DefaultComm.getComm()
+        cls.parallelEnv = Utils.createDefaultParallelEnv(cls.comm)
+
+    def test_all(self):
+        cls = self.__class__
+        rank = cls.comm.getRank()
+
+        file_dir = os.path.dirname(__file__)
+
+        # Create an Albany problem:
+        filename = "input_dirichlet_mixed_paramsT.yaml"
+        parameter = Utils.createParameterList(
+            file_dir + "/" + filename, cls.parallelEnv
+        )
+
+        parameter.sublist("Discretization").set("1D Elements", 10)
+        parameter.sublist("Discretization").set("2D Elements", 10)
+
+        problem = Utils.createAlbanyProblem(parameter, cls.parallelEnv)
+
+        g_target_before = 0.35681844
+        g_target_after = 0.17388298
+        p_0_target = 0.39886689
+        p_1_norm_target = 5.37319376038225
+        tol = 1e-8
+
+        problem.performSolve()
+
+        response_before_analysis = problem.getResponse(0)
+
+        problem.performAnalysis()
+
+        para_0 = problem.getParameter(0)
+        para_1 = problem.getParameter(1)
+
+        print(para_0.getData())
+        print(para_1.getData())
+
+        para_1_norm = Utils.norm(para_1.getData(), cls.comm)
+        print(para_1_norm)
+
+        if rank == 0:
+            self.assertTrue(np.abs(para_0[0] - p_0_target) < tol)
+            self.assertTrue(np.abs(para_1_norm - p_1_norm_target) < tol)
+
+        problem.performSolve()
+
+        response_after_analysis = problem.getResponse(0)
+
+        print("Response before analysis " + str(response_before_analysis.getData()))
+        print("Response after analysis " + str(response_after_analysis.getData()))
+        if rank == 0:
+            self.assertTrue(np.abs(response_before_analysis[0] - g_target_before) < tol)
+            self.assertTrue(np.abs(response_after_analysis[0] - g_target_after) < tol)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.parallelEnv = None
+        cls.comm = None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/PyAlbany/tests/small/SteadyHeat/multiple_runs_steadyHeat.py
+++ b/PyAlbany/tests/small/SteadyHeat/multiple_runs_steadyHeat.py
@@ -1,0 +1,75 @@
+from PyTrilinos import Tpetra
+from PyTrilinos import Teuchos
+
+import unittest
+import numpy as np
+
+try:
+    from PyAlbany import Utils
+except:
+    import Utils
+import os
+
+
+class TestSteadyHeat(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.comm = Teuchos.DefaultComm.getComm()
+        cls.parallelEnv = Utils.createDefaultParallelEnv(cls.comm)
+
+    def test_all(self):
+        cls = self.__class__
+        rank = cls.comm.getRank()
+
+        file_dir = os.path.dirname(__file__)
+
+        # Create an Albany problem:
+        filename = "input_dirichlet_mixed_paramsT.yaml"
+        parameter = Utils.createParameterList(
+            file_dir + "/" + filename, cls.parallelEnv
+        )
+
+        parameter.sublist("Discretization").set("1D Elements", 10)
+        parameter.sublist("Discretization").set("2D Elements", 10)
+
+        problem = Utils.createAlbanyProblem(parameter, cls.parallelEnv)
+
+        parameter_map_0 = problem.getParameterMap(0)
+        para_0_new = Tpetra.Vector(parameter_map_0, dtype="d")
+
+        parameter_map_1 = problem.getParameterMap(1)
+        para_1_new = Tpetra.Vector(parameter_map_1, dtype="d")
+        para_1_new[:] = 0.333333
+
+        n_values = 5
+        para_0_values = np.linspace(-1, 1, n_values)
+        responses = np.zeros((n_values,))
+
+        responses_target = np.array(
+            [0.69247527, 0.48990929, 0.35681844, 0.29320271, 0.2990621]
+        )
+        tol = 1e-8
+
+        for i in range(0, n_values):
+            para_0_new[:] = para_0_values[i]
+            problem.setParameter(0, para_0_new)
+
+            problem.performSolve()
+
+            response = problem.getResponse(0)
+            responses[i] = response.getData()[0]
+
+        print("p = " + str(para_0_values))
+        print("QoI = " + str(responses))
+
+        if rank == 0:
+            self.assertTrue(np.abs(np.amax(responses - responses_target)) < tol)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.parallelEnv = None
+        cls.comm = None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -322,6 +322,20 @@ ModelEvaluator (const Teuchos::RCP<Albany::Application>&    app_,
   timer = Teuchos::TimeMonitor::getNewTimer("Albany: Total Fill Time");
 }
 
+void ModelEvaluator::setNominalValue(int j, Teuchos::RCP<Thyra_Vector> p)
+{
+  TEUCHOS_TEST_FOR_EXCEPTION(
+      j >= num_param_vecs + num_dist_param_vecs || j < 0,
+      Teuchos::Exceptions::InvalidParameter,
+      std::endl
+          << "Error!  Albany::ModelEvaluator::setNominalValue():  "
+          << "Invalid parameter index j = "
+          << j
+          << std::endl);
+
+  nominalValues.set_p(j, p);
+}
+
 void ModelEvaluator::allocateVectors()
 {
   const Teuchos::RCP<const Thyra_MultiVector>   xMV  = app->getAdaptSolMgr()->getCurrentSolution();

--- a/src/Albany_ModelEvaluator.hpp
+++ b/src/Albany_ModelEvaluator.hpp
@@ -68,6 +68,9 @@ public:
   //! Create Hessian operator
   Teuchos::RCP<Thyra_LinearOp>  create_hess_g_pp( int j, int l1, int l2 ) const;
 
+  //! Set nominal value
+  void setNominalValue(int j, Teuchos::RCP<Thyra_Vector> p);
+
   //! Create InArgs
   Thyra_InArgs createInArgs() const;
 


### PR DESCRIPTION
This PR updates PyAlbany to add the following capabilities:

1. Add the possibility to create a PyAlbany problem using a `Teuchos::ParameterList` illustrated as follows (and as discussed with @bartgol ):
```
        filename = "input_dirichlet_mixed_paramsT.yaml"
        parameter = Utils.createParameterList(
            filename, parallelEnv
        )

        parameter.sublist("Discretization").set("1D Elements", 10)
        parameter.sublist("Discretization").set("2D Elements", 10)

        problem = Utils.createAlbanyProblem(parameter, parallelEnv)
```

2. Add the possibility to solve the inverse problem as follows:
```
        problem.performAnalysis()
```
It is then possible to access the parameter values as follows:
```
        para_0 = problem.getParameter(0)
```
Or even to compute sensitivity values and reduced Hessian evaluated at the last point of the optimization problem using:
```
        problem.performSolve()
```
3. Add the possibility to specify the values of the parameter where the response, the sensitivity values, and the reduced Hessian vector-product must be evaluated:
```
        problem.setParameter(0, para_0_new)
```
This allows to loop over samples and evaluate the model without creating a new one as follows:
```
        for i in range(0, n_values):
            para_0_new[:] = para_0_values[i]
            problem.setParameter(0, para_0_new)

            problem.performSolve()

            response = problem.getResponse(0)
            responses[i] = response.getData()[0]
```
There is, however, one known limitation, if the inverse problem of an instance of a PyAlbany problem has been solved,  we cannot manually change the values of the parameter. If needed, it is required to create a new instance of a PyAlbany problem and set the parameter for this second instance. If a user tries to set the parameter values after the solve of the inverse problem, an error is thrown.
 
All those capabilities are tested using ctest.

Finally, a Monte Carlo example has been added in PyAlbany/examples to illustrate the capability of looping over samples.
This example draws 200 samples of a uniform distribution, evaluates the forward problem for every of those samples, and draws a histogram of the random parameter, plots the samples and their corresponding quantity of interest value, and a histogram of the quantity of interest:

![UQ](https://user-images.githubusercontent.com/15634348/111176939-1056f180-85aa-11eb-98ca-f68701d34cb0.jpg)

@mperego @ikalash  