### PR TITLE
Sideset Refactor Cleanup - Phase 1

### DIFF
--- a/src/LandIce/evaluators/LandIce_BasalFrictionCoefficientGradient.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalFrictionCoefficientGradient.hpp
@@ -72,7 +72,6 @@ private:
   PHX::MDField<ScalarT>           grad_beta;           // Side, QuadPoint, Dim
 
   std::string basalSideName;
-  bool useCollapsedSidesets;
   Albany::LocalSideSetInfo sideSet;
 
   unsigned int numSideNodes;

--- a/src/LandIce/evaluators/LandIce_BasalFrictionCoefficientGradient_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalFrictionCoefficientGradient_Def.hpp
@@ -26,7 +26,7 @@ template<typename EvalT, typename Traits>
 BasalFrictionCoefficientGradient<EvalT, Traits>::
 BasalFrictionCoefficientGradient (const Teuchos::ParameterList& p,
                                   const Teuchos::RCP<Albany::Layouts>& dl) :
-  grad_beta (p.get<std::string> ("Basal Friction Coefficient Gradient Name"), (dl->useCollapsedSidesets && dl->isSideLayouts) ? dl->qp_gradient_sideset : dl->qp_gradient)
+  grad_beta (p.get<std::string> ("Basal Friction Coefficient Gradient Name"), dl->qp_gradient_sideset)
 {
 #ifdef OUTPUT_TO_SCREEN
   Teuchos::RCP<Teuchos::FancyOStream> output(Teuchos::VerboseObjectBase::getDefaultOStream());
@@ -38,8 +38,6 @@ BasalFrictionCoefficientGradient (const Teuchos::ParameterList& p,
 
   numSideQPs = dl->qp_gradient->extent(2);
   sideDim    = dl->qp_gradient->extent(3);
-
-  useCollapsedSidesets = dl->isSideLayouts && dl->useCollapsedSidesets;
 
   basalSideName = p.get<std::string>("Side Set Name");
   if (betaType == "GIVEN CONSTANT")
@@ -63,13 +61,13 @@ BasalFrictionCoefficientGradient (const Teuchos::ParameterList& p,
     given_field_name += "_" + basalSideName;;
 
     if (is_given_field_param) {
-      given_field_param = PHX::MDField<const ParamScalarT>(given_field_name, useCollapsedSidesets ? dl->node_scalar_sideset : dl->node_scalar);
+      given_field_param = PHX::MDField<const ParamScalarT>(given_field_name, dl->node_scalar_sideset);
       this->addDependentField (given_field_param);
     } else {
-      given_field = PHX::MDField<const RealType>(given_field_name, useCollapsedSidesets ? dl->node_scalar_sideset : dl->node_scalar);
+      given_field = PHX::MDField<const RealType>(given_field_name, dl->node_scalar_sideset);
       this->addDependentField (given_field);
     }
-    GradBF     = PHX::MDField<MeshScalarT>(p.get<std::string> ("Gradient BF Side Variable Name"), useCollapsedSidesets ? dl->node_qp_gradient_sideset : dl->node_qp_gradient);
+    GradBF     = PHX::MDField<MeshScalarT>(p.get<std::string> ("Gradient BF Side Variable Name"), dl->node_qp_gradient_sideset);
     this->addDependentField (GradBF);
 
     numSideNodes = dl->node_qp_gradient->extent(2);
@@ -87,11 +85,11 @@ BasalFrictionCoefficientGradient (const Teuchos::ParameterList& p,
 #endif
     beta_type = REGULARIZED_COULOMB;
 
-    N      = PHX::MDField<ParamScalarT>(p.get<std::string> ("Effective Pressure QP Name"), useCollapsedSidesets ? dl->qp_scalar_sideset : dl->qp_scalar);
-    U      = PHX::MDField<ScalarT>(p.get<std::string> ("Basal Velocity QP Name"), useCollapsedSidesets ? dl->qp_vector_sideset : dl->qp_vector);
-    gradN  = PHX::MDField<ScalarT>(p.get<std::string> ("Effective Pressure Gradient QP Name"), useCollapsedSidesets ? dl->qp_gradient_sideset : dl->qp_gradient);
-    gradU  = PHX::MDField<ScalarT>(p.get<std::string> ("Basal Velocity Gradient QP Name"), useCollapsedSidesets ? dl->qp_vecgradient_sideset : dl->qp_vecgradient);
-    u_norm = PHX::MDField<ScalarT>(p.get<std::string> ("Sliding Velocity QP Name"), useCollapsedSidesets ? dl->qp_scalar_sideset : dl->qp_scalar);
+    N      = PHX::MDField<ParamScalarT>(p.get<std::string> ("Effective Pressure QP Name"), dl->qp_scalar_sideset);
+    U      = PHX::MDField<ScalarT>(p.get<std::string> ("Basal Velocity QP Name"), dl->qp_vector_sideset);
+    gradN  = PHX::MDField<ScalarT>(p.get<std::string> ("Effective Pressure Gradient QP Name"), dl->qp_gradient_sideset);
+    gradU  = PHX::MDField<ScalarT>(p.get<std::string> ("Basal Velocity Gradient QP Name"), dl->qp_vecgradient_sideset);
+    u_norm = PHX::MDField<ScalarT>(p.get<std::string> ("Sliding Velocity QP Name"), dl->qp_scalar_sideset);
 
     muParam        = PHX::MDField<ScalarT,Dim>("Coulomb Friction Coefficient", dl->shared_param);
     lambdaParam    = PHX::MDField<ScalarT,Dim>("Bed Roughness", dl->shared_param);
@@ -127,7 +125,7 @@ BasalFrictionCoefficientGradient (const Teuchos::ParameterList& p,
   use_stereographic_map = stereographicMapList->get("Use Stereographic Map", false);
   if(use_stereographic_map)
   {
-    coordVec = PHX::MDField<const MeshScalarT>(p.get<std::string>("Coordinate Vector Variable Name"), useCollapsedSidesets ? dl->qp_coords_sideset : dl->qp_coords);
+    coordVec = PHX::MDField<const MeshScalarT>(p.get<std::string>("Coordinate Vector Variable Name"), dl->qp_coords_sideset);
 
     double R = stereographicMapList->get<double>("Earth Radius", 6371);
     x_0 = stereographicMapList->get<double>("X_0", 0);//-136);
@@ -231,7 +229,6 @@ void BasalFrictionCoefficientGradient<EvalT, Traits>::evaluateFields (typename T
       std::endl << "Error in LandIce::BasalFrictionCoefficientGradient: cannot compute the gradient of this type of beta.");
 
   if (workset.sideSetViews->find(basalSideName)==workset.sideSetViews->end()) return;
-
   if (memoizer.have_saved_data(workset,this->evaluatedFields())) return;
 
   if (beta_type==REGULARIZED_COULOMB)
@@ -243,99 +240,27 @@ void BasalFrictionCoefficientGradient<EvalT, Traits>::evaluateFields (typename T
 
   sideSet = workset.sideSetViews->at(basalSideName);
 
-  if (useCollapsedSidesets) {
-    switch (beta_type)
-    {
-      case GIVEN_CONSTANT:
-        grad_beta.deep_copy(0);
-        break;
-      case GIVEN_FIELD:
-        if (is_given_field_param) {
-          Kokkos::parallel_for(GivenFieldParam_Policy(0, sideSet.size), *this);
-        } else {
-          Kokkos::parallel_for(GivenField_Policy(0, sideSet.size), *this);
-        }
-        break;
-      case REGULARIZED_COULOMB:
-        Kokkos::parallel_for(RegularizedCoulomb_Policy(0, sideSet.size), *this);
-        break;
-      default:
-        TEUCHOS_TEST_FOR_EXCEPTION (true, Teuchos::Exceptions::InvalidParameter,
-              std::endl << "Error in LandIce::BasalFrictionCoefficientGradient: cannot compute the gradient of this type of beta.");
-    }
-    if (use_stereographic_map) {
-      Kokkos::parallel_for(StereographicMapCorrection_Policy(0, sideSet.size), *this);
-    }
+  switch (beta_type)
+  {
+    case GIVEN_CONSTANT:
+      grad_beta.deep_copy(0);
+      break;
+    case GIVEN_FIELD:
+      if (is_given_field_param) {
+        Kokkos::parallel_for(GivenFieldParam_Policy(0, sideSet.size), *this);
+      } else {
+        Kokkos::parallel_for(GivenField_Policy(0, sideSet.size), *this);
+      }
+      break;
+    case REGULARIZED_COULOMB:
+      Kokkos::parallel_for(RegularizedCoulomb_Policy(0, sideSet.size), *this);
+      break;
+    default:
+      TEUCHOS_TEST_FOR_EXCEPTION (true, Teuchos::Exceptions::InvalidParameter,
+            std::endl << "Error in LandIce::BasalFrictionCoefficientGradient: cannot compute the gradient of this type of beta.");
   }
-  else {
-    for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-    {
-      // Get the local data of side and cell
-      const int cell = sideSet.elem_LID(sideSet_idx);
-      const int side = sideSet.side_local_id(sideSet_idx);
-
-      switch (beta_type)
-      {
-        case GIVEN_CONSTANT:
-          for (unsigned int qp=0; qp<numSideQPs; ++qp)
-          {
-            for (unsigned int dim=0; dim<sideDim; ++dim)
-              grad_beta(cell,side,qp,dim) = 0.;
-          }
-          break;
-        case GIVEN_FIELD:
-          if (is_given_field_param) {
-            for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-              for (unsigned int dim=0; dim<sideDim; ++dim) {
-                grad_beta(cell,side,qp,dim) = 0.;
-                for (unsigned int node=0; node<numSideNodes; ++node) {
-                  grad_beta(cell,side,qp,dim) += GradBF(cell,side,node,qp,dim)*given_field_param(cell,side,node);
-            }}}
-          } else {
-            for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-              for (unsigned int dim=0; dim<sideDim; ++dim) {
-                grad_beta(cell,side,qp,dim) = 0.;
-                for (unsigned int node=0; node<numSideNodes; ++node) {
-                  grad_beta(cell,side,qp,dim) += GradBF(cell,side,node,qp,dim)*given_field(cell,side,node);
-            }}}
-          }
-          break;
-        case REGULARIZED_COULOMB:
-          for (unsigned int qp=0; qp<numSideQPs; ++qp)
-          {
-            ScalarT u_val      = u_norm(cell,side,qp);
-            ParamScalarT N_val = N(cell,side,qp);
-            ScalarT den        = u_val+lambda*std::pow(A*N_val,1./power);
-
-            ScalarT f_u = (power-1)*mu*N_val*std::pow(u_val,power-2)/std::pow(u_val+lambda*std::pow(A*N_val,1./power), power)
-                        - power*mu*N_val*std::pow(u_val,power-1)/std::pow(den, power+1);
-            ScalarT f_N = mu*std::pow(u_val,power-1)/std::pow(u_val+lambda*std::pow(A*N_val,1./power), power)
-                        - mu*N_val*std::pow(u_val,power-1)/std::pow(den, power+1)*lambda*std::pow(A*N_val,1./power-1)*A;
-            for (unsigned int dim=0; dim<sideDim; ++dim)
-            {
-              grad_beta(cell,side,qp,dim) = f_N*gradN(cell,side,qp,dim);
-              for (unsigned int comp=0; comp<vecDim; ++comp)
-                grad_beta(cell,side,qp,dim) += f_u * (U(cell,side,qp,comp)/u_val)*gradU(cell,side,qp,vecDim,dim);
-            }
-          }
-        default:
-          TEUCHOS_TEST_FOR_EXCEPTION (true, Teuchos::Exceptions::InvalidParameter,
-              std::endl << "Error in LandIce::BasalFrictionCoefficientGradient: cannot compute the gradient of this type of beta.");
-      }
-
-      // Correct the value if we are using a stereographic map
-      if (use_stereographic_map)
-      {
-        for (unsigned int qp=0; qp<numSideQPs; ++qp)
-        {
-          MeshScalarT x = coordVec(cell,side,qp,0) - x_0;
-          MeshScalarT y = coordVec(cell,side,qp,1) - y_0;
-          MeshScalarT h = 4.0*R2/(4.0*R2 + x*x + y*y);
-          for (unsigned int dim=0; dim<sideDim; ++dim)
-            grad_beta(cell,side,qp,dim) *= h*h;
-        }
-      }
-    }
+  if (use_stereographic_map) {
+    Kokkos::parallel_for(StereographicMapCorrection_Policy(0, sideSet.size), *this);
   }
 }
 

--- a/src/LandIce/evaluators/LandIce_BasalMeltRate.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalMeltRate.hpp
@@ -86,22 +86,16 @@ private:
 
   Albany::LocalSideSetInfo sideSet;
 
-  bool useCollapsedSidesets;
-
   public:
 
   typedef Kokkos::View<int***, PHX::Device>::execution_space ExecutionSpace;
 
   struct Basal_Melt_Rate_Tag{};
-  struct Basal_Melt_Rate_Collapsed_Tag{};
 
   typedef Kokkos::RangePolicy<ExecutionSpace,Basal_Melt_Rate_Tag> Basal_Melt_Rate_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Basal_Melt_Rate_Collapsed_Tag> Basal_Melt_Rate_Collapsed_Policy;
 
   KOKKOS_INLINE_FUNCTION
   void operator() (const Basal_Melt_Rate_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Basal_Melt_Rate_Collapsed_Tag& tag, const int& i) const;
 
 };
 

--- a/src/LandIce/evaluators/LandIce_BasalMeltRate_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalMeltRate_Def.hpp
@@ -20,41 +20,35 @@ namespace LandIce
 template<typename EvalT, typename Traits, typename VelocityST, typename MeltEnthST>
 BasalMeltRate<EvalT,Traits,VelocityST,MeltEnthST>::
 BasalMeltRate(const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>& dl_basal)
- : phi               (p.get<std::string> ("Water Content Side Variable Name"),(dl_basal->useCollapsedSidesets) ? dl_basal->node_scalar_sideset : dl_basal->node_scalar)
- , beta              (p.get<std::string> ("Basal Friction Coefficient Side Variable Name"),(dl_basal->useCollapsedSidesets) ? dl_basal->node_scalar_sideset : dl_basal->node_scalar)
- , velocity          (p.get<std::string> ("Velocity Side Variable Name"),(dl_basal->useCollapsedSidesets) ? dl_basal->node_vector_sideset : dl_basal->node_vector)
- , geoFluxHeat       (p.get<std::string> ("Geothermal Flux Side Variable Name"),(dl_basal->useCollapsedSidesets) ? dl_basal->node_scalar_sideset : dl_basal->node_scalar)
- , Enthalpy          (p.get<std::string> ("Enthalpy Side Variable Name"),(dl_basal->useCollapsedSidesets) ? dl_basal->node_scalar_sideset : dl_basal->node_scalar)
- , EnthalpyHs        (p.get<std::string> ("Enthalpy Hs Side Variable Name"),(dl_basal->useCollapsedSidesets) ? dl_basal->node_scalar_sideset : dl_basal->node_scalar)
+ : phi               (p.get<std::string> ("Water Content Side Variable Name"),dl_basal->node_scalar_sideset)
+ , beta              (p.get<std::string> ("Basal Friction Coefficient Side Variable Name"),dl_basal->node_scalar_sideset)
+ , velocity          (p.get<std::string> ("Velocity Side Variable Name"),dl_basal->node_vector_sideset)
+ , geoFluxHeat       (p.get<std::string> ("Geothermal Flux Side Variable Name"),dl_basal->node_scalar_sideset)
+ , Enthalpy          (p.get<std::string> ("Enthalpy Side Variable Name"),dl_basal->node_scalar_sideset)
+ , EnthalpyHs        (p.get<std::string> ("Enthalpy Hs Side Variable Name"),dl_basal->node_scalar_sideset)
  , homotopy          (p.get<std::string> ("Continuation Parameter Name"),dl_basal->shared_param)
- , enthalpyBasalFlux     (p.get<std::string> ("Basal Melt Rate Variable Name"), (dl_basal->useCollapsedSidesets) ? dl_basal->node_scalar_sideset : dl_basal->node_scalar)
- , basalVertVelocity (p.get<std::string> ("Basal Vertical Velocity Variable Name"),(dl_basal->useCollapsedSidesets) ? dl_basal->node_scalar_sideset : dl_basal->node_scalar)
+ , enthalpyBasalFlux     (p.get<std::string> ("Basal Melt Rate Variable Name"), dl_basal->node_scalar_sideset)
+ , basalVertVelocity (p.get<std::string> ("Basal Vertical Velocity Variable Name"),dl_basal->node_scalar_sideset)
 {
   nodal = p.isParameter("Nodal") ? p.get<bool>("Nodal") : false;
-  Teuchos::RCP<PHX::DataLayout> scalar_layout, scalar_sideset_layout, vector_layout, vector_sideset_layout;
+  Teuchos::RCP<PHX::DataLayout> scalar_layout, vector_layout;
   if (nodal) {
-    scalar_layout = dl_basal->node_scalar;
-    scalar_sideset_layout = dl_basal->node_scalar_sideset;
-    vector_layout = dl_basal->node_vector;
-    vector_sideset_layout = dl_basal->node_vector_sideset;
+    scalar_layout = dl_basal->node_scalar_sideset;
+    vector_layout = dl_basal->node_vector_sideset;
   } else {
-    scalar_layout = dl_basal->qp_scalar;
-    scalar_sideset_layout = dl_basal->qp_scalar_sideset;
-    vector_layout = dl_basal->qp_vector;
-    vector_sideset_layout = dl_basal->qp_vector_sideset;
+    scalar_layout = dl_basal->qp_scalar_sideset;
+    vector_layout = dl_basal->qp_vector_sideset;
   }
 
-  useCollapsedSidesets = dl_basal->useCollapsedSidesets;
-
-  phi = decltype(phi)(p.get<std::string> ("Water Content Side Variable Name"),(useCollapsedSidesets) ? scalar_sideset_layout : scalar_layout);
-  beta = decltype(beta)(p.get<std::string> ("Basal Friction Coefficient Side Variable Name"),(useCollapsedSidesets) ? scalar_sideset_layout : scalar_layout);
-  velocity = decltype(velocity)(p.get<std::string> ("Velocity Side Variable Name"),(useCollapsedSidesets) ? vector_sideset_layout : vector_layout);
-  geoFluxHeat = decltype(geoFluxHeat)(p.get<std::string> ("Geothermal Flux Side Variable Name"),(useCollapsedSidesets) ? scalar_sideset_layout : scalar_layout);
-  Enthalpy = decltype(Enthalpy)(p.get<std::string> ("Enthalpy Side Variable Name"),(useCollapsedSidesets) ? scalar_sideset_layout : scalar_layout);
-  EnthalpyHs = decltype(EnthalpyHs)(p.get<std::string> ("Enthalpy Hs Side Variable Name"),(useCollapsedSidesets) ? scalar_sideset_layout : scalar_layout);
+  phi = decltype(phi)(p.get<std::string> ("Water Content Side Variable Name"),scalar_layout);
+  beta = decltype(beta)(p.get<std::string> ("Basal Friction Coefficient Side Variable Name"),scalar_layout);
+  velocity = decltype(velocity)(p.get<std::string> ("Velocity Side Variable Name"),vector_layout);
+  geoFluxHeat = decltype(geoFluxHeat)(p.get<std::string> ("Geothermal Flux Side Variable Name"),scalar_layout);
+  Enthalpy = decltype(Enthalpy)(p.get<std::string> ("Enthalpy Side Variable Name"),scalar_layout);
+  EnthalpyHs = decltype(EnthalpyHs)(p.get<std::string> ("Enthalpy Hs Side Variable Name"),scalar_layout);
   homotopy = decltype(homotopy)(p.get<std::string> ("Continuation Parameter Name"),dl_basal->shared_param);
-  enthalpyBasalFlux = decltype(enthalpyBasalFlux)(p.get<std::string> ("Basal Melt Rate Variable Name"),(useCollapsedSidesets) ? scalar_sideset_layout : scalar_layout);
-  basalVertVelocity = decltype(basalVertVelocity)(p.get<std::string> ("Basal Vertical Velocity Variable Name"),(useCollapsedSidesets) ? scalar_sideset_layout : scalar_layout);
+  enthalpyBasalFlux = decltype(enthalpyBasalFlux)(p.get<std::string> ("Basal Melt Rate Variable Name"),scalar_layout);
+  basalVertVelocity = decltype(basalVertVelocity)(p.get<std::string> ("Basal Vertical Velocity Variable Name"),scalar_layout);
 
   this->addDependentField(phi);
   this->addDependentField(geoFluxHeat);
@@ -118,7 +112,7 @@ postRegistrationSetup(typename Traits::SetupData d, PHX::FieldManager<Traits>& f
 template<typename EvalT, typename Traits, typename VelocityST, typename MeltEnthST>
 KOKKOS_INLINE_FUNCTION
 void BasalMeltRate<EvalT,Traits,VelocityST,MeltEnthST>::
-operator() (const Basal_Melt_Rate_Collapsed_Tag& tag, const int& sideSet_idx) const {
+operator() (const Basal_Melt_Rate_Tag& tag, const int& sideSet_idx) const {
 
   const unsigned int numPts = nodal ? numSideNodes : numSideQPs;
 
@@ -148,130 +142,21 @@ operator() (const Basal_Melt_Rate_Collapsed_Tag& tag, const int& sideSet_idx) co
 }
 
 template<typename EvalT, typename Traits, typename VelocityST, typename MeltEnthST>
-KOKKOS_INLINE_FUNCTION
-void BasalMeltRate<EvalT,Traits,VelocityST,MeltEnthST>::
-operator() (const Basal_Melt_Rate_Tag& tag, const int& sideSet_idx) const {
-
-  const unsigned int numPts = nodal ? numSideNodes : numSideQPs;
-
-  // Get the local data of side and cell
-  const int cell = sideSet.elem_LID(sideSet_idx);
-  const int side = sideSet.side_local_id(sideSet_idx);
-
-  for (unsigned int node = 0; node < numPts; ++node) {
-    //always in presence of water on shelves (assuming that beta==0 <==> on shelves)
-    bool isThereWaterHere = isThereWater || (beta(cell,side,node) == 0.0);
-    ScalarT diffEnthalpy = Enthalpy(cell,side,node) - EnthalpyHs(cell,side,node);
-    ScalarT basal_reg_scale = (diffEnthalpy > 0 || !isThereWaterHere) ?  ScalarT(0.5 + 0.5*tanh(basal_reg_coeff * diffEnthalpy)) :
-                                                                        ScalarT(0.5 + 0.5* basal_reg_coeff * diffEnthalpy);
-                                                                  //    ScalarT(0.5 + 0.5* (0.5-0.5*std::pow(1-basal_reg_coeff * diffEnthalpy,2)));
-
-    //mstar, [W m^{-2}] = [Pa m s^{-1}]: basal latent heat in temperate ice
-    ScalarT mstar = geoFluxHeat(cell,side,node);
-    for (unsigned int dim = 0; dim < vecDimFO; dim++)
-      mstar += beta_scaling * beta(cell,side,node) * velocity(cell,side,node,dim) * velocity(cell,side,node,dim);
-
-    double dTdz_melting = beta_p * rho_i * g;
-    mstar += k_i * dTdz_melting;
-
-    enthalpyBasalFlux(cell,side,node) =  (basal_reg_scale-1) *mstar + k_i*dTdz_melting;
-
-    //ScalarT basal_water_flux = scyr * k_0 * (rho_w - rho_i) * g / eta_w * pow(phi(cell,side,node),alpha_om); //[m yr^{-1}]
-    ScalarT melting = scyr * basal_reg_scale * mstar / (L*rho_i); //[m yr^{-1}]
-    basalVertVelocity(cell,side,node) =  - melting /(1 - rho_w/rho_i*KU::min(phi(cell,side,node),0.5));
-  }
-
-}
-
-template<typename EvalT, typename Traits, typename VelocityST, typename MeltEnthST>
 void BasalMeltRate<EvalT,Traits,VelocityST,MeltEnthST>::
 evaluateFields(typename Traits::EvalData workset)
 {
   TEUCHOS_TEST_FOR_EXCEPTION (workset.sideSetViews==Teuchos::null, std::runtime_error,
                               "Side set views defined in input file but not properly specified on the mesh.\n");
+  if (workset.sideSetViews->find(basalSideName)==workset.sideSetViews->end()) return;
   if (memoizer.have_saved_data(workset,this->evaluatedFields())) return;
 
-  if (workset.sideSetViews->find(basalSideName) != workset.sideSetViews->end())
-  {
-    hom = homotopy(0);
-    basal_reg_coeff = basalMelt_reg_alpha*exp(basalMelt_reg_beta*hom); // [adim]
-    flux_reg_coeff = flux_reg_alpha*exp(flux_reg_beta*hom); // [adim]
+  hom = homotopy(0);
+  basal_reg_coeff = basalMelt_reg_alpha*exp(basalMelt_reg_beta*hom); // [adim]
+  flux_reg_coeff = flux_reg_alpha*exp(flux_reg_beta*hom); // [adim]
 
-    sideSet = workset.sideSetViews->at(basalSideName);
-  #ifdef ALBANY_KOKKOS_UNDER_DEVELOPMENT
-    if (useCollapsedSidesets) {
-      Kokkos::parallel_for(Basal_Melt_Rate_Collapsed_Policy(0, sideSet.size), *this);
-    } else {
-      Kokkos::parallel_for(Basal_Melt_Rate_Policy(0, sideSet.size), *this);
-    }
-  #else
-    const unsigned int numPts = nodal ? numSideNodes : numSideQPs;
+  sideSet = workset.sideSetViews->at(basalSideName);
 
-    if (useCollapsedSidesets) {
-      for (unsigned int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the local data of side and cell
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
-
-        for (unsigned int node = 0; node < numPts; ++node)
-        {
-          //always in presence of water on shelves (assuming that beta==0 <==> on shelves)
-          bool isThereWaterHere = isThereWater || (beta(sideSet_idx,node) == 0.0);
-          ScalarT diffEnthalpy = Enthalpy(sideSet_idx,node) - EnthalpyHs(sideSet_idx,node);
-          ScalarT basal_reg_scale = (diffEnthalpy > 0 || !isThereWaterHere) ?  ScalarT(0.5 + 0.5*tanh(basal_reg_coeff * diffEnthalpy)) :
-                                                                              ScalarT(0.5 + 0.5* basal_reg_coeff * diffEnthalpy);
-                                                                      //    ScalarT(0.5 + 0.5* (0.5-0.5*std::pow(1-basal_reg_coeff * diffEnthalpy,2)));
-
-          //mstar, [W m^{-2}] = [Pa m s^{-1}]: basal latent heat in temperate ice
-          ScalarT mstar = geoFluxHeat(sideSet_idx,node);
-          for (unsigned int dim = 0; dim < vecDimFO; dim++)
-            mstar += beta_scaling * beta(sideSet_idx,node) * velocity(sideSet_idx,node,dim) * velocity(sideSet_idx,node,dim);
-
-          double dTdz_melting = beta_p * rho_i * g;
-          mstar += k_i * dTdz_melting;
-
-          enthalpyBasalFlux(sideSet_idx,node) =  (basal_reg_scale-1) *mstar + k_i*dTdz_melting;
-
-          //ScalarT basal_water_flux = scyr * k_0 * (rho_w - rho_i) * g / eta_w * pow(phi(sideSet_idx,node),alpha_om); //[m yr^{-1}]
-          ScalarT melting = scyr * basal_reg_scale * mstar / (L*rho_i); //[m yr^{-1}]
-          basalVertVelocity(cell,side,node) =  - melting /(1 - rho_w/rho_i*std::min(phi(sideSet_idx,node),0.5));
-        }
-      }
-    } else {
-      for (unsigned int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the local data of side and cell
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
-
-        for (unsigned int node = 0; node < numPts; ++node)
-        {
-          //always in presence of water on shelves (assuming that beta==0 <==> on shelves)
-          bool isThereWaterHere = isThereWater || (beta(cell,side,node) == 0.0);
-          ScalarT diffEnthalpy = Enthalpy(cell,side,node) - EnthalpyHs(cell,side,node);
-          ScalarT basal_reg_scale = (diffEnthalpy > 0 || !isThereWaterHere) ?  ScalarT(0.5 + 0.5*tanh(basal_reg_coeff * diffEnthalpy)) :
-                                                                              ScalarT(0.5 + 0.5* basal_reg_coeff * diffEnthalpy);
-                                                                      //    ScalarT(0.5 + 0.5* (0.5-0.5*std::pow(1-basal_reg_coeff * diffEnthalpy,2)));
-
-          //mstar, [W m^{-2}] = [Pa m s^{-1}]: basal latent heat in temperate ice
-          ScalarT mstar = geoFluxHeat(cell,side,node);
-          for (unsigned int dim = 0; dim < vecDimFO; dim++)
-            mstar += beta_scaling * beta(cell,side,node) * velocity(cell,side,node,dim) * velocity(cell,side,node,dim);
-
-          double dTdz_melting = beta_p * rho_i * g;
-          mstar += k_i * dTdz_melting;
-
-          enthalpyBasalFlux(cell,side,node) =  (basal_reg_scale-1) *mstar + k_i*dTdz_melting;
-
-          //ScalarT basal_water_flux = scyr * k_0 * (rho_w - rho_i) * g / eta_w * pow(phi(cell,side,node),alpha_om); //[m yr^{-1}]
-          ScalarT melting = scyr * basal_reg_scale * mstar / (L*rho_i); //[m yr^{-1}]
-          basalVertVelocity(cell,side,node) =  - melting /(1 - rho_w/rho_i*std::min(phi(cell,side,node),0.5));
-        }
-      }
-    }
-  #endif 
-  }
+  Kokkos::parallel_for(Basal_Melt_Rate_Policy(0, sideSet.size), *this);
 }
 
 } //namespace LandIce

--- a/src/LandIce/evaluators/LandIce_DOFDivInterpolationSide.hpp
+++ b/src/LandIce/evaluators/LandIce_DOFDivInterpolationSide.hpp
@@ -55,8 +55,6 @@ private:
   unsigned int numSideQPs;
   unsigned int numDims;
 
-  bool useCollapsedSidesets;
-
   PHAL::MDFieldMemoizer<Traits> memoizer;
 
   Albany::LocalSideSetInfo sideSet;

--- a/src/LandIce/evaluators/LandIce_EnthalpyBasalResid.hpp
+++ b/src/LandIce/evaluators/LandIce_EnthalpyBasalResid.hpp
@@ -72,8 +72,6 @@ private:
   unsigned int sideDim;
   unsigned int vecDimFO;
 
-  bool useCollapsedSidesets;
-
   // double a;
   // double k_i;   //[W m^{-1} K^{-1}], Conductivity of ice
   // double beta_p;  //[K Pa^{-1}]
@@ -92,15 +90,11 @@ private:
   typedef Kokkos::View<int***, PHX::Device>::execution_space ExecutionSpace;
 
   struct Enthalpy_Basal_Residual_Tag{};
-  struct Enthalpy_Basal_Residual_Collapsed_Tag{};
 
   typedef Kokkos::RangePolicy<ExecutionSpace,Enthalpy_Basal_Residual_Tag> Enthalpy_Basal_Residual_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Enthalpy_Basal_Residual_Collapsed_Tag> Enthalpy_Basal_Residual_Collapsed_Policy;
 
   KOKKOS_INLINE_FUNCTION
   void operator() (const Enthalpy_Basal_Residual_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Enthalpy_Basal_Residual_Collapsed_Tag& tag, const int& i) const;
 
 };
 

--- a/src/LandIce/evaluators/LandIce_FluxDiv.hpp
+++ b/src/LandIce/evaluators/LandIce_FluxDiv.hpp
@@ -64,8 +64,6 @@ private:
   std::string sideSetName;
   unsigned int numSideQPs, numSideDims;
 
-  bool useCollapsedSidesets;
-
   PHAL::MDFieldMemoizer<Traits> memoizer;
 
   Albany::LocalSideSetInfo sideSet;

--- a/src/LandIce/evaluators/LandIce_GatherVerticallyContractedSolution.hpp
+++ b/src/LandIce/evaluators/LandIce_GatherVerticallyContractedSolution.hpp
@@ -64,8 +64,6 @@ protected:
 
   std::string meshPart;
 
-  bool useCollapsedSidesets;
-
   Teuchos::RCP<const CellTopologyData> cell_topo;
 
   ContractionOperator op;

--- a/src/LandIce/evaluators/LandIce_L2ProjectedBoundaryLaplacianResidual.hpp
+++ b/src/LandIce/evaluators/LandIce_L2ProjectedBoundaryLaplacianResidual.hpp
@@ -44,7 +44,6 @@ private:
   unsigned int sideDim;
 
   Albany::LocalSideSetInfo sideSet;
-  bool useCollapsedSidesets;
 
   // TODO: restore layout template arguments when removing old sideset layout
   PHX::MDField<const ScalarT,Cell,Node> solution;

--- a/src/LandIce/evaluators/LandIce_LaplacianRegularizationResidual.hpp
+++ b/src/LandIce/evaluators/LandIce_LaplacianRegularizationResidual.hpp
@@ -34,8 +34,10 @@ namespace LandIce {
 
   private:
 
+    Albany::LocalSideSetInfo sideSet;
+
     std::string sideName;
-    std::vector<std::vector<int> >  sideNodes;
+    Kokkos::View<int**, PHX::Device> sideNodes;
     Teuchos::RCP<shards::CellTopology> cellType;
     Teuchos::RCP<shards::CellTopology> sideType;
     
@@ -59,6 +61,21 @@ namespace LandIce {
 
     ScalarT p_reg, reg;
     double laplacian_coeff, mass_coeff, robin_coeff;
+
+  public:
+
+    typedef Kokkos::View<int***, PHX::Device>::execution_space ExecutionSpace;
+
+    struct LaplacianRegularization_Cell_Tag{};
+    struct LaplacianRegularization_Side_Tag{};
+
+    typedef Kokkos::RangePolicy<ExecutionSpace,LaplacianRegularization_Cell_Tag> LaplacianRegularization_Cell_Policy;
+    typedef Kokkos::RangePolicy<ExecutionSpace,LaplacianRegularization_Side_Tag> LaplacianRegularization_Side_Policy;
+
+    KOKKOS_INLINE_FUNCTION
+    void operator() (const LaplacianRegularization_Cell_Tag& tag, const int& i) const;
+    KOKKOS_INLINE_FUNCTION
+    void operator() (const LaplacianRegularization_Side_Tag& tag, const int& i) const;
   };
 
 } // Namespace LandIce

--- a/src/LandIce/evaluators/LandIce_StokesFOBasalResid.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOBasalResid.hpp
@@ -67,8 +67,6 @@ private:
   unsigned int vecDim;
   unsigned int vecDimFO;
 
-  bool useCollapsedSidesets;
-
   bool regularized;
 
   Albany::LocalSideSetInfo sideSet;

--- a/src/LandIce/evaluators/LandIce_StokesFOLateralResid.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOLateralResid.hpp
@@ -66,8 +66,6 @@ private:
 
   Kokkos::View<int**, PHX::Device> sideNodes;
   std::string                      lateralSideName;
-
-  bool useCollapsedSidesets;
   
   double rho_w;  // [Kg m^{-3}]
   double rho_i;  // [Kg m^{-3}]

--- a/src/LandIce/evaluators/LandIce_StokesFOSynteticTestBC.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOSynteticTestBC.hpp
@@ -68,8 +68,7 @@ private:
   std::string                     ssName;
 
   Albany::LocalSideSetInfo sideSet;
-  bool useCollapsedSidesets;
-
+  
   Kokkos::DynRankView<ScalarT, PHX::Device> qp_temp_buffer;
 
   unsigned int numSideNodes;

--- a/src/LandIce/evaluators/LandIce_StokesFOSynteticTestBC_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOSynteticTestBC_Def.hpp
@@ -47,11 +47,9 @@ StokesFOSynteticTestBC<EvalT, Traits, betaScalarT>::StokesFOSynteticTestBC (cons
 
   Teuchos::RCP<Albany::Layouts> dl_side = dl->side_layouts.at(ssName);
 
-  useCollapsedSidesets = dl_side->useCollapsedSidesets;
-
-  u         = decltype(u)(p.get<std::string> ("Velocity Side QP Variable Name"), useCollapsedSidesets ? dl_side->qp_vector_sideset : dl_side->qp_vector);
-  BF        = decltype(BF)(p.get<std::string> ("BF Side Name"), useCollapsedSidesets ? dl_side->node_qp_scalar_sideset : dl_side->node_qp_scalar);
-  w_measure = decltype(w_measure)(p.get<std::string> ("Weighted Measure Name"), useCollapsedSidesets ? dl_side->qp_scalar_sideset : dl_side->qp_scalar);
+  u         = decltype(u)(p.get<std::string> ("Velocity Side QP Variable Name"), dl_side->qp_vector_sideset);
+  BF        = decltype(BF)(p.get<std::string> ("BF Side Name"), dl_side->node_qp_scalar_sideset);
+  w_measure = decltype(w_measure)(p.get<std::string> ("Weighted Measure Name"), dl_side->qp_scalar_sideset);
 
   this->addDependentField(u);
   this->addDependentField(BF);
@@ -108,10 +106,10 @@ StokesFOSynteticTestBC<EvalT, Traits, betaScalarT>::StokesFOSynteticTestBC (cons
   beta  = pl.get<double>("beta");
 
   if (bc_type!=BCType::CONSTANT) {
-    qp_coords    = decltype(qp_coords)(p.get<std::string>("Coordinate Vector Name"), useCollapsedSidesets ? dl_side->qp_coords_sideset : dl_side->qp_coords);
+    qp_coords    = decltype(qp_coords)(p.get<std::string>("Coordinate Vector Name"), dl_side->qp_coords_sideset);
     this->addDependentField(qp_coords);
     if (bc_type!=BCType::CONFINED_SHELF) {
-      side_normals = decltype(qp_coords)(p.get<std::string>("Side Normal Name"), useCollapsedSidesets ? dl_side->qp_coords_sideset : dl_side->qp_coords);
+      side_normals = decltype(qp_coords)(p.get<std::string>("Side Normal Name"), dl_side->qp_coords_sideset);
       this->addDependentField(side_normals);
     }
   }
@@ -155,17 +153,10 @@ postRegistrationSetup(typename Traits::SetupData /* d */,
   std::vector<PHX::DataLayout::size_type> dims;
   u.fieldTag().dataLayout().dimensions(dims);
 
-  if (useCollapsedSidesets) {
-    TEUCHOS_TEST_FOR_EXCEPTION (dims.size() < 3, Teuchos::Exceptions::InvalidParameter, 
-      "Error! Field layout has fewer dimensions than expected. (StokesFOSynteticTestBC)\n");
+  TEUCHOS_TEST_FOR_EXCEPTION (dims.size() < 3, Teuchos::Exceptions::InvalidParameter, 
+    "Error! Field layout has fewer dimensions than expected. (StokesFOSynteticTestBC)\n");
 
-    qp_temp_buffer = Kokkos::createDynRankView(u.get_view(),"temporary_buffer", dims[0]*dims[1]*dims[2]);
-  } else {
-    TEUCHOS_TEST_FOR_EXCEPTION (dims.size() < 4, Teuchos::Exceptions::InvalidParameter, 
-      "Error! Field layout has fewer dimensions than expected. (StokesFOSynteticTestBC)\n");
-
-    qp_temp_buffer = Kokkos::createDynRankView(u.get_view(),"temporary_buffer", dims[0]*dims[1]*dims[2]*dims[3]);
-  }
+  qp_temp_buffer = Kokkos::createDynRankView(u.get_view(),"temporary_buffer", dims[0]*dims[1]*dims[2]);
 }
 
 //**********************************************************************
@@ -191,219 +182,111 @@ void StokesFOSynteticTestBC<EvalT, Traits, betaScalarT>::evaluateFields (typenam
     const int side = sideSet.side_local_id(sideSet_idx);
 
     Kokkos::deep_copy(qp_temp,0.0);
-    if (useCollapsedSidesets) {
-      switch (bc_type) {
-        case BCType::CONSTANT:
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            for (unsigned int dim=0; dim<components.size(); ++dim) {
-              qp_temp(qp,components[dim]) = beta*u(sideSet_idx,qp,components[dim])-alpha;
-          }}
-          break;
-        case BCType::EXPTRIG:
-        {
-          constexpr double a  = 1.0;
-          constexpr double A  = 1.0;
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            const MeshScalarT x = qp_coords(sideSet_idx,qp,0);
-            const MeshScalarT y2pi = 2.0*pi*qp_coords(sideSet_idx,qp,1);
-            MeshScalarT muargt = (a*a + 4.0*pi*pi - 2.0*pi*a)*sin(y2pi)*sin(y2pi) + 1.0/4.0*(2.0*pi+a)*(2.0*pi+a)*cos(y2pi)*cos(y2pi);
-            muargt = sqrt(muargt)*exp(a*x);
-            const MeshScalarT betaXY = 1.0/2.0*pow(A,-1.0/n)*pow(muargt, 1.0/n -1.0);
-            for (unsigned int dim=0; dim<components.size(); ++dim) {
-              qp_temp(qp,components[dim]) = betaXY*beta*u(sideSet_idx,qp,components[dim])-alpha*side_normals(sideSet_idx,qp,dim);
-          }}
-          break;
-        }
-        case BCType::ISMIP_HOM_TEST_C:
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            const MeshScalarT x = qp_coords(sideSet_idx,qp,0);
-            const MeshScalarT y = qp_coords(sideSet_idx,qp,1);
-            const MeshScalarT betaXY = 1.0 + sin(2.0*pi/L*x)*sin(2.0*pi/L*y);
-            for (unsigned int dim=0; dim<components.size(); ++dim) {
-              qp_temp(qp,components[dim]) = betaXY*beta*u(sideSet_idx,qp,components[dim])-alpha*side_normals(sideSet_idx,qp,dim);
-          }}
-          break;
-        case BCType::ISMIP_HOM_TEST_D:
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            const MeshScalarT x = qp_coords(sideSet_idx,qp,0);
-            const MeshScalarT betaXY = 1.0 + sin(2.0*pi/L*x);
-            for (unsigned int dim=0; dim<components.size(); ++dim) {
-              qp_temp(qp,components[dim]) = betaXY*beta*u(sideSet_idx,qp,components[dim])-alpha*side_normals(sideSet_idx,qp,dim);
-          }}
-          break;
-        case BCType::CIRCULAR_SHELF:
-        {
-          constexpr double s = 0.11479;
-          const MeshScalarT zero(0.0);
-          const MeshScalarT minus_one(-1.0);
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            const MeshScalarT z = qp_coords(sideSet_idx,qp,2);
-            const MeshScalarT betaXY = z*(z>0 ? zero : minus_one);
-            const MeshScalarT coeff = -(beta*(s-z) + alpha*betaXY);
-            for (unsigned int dim=0; dim<components.size(); ++dim) {
-              qp_temp(qp,components[dim]) = coeff*side_normals(sideSet_idx,qp,components[dim]);
-            }
-          }
-          break;
-        }
-        case BCType::CONFINED_SHELF:
-        {
-          constexpr double s = 0.06;
-          const MeshScalarT zero(0.0);
-          const MeshScalarT minus_one(-1.0);
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            const MeshScalarT z = qp_coords(sideSet_idx,qp,2);
-            const MeshScalarT betaXY = z*(z>0 ? zero : minus_one);
-            const MeshScalarT coeff = -(beta*(s-z) + alpha*betaXY);
-            for (unsigned int dim=0; dim<components.size(); ++dim) {
-              qp_temp(qp,components[dim]) = coeff;
-          }}
-          break;
-        }
-        case BCType::XZ_MMS:
-        {
-          constexpr double H  = 1.0;
-          constexpr double alpha0 = 4e-5;
-          constexpr double beta0 = 1.0;
-          constexpr double rho_g = 910.0*9.8;
-          constexpr double s0 = 2.0;
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            constexpr double A = 1e-4;
-            const MeshScalarT x = qp_coords(sideSet_idx,qp,0);
-            const MeshScalarT z = qp_coords(sideSet_idx,qp,1);
-            const MeshScalarT s = s0 - alpha0*x*x;
-            const MeshScalarT phi1 = z - s;
-            const MeshScalarT phi2 = 4.0*A*pow(alpha0*rho_g, 3)*x;
-            const MeshScalarT phi3 = 4.0*x*x*x*pow(phi1,5)*phi2*phi2;
-            const MeshScalarT phi4 = 8.0*alpha0*pow(x,3)*pow(phi1,3)*phi2 - 2.0*H*alpha0*rho_g/beta0 + 3.0*x*phi2*(pow(phi1,4) - pow(H,4));
-            const MeshScalarT mu = 0.5*pow(A*phi4*phi4 + A*x*phi1*phi3, -1.0/3.0);
-            for (unsigned int dim=0; dim<vecDimFO; ++dim) {
-              qp_temp(qp,dim) = beta*u(sideSet_idx,qp,dim)
-                              + 4.0*phi4*mu*alpha*side_normals(sideSet_idx,qp,0)
-                              + 4.0*phi2*x*x*pow(phi1,3)*mu*beta1*side_normals(sideSet_idx,qp,1)
-                              - (2.0*H*alpha0*rho_g*x - beta0*x*x*phi2*(pow(phi1,4) - pow(H,4)))*beta2;
-          }}
-          break;
-        }
-        default:
-          TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error! Reached an unreachable switch case. Please, contact developers.\n");
+    
+    switch (bc_type) {
+      case BCType::CONSTANT:
+        for (unsigned int qp=0; qp<numSideQPs; ++qp) {
+          for (unsigned int dim=0; dim<components.size(); ++dim) {
+            qp_temp(qp,components[dim]) = beta*u(sideSet_idx,qp,components[dim])-alpha;
+        }}
+        break;
+      case BCType::EXPTRIG:
+      {
+        constexpr double a  = 1.0;
+        constexpr double A  = 1.0;
+        for (unsigned int qp=0; qp<numSideQPs; ++qp) {
+          const MeshScalarT x = qp_coords(sideSet_idx,qp,0);
+          const MeshScalarT y2pi = 2.0*pi*qp_coords(sideSet_idx,qp,1);
+          MeshScalarT muargt = (a*a + 4.0*pi*pi - 2.0*pi*a)*sin(y2pi)*sin(y2pi) + 1.0/4.0*(2.0*pi+a)*(2.0*pi+a)*cos(y2pi)*cos(y2pi);
+          muargt = sqrt(muargt)*exp(a*x);
+          const MeshScalarT betaXY = 1.0/2.0*pow(A,-1.0/n)*pow(muargt, 1.0/n -1.0);
+          for (unsigned int dim=0; dim<components.size(); ++dim) {
+            qp_temp(qp,components[dim]) = betaXY*beta*u(sideSet_idx,qp,components[dim])-alpha*side_normals(sideSet_idx,qp,dim);
+        }}
+        break;
       }
+      case BCType::ISMIP_HOM_TEST_C:
+        for (unsigned int qp=0; qp<numSideQPs; ++qp) {
+          const MeshScalarT x = qp_coords(sideSet_idx,qp,0);
+          const MeshScalarT y = qp_coords(sideSet_idx,qp,1);
+          const MeshScalarT betaXY = 1.0 + sin(2.0*pi/L*x)*sin(2.0*pi/L*y);
+          for (unsigned int dim=0; dim<components.size(); ++dim) {
+            qp_temp(qp,components[dim]) = betaXY*beta*u(sideSet_idx,qp,components[dim])-alpha*side_normals(sideSet_idx,qp,dim);
+        }}
+        break;
+      case BCType::ISMIP_HOM_TEST_D:
+        for (unsigned int qp=0; qp<numSideQPs; ++qp) {
+          const MeshScalarT x = qp_coords(sideSet_idx,qp,0);
+          const MeshScalarT betaXY = 1.0 + sin(2.0*pi/L*x);
+          for (unsigned int dim=0; dim<components.size(); ++dim) {
+            qp_temp(qp,components[dim]) = betaXY*beta*u(sideSet_idx,qp,components[dim])-alpha*side_normals(sideSet_idx,qp,dim);
+        }}
+        break;
+      case BCType::CIRCULAR_SHELF:
+      {
+        constexpr double s = 0.11479;
+        const MeshScalarT zero(0.0);
+        const MeshScalarT minus_one(-1.0);
+        for (unsigned int qp=0; qp<numSideQPs; ++qp) {
+          const MeshScalarT z = qp_coords(sideSet_idx,qp,2);
+          const MeshScalarT betaXY = z*(z>0 ? zero : minus_one);
+          const MeshScalarT coeff = -(beta*(s-z) + alpha*betaXY);
+          for (unsigned int dim=0; dim<components.size(); ++dim) {
+            qp_temp(qp,components[dim]) = coeff*side_normals(sideSet_idx,qp,components[dim]);
+          }
+        }
+        break;
+      }
+      case BCType::CONFINED_SHELF:
+      {
+        constexpr double s = 0.06;
+        const MeshScalarT zero(0.0);
+        const MeshScalarT minus_one(-1.0);
+        for (unsigned int qp=0; qp<numSideQPs; ++qp) {
+          const MeshScalarT z = qp_coords(sideSet_idx,qp,2);
+          const MeshScalarT betaXY = z*(z>0 ? zero : minus_one);
+          const MeshScalarT coeff = -(beta*(s-z) + alpha*betaXY);
+          for (unsigned int dim=0; dim<components.size(); ++dim) {
+            qp_temp(qp,components[dim]) = coeff;
+        }}
+        break;
+      }
+      case BCType::XZ_MMS:
+      {
+        constexpr double H  = 1.0;
+        constexpr double alpha0 = 4e-5;
+        constexpr double beta0 = 1.0;
+        constexpr double rho_g = 910.0*9.8;
+        constexpr double s0 = 2.0;
+        for (unsigned int qp=0; qp<numSideQPs; ++qp) {
+          constexpr double A = 1e-4;
+          const MeshScalarT x = qp_coords(sideSet_idx,qp,0);
+          const MeshScalarT z = qp_coords(sideSet_idx,qp,1);
+          const MeshScalarT s = s0 - alpha0*x*x;
+          const MeshScalarT phi1 = z - s;
+          const MeshScalarT phi2 = 4.0*A*pow(alpha0*rho_g, 3)*x;
+          const MeshScalarT phi3 = 4.0*x*x*x*pow(phi1,5)*phi2*phi2;
+          const MeshScalarT phi4 = 8.0*alpha0*pow(x,3)*pow(phi1,3)*phi2 - 2.0*H*alpha0*rho_g/beta0 + 3.0*x*phi2*(pow(phi1,4) - pow(H,4));
+          const MeshScalarT mu = 0.5*pow(A*phi4*phi4 + A*x*phi1*phi3, -1.0/3.0);
+          for (unsigned int dim=0; dim<vecDimFO; ++dim) {
+            qp_temp(qp,dim) = beta*u(sideSet_idx,qp,dim)
+                            + 4.0*phi4*mu*alpha*side_normals(sideSet_idx,qp,0)
+                            + 4.0*phi2*x*x*pow(phi1,3)*mu*beta1*side_normals(sideSet_idx,qp,1)
+                            - (2.0*H*alpha0*rho_g*x - beta0*x*x*phi2*(pow(phi1,4) - pow(H,4)))*beta2;
+        }}
+        break;
+      }
+      default:
+        TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error! Reached an unreachable switch case. Please, contact developers.\n");
+    }
 
-      for (unsigned int node=0; node<numSideNodes; ++node) {
-        for (unsigned int dim=0; dim<components.size(); ++dim) {
-          ScalarT res = 0.0;
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            res += qp_temp(qp,components[dim]) * BF(sideSet_idx,node,qp)*w_measure(sideSet_idx,qp);
-          }
-          residual(cell,sideNodes[side][node],components[dim]) += res;
+    for (unsigned int node=0; node<numSideNodes; ++node) {
+      for (unsigned int dim=0; dim<components.size(); ++dim) {
+        ScalarT res = 0.0;
+        for (unsigned int qp=0; qp<numSideQPs; ++qp) {
+          res += qp_temp(qp,components[dim]) * BF(sideSet_idx,node,qp)*w_measure(sideSet_idx,qp);
         }
-      }
-    } else {
-      switch (bc_type) {
-        case BCType::CONSTANT:
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            for (unsigned int dim=0; dim<components.size(); ++dim) {
-              qp_temp(qp,components[dim]) = beta*u(cell,side,qp,components[dim])-alpha;
-          }}
-          break;
-        case BCType::EXPTRIG:
-        {
-          constexpr double a  = 1.0;
-          constexpr double A  = 1.0;
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            const MeshScalarT x = qp_coords(cell,side,qp,0);
-            const MeshScalarT y2pi = 2.0*pi*qp_coords(cell,side,qp,1);
-            MeshScalarT muargt = (a*a + 4.0*pi*pi - 2.0*pi*a)*sin(y2pi)*sin(y2pi) + 1.0/4.0*(2.0*pi+a)*(2.0*pi+a)*cos(y2pi)*cos(y2pi);
-            muargt = sqrt(muargt)*exp(a*x);
-            const MeshScalarT betaXY = 1.0/2.0*pow(A,-1.0/n)*pow(muargt, 1.0/n -1.0);
-            for (unsigned int dim=0; dim<components.size(); ++dim) {
-              qp_temp(qp,components[dim]) = betaXY*beta*u(cell,side,qp,components[dim])-alpha*side_normals(cell,side,qp,dim);
-          }}
-          break;
-        }
-        case BCType::ISMIP_HOM_TEST_C:
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            const MeshScalarT x = qp_coords(cell,side,qp,0);
-            const MeshScalarT y = qp_coords(cell,side,qp,1);
-            const MeshScalarT betaXY = 1.0 + sin(2.0*pi/L*x)*sin(2.0*pi/L*y);
-            for (unsigned int dim=0; dim<components.size(); ++dim) {
-              qp_temp(qp,components[dim]) = betaXY*beta*u(cell,side,qp,components[dim])-alpha*side_normals(cell,side,qp,dim);
-          }}
-          break;
-        case BCType::ISMIP_HOM_TEST_D:
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            const MeshScalarT x = qp_coords(cell,side,qp,0);
-            const MeshScalarT betaXY = 1.0 + sin(2.0*pi/L*x);
-            for (unsigned int dim=0; dim<components.size(); ++dim) {
-              qp_temp(qp,components[dim]) = betaXY*beta*u(cell,side,qp,components[dim])-alpha*side_normals(cell,side,qp,dim);
-          }}
-          break;
-        case BCType::CIRCULAR_SHELF:
-        {
-          constexpr double s = 0.11479;
-          const MeshScalarT zero(0.0);
-          const MeshScalarT minus_one(-1.0);
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            const MeshScalarT z = qp_coords(cell,side,qp,2);
-            const MeshScalarT betaXY = z*(z>0 ? zero : minus_one);
-            const MeshScalarT coeff = -(beta*(s-z) + alpha*betaXY);
-            for (unsigned int dim=0; dim<components.size(); ++dim) {
-              qp_temp(qp,components[dim]) = coeff*side_normals(cell,side,qp,components[dim]);
-            }
-          }
-          break;
-        }
-        case BCType::CONFINED_SHELF:
-        {
-          constexpr double s = 0.06;
-          const MeshScalarT zero(0.0);
-          const MeshScalarT minus_one(-1.0);
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            const MeshScalarT z = qp_coords(cell,side,qp,2);
-            const MeshScalarT betaXY = z*(z>0 ? zero : minus_one);
-            const MeshScalarT coeff = -(beta*(s-z) + alpha*betaXY);
-            for (unsigned int dim=0; dim<components.size(); ++dim) {
-              qp_temp(qp,components[dim]) = coeff;
-          }}
-          break;
-        }
-        case BCType::XZ_MMS:
-        {
-          constexpr double H  = 1.0;
-          constexpr double alpha0 = 4e-5;
-          constexpr double beta0 = 1.0;
-          constexpr double rho_g = 910.0*9.8;
-          constexpr double s0 = 2.0;
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            constexpr double A = 1e-4;
-            const MeshScalarT x = qp_coords(cell,side,qp,0);
-            const MeshScalarT z = qp_coords(cell,side,qp,1);
-            const MeshScalarT s = s0 - alpha0*x*x;
-            const MeshScalarT phi1 = z - s;
-            const MeshScalarT phi2 = 4.0*A*pow(alpha0*rho_g, 3)*x;
-            const MeshScalarT phi3 = 4.0*x*x*x*pow(phi1,5)*phi2*phi2;
-            const MeshScalarT phi4 = 8.0*alpha0*pow(x,3)*pow(phi1,3)*phi2 - 2.0*H*alpha0*rho_g/beta0 + 3.0*x*phi2*(pow(phi1,4) - pow(H,4));
-            const MeshScalarT mu = 0.5*pow(A*phi4*phi4 + A*x*phi1*phi3, -1.0/3.0);
-            for (unsigned int dim=0; dim<vecDimFO; ++dim) {
-              qp_temp(qp,dim) = beta*u(cell,side,qp,dim)
-                              + 4.0*phi4*mu*alpha*side_normals(cell,side,qp,0)
-                              + 4.0*phi2*x*x*pow(phi1,3)*mu*beta1*side_normals(cell,side,qp,1)
-                              - (2.0*H*alpha0*rho_g*x - beta0*x*x*phi2*(pow(phi1,4) - pow(H,4)))*beta2;
-          }}
-          break;
-        }
-        default:
-          TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error! Reached an unreachable switch case. Please, contact developers.\n");
-      }
-
-      for (unsigned int node=0; node<numSideNodes; ++node) {
-        for (unsigned int dim=0; dim<components.size(); ++dim) {
-          ScalarT res = 0.0;
-          for (unsigned int qp=0; qp<numSideQPs; ++qp) {
-            res += qp_temp(qp,components[dim]) * BF(cell,side,node,qp)*w_measure(cell,side,qp);
-          }
-          residual(cell,sideNodes[side][node],components[dim]) += res;
-        }
+        residual(cell,sideNodes[side][node],components[dim]) += res;
       }
     }
   }

--- a/src/LandIce/evaluators/LandIce_ThicknessResid.hpp
+++ b/src/LandIce/evaluators/LandIce_ThicknessResid.hpp
@@ -64,9 +64,6 @@ private:
 
   std::size_t numVecFODims;
 
-  bool useCollapsedSidesets;
-
-
   Teuchos::RCP<shards::CellTopology> cellType;
   Teuchos::RCP<shards::CellTopology> sideType;
   Teuchos::RCP<Intrepid2::Cubature<PHX::Device> > cubatureSide;

--- a/src/LandIce/evaluators/LandIce_ThicknessResid_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_ThicknessResid_Def.hpp
@@ -54,8 +54,7 @@ ThicknessResid(const Teuchos::ParameterList& p,
                               "Error! Layout for side set " << sideSetName << " not found.\n");
   Teuchos::RCP<Albany::Layouts> dl_side = dl->side_layouts.at(sideSetName);
 
-  useCollapsedSidesets = dl_side->useCollapsedSidesets;
-  auto av_v_layout = useCollapsedSidesets ? dl_side->node_vector_sideset : dl_side->node_vector;
+  auto av_v_layout = dl_side->node_vector_sideset;
   V = decltype(V)(p.get<std::string>("Averaged Velocity Variable Name"), av_v_layout);
   this->addDependentField(V);
 
@@ -234,11 +233,7 @@ evaluateFields(typename Traits::EvalData workset)
         H0_Cell(node) = H0(elem_LID, node);
         SMB_Cell(node) = have_SMB ? SMB(elem_LID, node) : ScalarT(0.0);
         for (std::size_t dim = 0; dim < numVecFODims; ++dim) {
-          if (useCollapsedSidesets) {
-            V_Cell(node, dim) = V(iSide, i, dim);
-          } else {
-            V_Cell(node, dim) = V(elem_LID, elem_side, i, dim);
-          }
+          V_Cell(node, dim) = V(iSide, i, dim);
         }
       }
 

--- a/src/LandIce/evaluators/LandIce_w_Resid.hpp
+++ b/src/LandIce/evaluators/LandIce_w_Resid.hpp
@@ -53,14 +53,29 @@ private:
   // Output
   PHX::MDField<ScalarT,Cell,Node> Residual;
 
+  Albany::LocalSideSetInfo sideSet;
+
   std::string sideName;
-  std::vector<std::vector<int> >  sideNodes;
+  Kokkos::View<int**, PHX::Device> sideNodes;
   unsigned int numNodes;
   unsigned int numSideNodes;
   unsigned int numQPs;
   unsigned int numSideQPs;
 
-  bool useCollapsedSidesets;
+public:
+
+  typedef Kokkos::View<int***, PHX::Device>::execution_space ExecutionSpace;
+
+  struct wResid_Cell_Tag{};
+  struct wResid_Side_Tag{};
+
+  typedef Kokkos::RangePolicy<ExecutionSpace,wResid_Cell_Tag> wResid_Cell_Policy;
+  typedef Kokkos::RangePolicy<ExecutionSpace,wResid_Side_Tag> wResid_Side_Policy;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const wResid_Cell_Tag& tag, const int& i) const;
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const wResid_Side_Tag& tag, const int& i) const;
 };
 
 }	// Namespace LandIce

--- a/src/LandIce/evaluators/LandIce_w_Resid_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_w_Resid_Def.hpp
@@ -47,7 +47,6 @@ namespace LandIce
     TEUCHOS_TEST_FOR_EXCEPTION (dl->side_layouts.find(sideName)==dl->side_layouts.end(), std::runtime_error,
                                 "Error! Basal side data layout not found.\n");
     Teuchos::RCP<Albany::Layouts> dl_side = dl->side_layouts.at(sideName);
-    useCollapsedSidesets = dl_side->useCollapsedSidesets;
 
     TEUCHOS_TEST_FOR_EXCEPTION (not dl_side->useCollapsedSidesets, std::runtime_error,
                                 "Error! LandIce::w_Resid only implemented for collapsed sidesets.\n");
@@ -68,14 +67,17 @@ namespace LandIce
     unsigned int numSides = dl_side->node_scalar->extent(1);
     unsigned int sideDim  = cellType->getDimension()-1;
 
-    sideNodes.resize(numSides);
-    for (unsigned int side=0; side<numSides; ++side)
-    {
-      //Need to get the subcell exact count, since different sides may have different number of nodes (e.g., Wedge)
+    unsigned int nodeMax = 0;
+    for (unsigned int side=0; side<numSides; ++side) {
       unsigned int thisSideNodes = cellType->getNodeCount(sideDim,side);
-      sideNodes[side].resize(thisSideNodes);
-      for (unsigned int node=0; node<thisSideNodes; ++node)
-        sideNodes[side][node] = cellType->getNodeMap(sideDim,side,node);
+      nodeMax = std::max(nodeMax, thisSideNodes);
+    }
+    sideNodes = Kokkos::View<int**, PHX::Device>("sideNodes", numSides, nodeMax);
+    for (unsigned int side=0; side<numSides; ++side) {
+      unsigned int thisSideNodes = cellType->getNodeCount(sideDim,side);
+      for (unsigned int node=0; node<thisSideNodes; ++node) {
+        sideNodes(side,node) = cellType->getNodeMap(sideDim,side,node);
+      }
     }
 
     this->addDependentField(GradVelocity);
@@ -94,6 +96,55 @@ namespace LandIce
     this->setName("W Residual");
   }
 
+  //**********************************************************************
+  //Kokkos functor
+  template<typename EvalT, typename Traits, typename VelocityType>
+  KOKKOS_INLINE_FUNCTION
+  void w_Resid<EvalT,Traits,VelocityType>::
+  operator() (const wResid_Cell_Tag& tag, const int& cell) const {
+
+    MeshScalarT diam_z(0);//, diam_xy(0), diam_z(0);
+    for (std::size_t i = 0; i < numNodes; ++i) {
+      //  diam = std::max(diam,distance<MeshScalarT>(coordVec(cell,i,0),coordVec(cell,i,1),coordVec(cell,i,2),
+      //                                              coordVec(cell,0,0),coordVec(cell,0,1),coordVec(cell,j,2)));
+      //  diam_xy = std::max(diam_xy,distance<MeshScalarT>(coordVec(cell,i,0),coordVec(cell,i,1),MeshScalarT(0.0),coordVec(cell,0,0),coordVec(cell,0,1),MeshScalarT(0.0)));
+      diam_z = std::max(diam_z,std::abs(coordVec(cell,i,2) - coordVec(cell,0,2)));
+    }
+    for (std::size_t node = 0; node < numNodes; ++node)
+      for (std::size_t qp = 0; qp < numQPs; ++qp)
+        Residual(cell,node) += ( w_z(cell,qp,2) + GradVelocity(cell,qp,0,0) +  GradVelocity(cell,qp,1,1) ) * wBF(cell,node,qp)
+                            + 0.0*  diam_z * w_z(cell,qp,2) * wGradBF(cell,node,qp,2);// + diam_xy * GradVelocity(cell,qp,0,0) * wGradBF(cell,node,qp,0);// +  diam_xy * GradVelocity(cell,qp,1,1) * wGradBF(cell,node,qp,1);
+
+  }
+
+  template<typename EvalT, typename Traits, typename VelocityType>
+  KOKKOS_INLINE_FUNCTION
+  void w_Resid<EvalT,Traits,VelocityType>::
+  operator() (const wResid_Side_Tag& tag, const int& side_idx) const {
+
+    // Get the local data of side and cell
+    const int cell = sideSet.elem_LID(side_idx);
+    const int side = sideSet.side_local_id(side_idx);
+
+    for (unsigned int snode=0; snode<numSideNodes; ++snode){
+      int cnode = sideNodes(side,snode);
+      Residual(cell,cnode) =0;
+      }
+
+    for (unsigned int snode=0; snode<numSideNodes; ++snode) {
+      int cnode = sideNodes(side,snode);
+      for (std::size_t qp = 0; qp < numSideQPs; ++qp) {
+      Residual(cell,cnode) += (side_w_qp(side_idx,qp) * normals(side_idx,qp,2) +
+                                  velocity(cell,qp,0)  * normals(side_idx,qp,0) +
+                                  velocity(cell,qp,1)  * normals(side_idx,qp,1) +
+                                  basalVerticalVelocitySideQP(side_idx, qp)) *
+                              sideBF(side_idx,snode,qp) * side_w_measure(side_idx,qp);
+      }
+    }
+
+  }
+
+  //**********************************************************************
   template<typename EvalT, typename Traits, typename VelocityType>
   void w_Resid<EvalT,Traits,VelocityType>::
   postRegistrationSetup(typename Traits::SetupData d, PHX::FieldManager<Traits>&)
@@ -105,49 +156,13 @@ namespace LandIce
   void w_Resid<EvalT,Traits,VelocityType>::
   evaluateFields(typename Traits::EvalData d)
   {
-    for (std::size_t cell = 0; cell < d.numCells; ++cell)
-      for (std::size_t node = 0; node < numNodes; ++node)
-        Residual(cell,node) = 0.0;
+    Residual.deep_copy(0.0);
 
-    for (std::size_t cell = 0; cell < d.numCells; ++cell) {
-      MeshScalarT diam_z(0);//, diam_xy(0), diam_z(0);
-      for (std::size_t i = 0; i < numNodes; ++i) {
-        //  diam = std::max(diam,distance<MeshScalarT>(coordVec(cell,i,0),coordVec(cell,i,1),coordVec(cell,i,2),
-        //                                              coordVec(cell,0,0),coordVec(cell,0,1),coordVec(cell,j,2)));
-        //  diam_xy = std::max(diam_xy,distance<MeshScalarT>(coordVec(cell,i,0),coordVec(cell,i,1),MeshScalarT(0.0),coordVec(cell,0,0),coordVec(cell,0,1),MeshScalarT(0.0)));
-        diam_z = std::max(diam_z,std::abs(coordVec(cell,i,2) - coordVec(cell,0,2)));
-      }
-      for (std::size_t node = 0; node < numNodes; ++node)
-        for (std::size_t qp = 0; qp < numQPs; ++qp)
-          Residual(cell,node) += ( w_z(cell,qp,2) + GradVelocity(cell,qp,0,0) +  GradVelocity(cell,qp,1,1) ) * wBF(cell,node,qp)
-                              + 0.0*  diam_z * w_z(cell,qp,2) * wGradBF(cell,node,qp,2);// + diam_xy * GradVelocity(cell,qp,0,0) * wGradBF(cell,node,qp,0);// +  diam_xy * GradVelocity(cell,qp,1,1) * wGradBF(cell,node,qp,1);
-
-    }
-
+    Kokkos::parallel_for(wResid_Cell_Policy(0, d.numCells), *this);
 
     if (d.sideSetViews->find(sideName)==d.sideSetViews->end()) return;
 
-    auto sideSet = d.sideSetViews->at(sideName);
-    for (int side_idx = 0; side_idx < sideSet.size; ++side_idx)
-    {
-      // Get the local data of side and cell
-      const int cell = sideSet.elem_LID(side_idx);
-      const int side = sideSet.side_local_id(side_idx);
-      for (unsigned int snode=0; snode<numSideNodes; ++snode){
-        int cnode = sideNodes[side][snode];
-        Residual(cell,cnode) =0;
-       }
-
-      for (unsigned int snode=0; snode<numSideNodes; ++snode) {
-        int cnode = sideNodes[side][snode];
-        for (std::size_t qp = 0; qp < numSideQPs; ++qp) {
-        Residual(cell,cnode) += (side_w_qp(side_idx,qp) * normals(side_idx,qp,2) +
-                                   velocity(cell,qp,0)  * normals(side_idx,qp,0) +
-                                   velocity(cell,qp,1)  * normals(side_idx,qp,1) +
-                                   basalVerticalVelocitySideQP(side_idx, qp)) *
-                                sideBF(side_idx,snode,qp) * side_w_measure(side_idx,qp);
-        }
-      }
-    }
+    sideSet = d.sideSetViews->at(sideName);
+    Kokkos::parallel_for(wResid_Side_Policy(0, sideSet.size), *this);
   }
 }

--- a/src/LandIce/problems/LandIce_LaplacianSampling.cpp
+++ b/src/LandIce/problems/LandIce_LaplacianSampling.cpp
@@ -84,7 +84,7 @@ void LandIce::LaplacianSampling::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Al
     auto numSideQPs      = sideCubature->getNumPoints();
 
 
-    dl_side = rcp(new Albany::Layouts(worksetSize,numSideVertices,numSideNodes, numSideQPs,numDim-1,numDim,numCellSides,1));
+    dl_side = rcp(new Albany::Layouts(worksetSize,numSideVertices,numSideNodes, numSideQPs,numDim-1,numDim,numCellSides,1,true,sideMeshSpecs.worksetSize));
     dl->side_layouts[sideName] = dl_side;
   }
 

--- a/src/LandIce/problems/LandIce_LaplacianSampling.hpp
+++ b/src/LandIce/problems/LandIce_LaplacianSampling.hpp
@@ -190,7 +190,7 @@ LandIce::LaplacianSampling::constructEvaluators (PHX::FieldManager<PHAL::AlbanyT
 
   if(sideName != "INVALID") {
     //---- Restrict vertex coordinates from cell-based to cell-side-based
-    ev = evalUtils.getMSTUtils().constructDOFCellToSideEvaluator("Coord Vec",sideName,"Vertex Vector",cellType,"Coord Vec " + sideName);
+    ev = evalUtils.getMSTUtils().constructDOFCellToSideEvaluator("Coord Vec",sideName,"Vertex Vector Sideset",cellType,"Coord Vec " + sideName);
     fm0.template registerEvaluator<EvalT> (ev);
 
     ev = evalUtils.constructComputeBasisFunctionsSideEvaluator(cellType, sideBasis, sideCubature, sideName);

--- a/src/evaluators/interpolation/PHAL_DOFGradInterpolationSide.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFGradInterpolationSide.hpp
@@ -56,8 +56,6 @@ private:
   //! Values at quadrature points
   PHX::MDField<OutputScalarT> grad_qp;
 
-  bool useCollapsedSidesets;
-
   Albany::LocalSideSetInfo sideSet;
 
   int numSideNodes;

--- a/src/evaluators/interpolation/PHAL_DOFGradInterpolationSide_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFGradInterpolationSide_Def.hpp
@@ -20,9 +20,9 @@ DOFGradInterpolationSideBase<EvalT, Traits, ScalarT>::
 DOFGradInterpolationSideBase(const Teuchos::ParameterList& p,
                          const Teuchos::RCP<Albany::Layouts>& dl_side) :
   sideSetName (p.get<std::string> ("Side Set Name")),
-  val_node    (p.get<std::string> ("Variable Name"), (dl_side->useCollapsedSidesets) ? dl_side->node_scalar_sideset : dl_side->node_scalar),
-  gradBF      (p.get<std::string> ("Gradient BF Name"), (dl_side->useCollapsedSidesets) ? dl_side->node_qp_gradient_sideset : dl_side->node_qp_gradient),
-  grad_qp      (p.get<std::string> ("Gradient Variable Name"), (dl_side->useCollapsedSidesets) ? dl_side->qp_gradient_sideset : dl_side->qp_gradient)
+  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_scalar_sideset),
+  gradBF      (p.get<std::string> ("Gradient BF Name"), dl_side->node_qp_gradient_sideset),
+  grad_qp      (p.get<std::string> ("Gradient Variable Name"), dl_side->qp_gradient_sideset)
 {
   TEUCHOS_TEST_FOR_EXCEPTION (!dl_side->isSideLayouts, Teuchos::Exceptions::InvalidParameter,
                               "Error! The layouts structure does not appear to be that of a side set.\n");
@@ -32,8 +32,6 @@ DOFGradInterpolationSideBase(const Teuchos::ParameterList& p,
   this->addEvaluatedField(grad_qp);
 
   this->setName("DOFGradInterpolationSide("+p.get<std::string>("Variable Name") + ")"+PHX::print<EvalT>());
-
-  useCollapsedSidesets = dl_side->useCollapsedSidesets;
 
   numSideNodes = dl_side->node_qp_gradient->extent(2);
   numSideQPs   = dl_side->node_qp_gradient->extent(3);
@@ -81,26 +79,8 @@ evaluateFields(typename Traits::EvalData workset)
   if (memoizer.have_saved_data(workset,this->evaluatedFields())) return;
 
   sideSet = workset.sideSetViews->at(sideSetName);
-  if (useCollapsedSidesets) {
-    Kokkos::parallel_for(GradInterpolationSide_Policy(0, sideSet.size), *this);
-  } else {
-    for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-    {
-      // Get the data that corresponds to the side
-      const int cell = sideSet.elem_LID(sideSet_idx);
-      const int side = sideSet.side_local_id(sideSet_idx);
-
-      for (int qp=0; qp<numSideQPs; ++qp) {
-        for (int dim=0; dim<numDims; ++dim) {
-          grad_qp(cell,side,qp,dim) = 0.;
-          for (int node=0; node<numSideNodes; ++node) {
-            grad_qp(cell,side,qp,dim) += val_node(cell,side,node) * gradBF(cell,side,node,qp,dim);
-          }
-        }
-      }
-    }
-  }
-    
+  
+  Kokkos::parallel_for(GradInterpolationSide_Policy(0, sideSet.size), *this);    
 }
 
 } // Namespace PHAL

--- a/src/evaluators/interpolation/PHAL_DOFInterpolationSide.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFInterpolationSide.hpp
@@ -54,7 +54,6 @@ private:
 
   int numSideNodes;
   int numSideQPs;
-  bool useCollapsedSidesets;
 
   MDFieldMemoizer<Traits> memoizer;
 
@@ -63,18 +62,12 @@ private:
 public:
 
   typedef Kokkos::View<int***, PHX::Device>::execution_space ExecutionSpace;
-  struct DOFInterpolationSideBase_Tag{};
-  struct DOFInterpolationSideBase_Collapsed_Tag{};
+  struct InterpolationSide_Tag{};
 
-  typedef Kokkos::RangePolicy<ExecutionSpace, DOFInterpolationSideBase_Tag> DOFInterpolationSideBase_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace, DOFInterpolationSideBase_Collapsed_Tag> DOFInterpolationSideBase_Collapsed_Policy;
+  typedef Kokkos::RangePolicy<ExecutionSpace, InterpolationSide_Tag> InterpolationSide_Policy;
 
   KOKKOS_INLINE_FUNCTION
-  void operator() (const DOFInterpolationSideBase_Tag& tag, const int& sideSet_idx) const;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const DOFInterpolationSideBase_Collapsed_Tag& tag, const int& sideSet_idx) const;
-
+  void operator() (const InterpolationSide_Tag& tag, const int& sideSet_idx) const;
 };
 
 // Some shortcut names

--- a/src/evaluators/interpolation/PHAL_DOFInterpolationSide_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFInterpolationSide_Def.hpp
@@ -16,9 +16,9 @@ DOFInterpolationSideBase<EvalT, Traits, ScalarT>::
 DOFInterpolationSideBase (const Teuchos::ParameterList& p,
                           const Teuchos::RCP<Albany::Layouts>& dl_side) :
   sideSetName (p.get<std::string> ("Side Set Name")),
-  val_node    (p.get<std::string> ("Variable Name"), (dl_side->useCollapsedSidesets) ? dl_side->node_scalar_sideset : dl_side->node_scalar),
-  BF          (p.get<std::string> ("BF Name"), (dl_side->useCollapsedSidesets) ? dl_side->node_qp_scalar_sideset : dl_side->node_qp_scalar),
-  val_qp      (p.get<std::string> ("Variable Name"), (dl_side->useCollapsedSidesets) ? dl_side->qp_scalar_sideset : dl_side->qp_scalar)
+  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_scalar_sideset),
+  BF          (p.get<std::string> ("BF Name"), dl_side->node_qp_scalar_sideset),
+  val_qp      (p.get<std::string> ("Variable Name"), dl_side->qp_scalar_sideset)
 {
   TEUCHOS_TEST_FOR_EXCEPTION (!dl_side->isSideLayouts, Teuchos::Exceptions::InvalidParameter,
                               "Error! The layouts structure does not appear to be that of a side set.\n");
@@ -31,8 +31,6 @@ DOFInterpolationSideBase (const Teuchos::ParameterList& p,
 
   numSideNodes = dl_side->node_qp_scalar->extent(2);
   numSideQPs   = dl_side->node_qp_scalar->extent(3);
-
-  useCollapsedSidesets = dl_side->useCollapsedSidesets;
 }
 
 //**********************************************************************
@@ -54,25 +52,7 @@ postRegistrationSetup(typename Traits::SetupData d,
 template<typename EvalT, typename Traits, typename ScalarT>
 KOKKOS_INLINE_FUNCTION
 void DOFInterpolationSideBase<EvalT, Traits, ScalarT>::
-operator() (const DOFInterpolationSideBase_Tag& tag, const int& sideSet_idx) const {
-  
-  // Get the local data of side and cell
-  const int cell = sideSet.elem_LID(sideSet_idx);
-  const int side = sideSet.side_local_id(sideSet_idx);
-  
-  for (int qp=0; qp<numSideQPs; ++qp) {
-    val_qp(cell,side,qp) = 0;
-    for (int node=0; node<numSideNodes; ++node) {
-      val_qp(cell,side,qp) += val_node(cell,side,node) * BF(cell,side,node,qp);
-    }
-  }
-
-}
-
-template<typename EvalT, typename Traits, typename ScalarT>
-KOKKOS_INLINE_FUNCTION
-void DOFInterpolationSideBase<EvalT, Traits, ScalarT>::
-operator() (const DOFInterpolationSideBase_Collapsed_Tag& tag, const int& sideSet_idx) const {
+operator() (const InterpolationSide_Tag& tag, const int& sideSet_idx) const {
 
   for (int qp=0; qp<numSideQPs; ++qp) {
     val_qp(sideSet_idx,qp) = 0;
@@ -88,54 +68,12 @@ template<typename EvalT, typename Traits, typename ScalarT>
 void DOFInterpolationSideBase<EvalT, Traits, ScalarT>::
 evaluateFields(typename Traits::EvalData workset)
 {
-  if (workset.sideSetViews->find(sideSetName)==workset.sideSetViews->end())
-    return;
+  if (workset.sideSetViews->find(sideSetName)==workset.sideSetViews->end()) return;
   if (memoizer.have_saved_data(workset,this->evaluatedFields())) return;
 
   sideSet = workset.sideSetViews->at(sideSetName);
-#ifdef ALBANY_KOKKOS_UNDER_DEVELOPMENT
-  if (useCollapsedSidesets) {
-    Kokkos::parallel_for(DOFInterpolationSideBase_Collapsed_Policy(0, sideSet.size), *this);
-  } else {
-    for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-    {
-      // Get the local data of side and cell
-      const int cell = sideSet.elem_LID(sideSet_idx);
-      const int side = sideSet.side_local_id(sideSet_idx);
-
-      for (int qp=0; qp<numSideQPs; ++qp) {
-        val_qp(cell,side,qp) = 0;
-        for (int node=0; node<numSideNodes; ++node) {
-          val_qp(cell,side,qp) += val_node(cell,side,node) * BF(cell,side,node,qp);
-        }
-      }
-    }
-  }
-#else
-  for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-  {
-    // Get the local data of side and cell
-    const int cell = sideSet.elem_LID(sideSet_idx);
-    const int side = sideSet.side_local_id(sideSet_idx);
-
-    if (useCollapsedSidesets) {
-      for (int qp=0; qp<numSideQPs; ++qp) {
-        val_qp(sideSet_idx,qp) = 0;
-        for (int node=0; node<numSideNodes; ++node) {
-          val_qp(sideSet_idx,qp) += val_node(sideSet_idx,node) * BF(sideSet_idx,node,qp);
-        }
-      }
-    } else {
-      for (int qp=0; qp<numSideQPs; ++qp) {
-        val_qp(cell,side,qp) = 0;
-        for (int node=0; node<numSideNodes; ++node) {
-          val_qp(cell,side,qp) += val_node(cell,side,node) * BF(cell,side,node,qp);
-        }
-      }
-    }
-  }
-#endif
-
+  
+  Kokkos::parallel_for(InterpolationSide_Policy(0, sideSet.size), *this);
 }
 
 } // Namespace PHAL

--- a/src/evaluators/interpolation/PHAL_DOFVecGradInterpolationSide.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFVecGradInterpolationSide.hpp
@@ -54,8 +54,6 @@ private:
   //! Values at quadrature points
   PHX::MDField<OutputScalarT> grad_qp;
 
-  bool useCollapsedSidesets;
-
   Albany::LocalSideSetInfo sideSet;
 
   int numSideNodes;

--- a/src/evaluators/interpolation/PHAL_DOFVecGradInterpolationSide_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFVecGradInterpolationSide_Def.hpp
@@ -16,9 +16,9 @@ DOFVecGradInterpolationSideBase<EvalT, Traits, ScalarT>::
 DOFVecGradInterpolationSideBase(const Teuchos::ParameterList& p,
                             const Teuchos::RCP<Albany::Layouts>& dl_side) :
   sideSetName (p.get<std::string> ("Side Set Name")),
-  val_node    (p.get<std::string> ("Variable Name"), (dl_side->useCollapsedSidesets) ? dl_side->node_vector_sideset : dl_side->node_vector),
-  gradBF      (p.get<std::string> ("Gradient BF Name"), (dl_side->useCollapsedSidesets) ? dl_side->node_qp_gradient_sideset : dl_side->node_qp_gradient),
-  grad_qp     (p.get<std::string> ("Gradient Variable Name"), (dl_side->useCollapsedSidesets) ? dl_side->qp_vecgradient_sideset : dl_side->qp_vecgradient)
+  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_vector_sideset),
+  gradBF      (p.get<std::string> ("Gradient BF Name"), dl_side->node_qp_gradient_sideset),
+  grad_qp     (p.get<std::string> ("Gradient Variable Name"), dl_side->qp_vecgradient_sideset)
 {
   TEUCHOS_TEST_FOR_EXCEPTION (!dl_side->isSideLayouts, Teuchos::Exceptions::InvalidParameter,
                               "Error! The layouts structure does not appear to be that of a side set.\n");
@@ -28,8 +28,6 @@ DOFVecGradInterpolationSideBase(const Teuchos::ParameterList& p,
   this->addEvaluatedField(grad_qp);
 
   this->setName("DOFVecGradInterpolationSideBase" );
-
-  useCollapsedSidesets = dl_side->useCollapsedSidesets;
 
   numSideNodes = dl_side->node_qp_gradient->extent(2);
   numSideQPs   = dl_side->node_qp_gradient->extent(3);
@@ -76,27 +74,8 @@ evaluateFields(typename Traits::EvalData workset)
   if (workset.sideSetViews->find(sideSetName)==workset.sideSetViews->end()) return;
 
   sideSet = workset.sideSetViews->at(sideSetName);
-  if (useCollapsedSidesets) {
-    Kokkos::parallel_for(VecGradInterpolationSide_Policy(0, sideSet.size), *this);
-  } else {
-    for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-    {
-      // Get the data that corresponds to the side
-      const int cell = sideSet.elem_LID(sideSet_idx);
-      const int side = sideSet.side_local_id(sideSet_idx);
-
-      for (int qp=0; qp<numSideQPs; ++qp) {
-        for (int comp=0; comp<vecDim; ++comp) {
-          for (int dim=0; dim<numDims; ++dim) {
-            grad_qp(cell,side,qp,comp,dim) = 0.;
-            for (int node=0; node<numSideNodes; ++node) {
-              grad_qp(cell,side,qp,comp,dim) += val_node(cell,side,node,comp) * gradBF(cell,side,node,qp,dim);
-            }
-          }
-        }
-      }
-    }
-  }
+  
+  Kokkos::parallel_for(VecGradInterpolationSide_Policy(0, sideSet.size), *this);
 }
 
 } // Namespace PHAL

--- a/src/evaluators/interpolation/PHAL_DOFVecInterpolationSide.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFVecInterpolationSide.hpp
@@ -56,7 +56,6 @@ private:
   int numSideNodes;
   int numSideQPs;
   int vecDim;
-  bool useCollapsedSidesets;
 
   MDFieldMemoizer<Traits> memoizer;
 
@@ -65,17 +64,12 @@ private:
 public:
 
   typedef Kokkos::View<int***, PHX::Device>::execution_space ExecutionSpace;
-  struct DOFVecInterpolationSideBase_Tag{};
-  struct DOFVecInterpolationSideBase_Collapsed_Tag{};
+  struct VecInterpolationSide_Tag{};
 
-  typedef Kokkos::RangePolicy<ExecutionSpace, DOFVecInterpolationSideBase_Tag> DOFVecInterpolationSideBase_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace, DOFVecInterpolationSideBase_Collapsed_Tag> DOFVecInterpolationSideBase_Collapsed_Policy;
+  typedef Kokkos::RangePolicy<ExecutionSpace, VecInterpolationSide_Tag> VecInterpolationSide_Policy;
 
   KOKKOS_INLINE_FUNCTION
-  void operator() (const DOFVecInterpolationSideBase_Tag& tag, const int& sideSet_idx) const;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const DOFVecInterpolationSideBase_Collapsed_Tag& tag, const int& sideSet_idx) const;
+  void operator() (const VecInterpolationSide_Tag& tag, const int& sideSet_idx) const;
 
 };
 

--- a/src/evaluators/interpolation/PHAL_DOFVecInterpolationSide_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFVecInterpolationSide_Def.hpp
@@ -17,9 +17,9 @@ DOFVecInterpolationSideBase<EvalT, Traits, Type>::
 DOFVecInterpolationSideBase(const Teuchos::ParameterList& p,
                             const Teuchos::RCP<Albany::Layouts>& dl_side) :
   sideSetName (p.get<std::string> ("Side Set Name")),
-  val_node    (p.get<std::string> ("Variable Name"), (dl_side->useCollapsedSidesets) ? dl_side->node_vector_sideset : dl_side->node_vector),
-  BF          (p.get<std::string> ("BF Name"), (dl_side->useCollapsedSidesets) ? dl_side->node_qp_scalar_sideset : dl_side->node_qp_scalar),
-  val_qp      (p.get<std::string> ("Variable Name"), (dl_side->useCollapsedSidesets) ? dl_side->qp_vector_sideset : dl_side->qp_vector)
+  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_vector_sideset),
+  BF          (p.get<std::string> ("BF Name"), dl_side->node_qp_scalar_sideset),
+  val_qp      (p.get<std::string> ("Variable Name"), dl_side->qp_vector_sideset)
 {
   TEUCHOS_TEST_FOR_EXCEPTION (!dl_side->isSideLayouts, Teuchos::Exceptions::InvalidParameter,
                               "Error! The layouts structure does not appear to be that of a side set.\n");
@@ -33,8 +33,6 @@ DOFVecInterpolationSideBase(const Teuchos::ParameterList& p,
   numSideNodes = dl_side->node_qp_scalar->extent(2);
   numSideQPs   = dl_side->node_qp_scalar->extent(3);
   vecDim       = dl_side->qp_vector->extent(3);
-
-  useCollapsedSidesets = dl_side->useCollapsedSidesets;
 }
 
 //**********************************************************************
@@ -55,27 +53,7 @@ postRegistrationSetup(typename Traits::SetupData d,
 template<typename EvalT, typename Traits, typename Type>
 KOKKOS_INLINE_FUNCTION
 void DOFVecInterpolationSideBase<EvalT, Traits, Type>::
-operator() (const DOFVecInterpolationSideBase_Tag& tag, const int& sideSet_idx) const {
-  
-  // Get the local data of side and cell
-  const int cell = sideSet.elem_LID(sideSet_idx);
-  const int side = sideSet.side_local_id(sideSet_idx);
-  
-  for (int dim=0; dim<vecDim; ++dim) {
-    for (int qp=0; qp<numSideQPs; ++qp) {
-      val_qp(cell,side,qp,dim) = val_node(cell,side,0,dim) * BF(cell,side,0,qp);
-      for (int node=1; node<numSideNodes; ++node) {
-        val_qp(cell,side,qp,dim) += val_node(cell,side,node,dim) * BF(cell,side,node,qp);
-      }
-    }
-  }
-
-}
-
-template<typename EvalT, typename Traits, typename Type>
-KOKKOS_INLINE_FUNCTION
-void DOFVecInterpolationSideBase<EvalT, Traits, Type>::
-operator() (const DOFVecInterpolationSideBase_Collapsed_Tag& tag, const int& sideSet_idx) const {
+operator() (const VecInterpolationSide_Tag& tag, const int& sideSet_idx) const {
   
   for (int dim=0; dim<vecDim; ++dim) {
     for (int qp=0; qp<numSideQPs; ++qp) {
@@ -93,60 +71,12 @@ template<typename EvalT, typename Traits, typename Type>
 void DOFVecInterpolationSideBase<EvalT, Traits, Type>::
 evaluateFields(typename Traits::EvalData workset)
 {
-  if (workset.sideSetViews->find(sideSetName)==workset.sideSetViews->end())
-    return;
+  if (workset.sideSetViews->find(sideSetName)==workset.sideSetViews->end()) return;
   if (memoizer.have_saved_data(workset,this->evaluatedFields())) return;
 
   sideSet = workset.sideSetViews->at(sideSetName);
-#ifdef ALBANY_KOKKOS_UNDER_DEVELOPMENT
-if (useCollapsedSidesets) {
-    Kokkos::parallel_for(DOFVecInterpolationSideBase_Collapsed_Policy(0, sideSet.size), *this);
-  } else {
-    for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-    {
-      // Get the local data of side and cell
-      const int cell = sideSet.elem_LID(sideSet_idx);
-      const int side = sideSet.side_local_id(sideSet_idx);
 
-      for (int dim=0; dim<vecDim; ++dim) {
-        for (int qp=0; qp<numSideQPs; ++qp) {
-          val_qp(cell,side,qp,dim) = val_node(cell,side,0,dim) * BF(cell,side,0,qp);
-          for (int node=1; node<numSideNodes; ++node) {
-            val_qp(cell,side,qp,dim) += val_node(cell,side,node,dim) * BF(cell,side,node,qp);
-          }
-        }
-      }
-    }
-  }
-#else
-  for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-  {
-    // Get the local data of side and cell
-    const int cell = sideSet.elem_LID(sideSet_idx);
-    const int side = sideSet.side_local_id(sideSet_idx);
-
-    if (useCollapsedSidesets) {
-      for (int dim=0; dim<vecDim; ++dim) {
-        for (int qp=0; qp<numSideQPs; ++qp) {
-          val_qp(sideSet_idx,qp,dim) = val_node(sideSet_idx,0,dim) * BF(sideSet_idx,0,qp);
-          for (int node=1; node<numSideNodes; ++node) {
-            val_qp(sideSet_idx,qp,dim) += val_node(sideSet_idx,node,dim) * BF(sideSet_idx,node,qp);
-          }
-        }
-      }
-    } else {
-      for (int dim=0; dim<vecDim; ++dim) {
-        for (int qp=0; qp<numSideQPs; ++qp) {
-          val_qp(cell,side,qp,dim) = val_node(cell,side,0,dim) * BF(cell,side,0,qp);
-          for (int node=1; node<numSideNodes; ++node) {
-            val_qp(cell,side,qp,dim) += val_node(cell,side,node,dim) * BF(cell,side,node,qp);
-          }
-        }
-      }
-    }
-  }
-#endif
-
+  Kokkos::parallel_for(VecInterpolationSide_Policy(0, sideSet.size), *this);
 }
 
 } // Namespace PHAL

--- a/src/evaluators/pde/PHAL_SideLaplacianResidual.hpp
+++ b/src/evaluators/pde/PHAL_SideLaplacianResidual.hpp
@@ -46,7 +46,7 @@ private:
   PHX::MDField<RealType>                                BF;
   PHX::MDField<MeshScalarT>                             GradBF;
   PHX::MDField<MeshScalarT>                             w_measure;
-  PHX::MDField<MeshScalarT,Cell,Side,QuadPoint,Dim,Dim> metric; // Only used in 2D, so we know the layout
+  PHX::MDField<MeshScalarT> metric; // Only used in 2D, so we know the layout (Cell,Side,QuadPoint,Dim,Dim)
 
   PHX::MDField<ScalarT>                                 u;
   PHX::MDField<ScalarT>                                 grad_u;
@@ -54,8 +54,10 @@ private:
   // Output:
   PHX::MDField<ScalarT,Cell,Node>                       residual; // Always a 3D residual, so we know the layout
 
+  Albany::LocalSideSetInfo sideSet;
+
   std::string                     sideSetName;
-  std::vector<std::vector<int> >  sideNodes;
+  Kokkos::View<int**, PHX::Device> sideNodes;
 
   int spaceDim;
   int gradDim;
@@ -63,6 +65,21 @@ private:
   int numQPs;
 
   bool sideSetEquation;
+
+public:
+
+  typedef Kokkos::View<int***, PHX::Device>::execution_space ExecutionSpace;
+
+  struct SideLaplacianResidual_Side_Tag{};
+  struct SideLaplacianResidual_Cell_Tag{};
+
+  typedef Kokkos::RangePolicy<ExecutionSpace,SideLaplacianResidual_Side_Tag> SideLaplacianResidual_Side_Policy;
+  typedef Kokkos::RangePolicy<ExecutionSpace,SideLaplacianResidual_Cell_Tag> SideLaplacianResidual_Cell_Policy;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const SideLaplacianResidual_Side_Tag& tag, const int& i) const;
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const SideLaplacianResidual_Cell_Tag& tag, const int& i) const;
 };
 
 } // Namespace PHAL

--- a/src/evaluators/pde/PHAL_SideLaplacianResidual_Def.hpp
+++ b/src/evaluators/pde/PHAL_SideLaplacianResidual_Def.hpp
@@ -31,12 +31,12 @@ SideLaplacianResidual<EvalT, Traits>::SideLaplacianResidual (const Teuchos::Para
 
     auto dl_side = dl->side_layouts.at(sideSetName);
 
-    u          = PHX::MDField<ScalarT>(p.get<std::string> ("Solution QP Variable Name"), dl_side->qp_scalar);
-    grad_u     = PHX::MDField<ScalarT>(p.get<std::string> ("Solution Gradient QP Variable Name"), dl_side->qp_gradient);
-    BF         = PHX::MDField<RealType>(p.get<std::string> ("BF Variable Name"), dl_side->node_qp_scalar);
-    GradBF     = PHX::MDField<MeshScalarT>(p.get<std::string> ("Gradient BF Variable Name"), dl_side->node_qp_gradient);
-    w_measure  = PHX::MDField<MeshScalarT>(p.get<std::string> ("Weighted Measure Variable Name"), dl_side->qp_scalar);
-    metric     = PHX::MDField<MeshScalarT,Cell,Side,QuadPoint,Dim,Dim>(p.get<std::string> ("Metric Name"), dl_side->qp_tensor);
+    u          = PHX::MDField<ScalarT>(p.get<std::string> ("Solution QP Variable Name"), dl_side->qp_scalar_sideset);
+    grad_u     = PHX::MDField<ScalarT>(p.get<std::string> ("Solution Gradient QP Variable Name"), dl_side->qp_gradient_sideset);
+    BF         = PHX::MDField<RealType>(p.get<std::string> ("BF Variable Name"), dl_side->node_qp_scalar_sideset);
+    GradBF     = PHX::MDField<MeshScalarT>(p.get<std::string> ("Gradient BF Variable Name"), dl_side->node_qp_gradient_sideset);
+    w_measure  = PHX::MDField<MeshScalarT>(p.get<std::string> ("Weighted Measure Variable Name"), dl_side->qp_scalar_sideset);
+    metric     = PHX::MDField<MeshScalarT>(p.get<std::string> ("Metric Name"), dl_side->qp_tensor_sideset);
     this->addDependentField(metric.fieldTag());
 
     int numSides = dl_side->cell_gradient->extent(1);
@@ -47,14 +47,17 @@ SideLaplacianResidual<EvalT, Traits>::SideLaplacianResidual (const Teuchos::Para
     // Index of the nodes on the sides in the numeration of the cell
     Teuchos::RCP<shards::CellTopology> cellType;
     cellType = p.get<Teuchos::RCP <shards::CellTopology> > ("Cell Type");
-    sideNodes.resize(numSides);
-    for (int side=0; side<numSides; ++side)
-    {
-      // Need to get the subcell exact count, since different sides may have different number of nodes (e.g., Wedge)
-      int thisSideNodes = cellType->getNodeCount(sideDim,side);
-      sideNodes[side].resize(thisSideNodes);
-      for (int node=0; node<thisSideNodes; ++node)
-        sideNodes[side][node] = cellType->getNodeMap(sideDim,side,node);
+    unsigned int nodeMax = 0;
+    for (unsigned int side=0; side<numSides; ++side) {
+      unsigned int thisSideNodes = cellType->getNodeCount(sideDim,side);
+      nodeMax = std::max(nodeMax, thisSideNodes);
+    }
+    sideNodes = Kokkos::View<int**, PHX::Device>("sideNodes", numSides, nodeMax);
+    for (unsigned int side=0; side<numSides; ++side) {
+      unsigned int thisSideNodes = cellType->getNodeCount(sideDim,side);
+      for (unsigned int node=0; node<thisSideNodes; ++node) {
+        sideNodes(side,node) = cellType->getNodeMap(sideDim,side,node);
+      }
     }
   }
   else
@@ -102,6 +105,52 @@ postRegistrationSetup(typename Traits::SetupData d,
 }
 
 //**********************************************************************
+//Kokkos functor
+template<typename EvalT, typename Traits>
+KOKKOS_INLINE_FUNCTION
+void SideLaplacianResidual<EvalT,Traits>::
+operator() (const SideLaplacianResidual_Side_Tag& tag, const int& sideSet_idx) const {
+
+  // Get the local data of side and cell
+  const int cell = sideSet.elem_LID(sideSet_idx);
+  const int side = sideSet.side_local_id(sideSet_idx);
+
+  // Assembling the residual of -\Delta u + u = f
+  for (int node=0; node<numNodes; ++node) {
+    for (int qp=0; qp<numQPs; ++qp) {
+      for (int idim(0); idim<gradDim; ++idim) {
+        for (int jdim(0); jdim<gradDim; ++jdim) {
+          residual(cell,sideNodes(side,node)) -= grad_u(sideSet_idx,qp,idim)
+                                                * metric(sideSet_idx,qp,idim,jdim)
+                                                * GradBF(sideSet_idx,node,qp,jdim)
+                                                * w_measure(sideSet_idx,qp);
+        }
+      }
+      residual(cell,sideNodes(side,node)) += 1.0 * BF(sideSet_idx,node,qp) * w_measure(sideSet_idx,qp);
+    }
+  }
+
+}
+
+template<typename EvalT, typename Traits>
+KOKKOS_INLINE_FUNCTION
+void SideLaplacianResidual<EvalT,Traits>::
+operator() (const SideLaplacianResidual_Cell_Tag& tag, const int& cell) const {
+
+  // Assembling the residual of -\Delta u + u = f
+  for (int node(0); node<numNodes; ++node) {
+    residual(cell,node) = 0;
+    for (int qp=0; qp<numQPs; ++qp) {
+      for (int idim(0); idim<gradDim; ++idim) {
+        residual(cell,node) -= grad_u(cell,qp,idim)*GradBF(cell,node,qp,idim)*w_measure(cell,qp);
+      }
+      residual(cell,node) += 1.0*BF(cell,node,qp)*w_measure(cell,qp);
+    }
+  }
+
+}
+
+//**********************************************************************
 template<typename EvalT, typename Traits>
 void SideLaplacianResidual<EvalT, Traits>::evaluateFields (typename Traits::EvalData workset)
 {
@@ -118,53 +167,15 @@ void SideLaplacianResidual<EvalT, Traits>::evaluateFieldsSide (typename Traits::
   if (workset.sideSets->find(sideSetName)==workset.sideSets->end())
     return;
 
-  const std::vector<Albany::SideStruct>& sideSet = workset.sideSets->at(sideSetName);
-  for (auto const& it_side : sideSet)
-  {
-    // Get the local data of side and cell
-    const int cell = it_side.elem_LID;
-    const int side = it_side.side_local_id;
-
-    // Assembling the residual of -\Delta u + u = f
-    for (int node=0; node<numNodes; ++node)
-    {
-      for (int qp=0; qp<numQPs; ++qp)
-      {
-        for (int idim(0); idim<gradDim; ++idim)
-        {
-          for (int jdim(0); jdim<gradDim; ++jdim)
-          {
-            residual(cell,sideNodes[side][node]) -= grad_u(cell,side,qp,idim)
-                                                  * metric(cell,side,qp,idim,jdim)
-                                                  * GradBF(cell,side,node,qp,jdim)
-                                                  * w_measure(cell,side,qp);
-          }
-        }
-        residual(cell,sideNodes[side][node]) += 1.0 * BF(cell,side,node,qp) * w_measure(cell,side,qp);
-      }
-    }
-  }
+  sideSet = workset.sideSetViews->at(sideSetName);
+  
+  Kokkos::parallel_for(SideLaplacianResidual_Side_Policy(0, sideSet.size), *this);
 }
 
 template<typename EvalT, typename Traits>
 void SideLaplacianResidual<EvalT,Traits>::evaluateFieldsCell (typename Traits::EvalData workset)
 {
-  for (size_t cell(0); cell<workset.numCells; ++cell)
-  {
-    // Assembling the residual of -\Delta u + u = f
-    for (int node(0); node<numNodes; ++node)
-    {
-      residual(cell,node) = 0;
-      for (int qp=0; qp<numQPs; ++qp)
-      {
-        for (int idim(0); idim<gradDim; ++idim)
-        {
-          residual(cell,node) -= grad_u(cell,qp,idim)*GradBF(cell,node,qp,idim)*w_measure(cell,qp);
-        }
-        residual(cell,node) += 1.0*BF(cell,node,qp)*w_measure(cell,qp);
-      }
-    }
-  }
+  Kokkos::parallel_for(SideLaplacianResidual_Cell_Policy(0, workset.numCells), *this);
 }
 
 } // namespace PHAL

--- a/src/evaluators/state/PHAL_LoadSideSetStateField.hpp
+++ b/src/evaluators/state/PHAL_LoadSideSetStateField.hpp
@@ -42,8 +42,6 @@ private:
   std::string fieldName;
   std::string stateName;
 
-  bool useCollapsedLayouts;
-
   Albany::LocalSideSetInfo sideSet;
 
   MDFieldMemoizer<Traits> memoizer;

--- a/src/evaluators/state/PHAL_SaveSideSetStateField.hpp
+++ b/src/evaluators/state/PHAL_SaveSideSetStateField.hpp
@@ -70,7 +70,6 @@ private:
   std::string stateName;
 
   bool nodalState;
-  bool useCollapsedSidesets;
 
   Kokkos::View<int**, PHX::Device> sideNodes;
 

--- a/src/evaluators/state/PHAL_SaveSideSetStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_SaveSideSetStateField_Def.hpp
@@ -59,24 +59,15 @@ SaveSideSetStateField (const Teuchos::ParameterList& p,
 
   savestate_operation = Teuchos::rcp(new PHX::Tag<ScalarT>(fieldName, dl->dummy));
 
-  useCollapsedSidesets = dl->useCollapsedSidesets;
-
   this->addDependentField (field.fieldTag());
   this->addEvaluatedField (*savestate_operation);
 
   if (nodalState)
   {
-    if (useCollapsedSidesets) {
-      TEUCHOS_TEST_FOR_EXCEPTION(field.fieldTag().dataLayout().size()<2, Teuchos::Exceptions::InvalidParameter,
-                                  "Error! To save a side-set nodal state, pass the cell-side-based version of it (<Cell,Side,Node,...>).\n");
-      TEUCHOS_TEST_FOR_EXCEPTION(field.fieldTag().dataLayout().name(1)!=PHX::print<Node>(), Teuchos::Exceptions::InvalidParameter,
-                                  "Error! To save a side-set nodal state, the third tag of the layout MUST be 'Node'.\n");
-    } else {
-      TEUCHOS_TEST_FOR_EXCEPTION(field.fieldTag().dataLayout().size()<3, Teuchos::Exceptions::InvalidParameter,
-                                  "Error! To save a side-set nodal state, pass the cell-side-based version of it (<Cell,Side,Node,...>).\n");
-      TEUCHOS_TEST_FOR_EXCEPTION(field.fieldTag().dataLayout().name(2)!=PHX::print<Node>(), Teuchos::Exceptions::InvalidParameter,
-                                  "Error! To save a side-set nodal state, the third tag of the layout MUST be 'Node'.\n");
-    }
+    TEUCHOS_TEST_FOR_EXCEPTION(field.fieldTag().dataLayout().size()<2, Teuchos::Exceptions::InvalidParameter,
+                                  "Error! To save a side-set nodal state, pass the side-based version of it (<Side,Node,...>).\n");
+    TEUCHOS_TEST_FOR_EXCEPTION(field.fieldTag().dataLayout().name(1)!=PHX::print<Node>(), Teuchos::Exceptions::InvalidParameter,
+                                  "Error! To save a side-set nodal state, the second tag of the layout MUST be 'Node'.\n");
 
     Teuchos::RCP<shards::CellTopology> cellType;
     cellType = p.get<Teuchos::RCP <shards::CellTopology> > ("Cell Type");
@@ -171,10 +162,7 @@ saveElemState(typename Traits::EvalData workset)
   std::vector<PHX::DataLayout::size_type> dims;
   field.dimensions(dims);
   const std::string& tag1 = dims.size()>1 ? field.fieldTag().dataLayout().name(1) : "";
-  const std::string& tag2 = dims.size()>2 ? field.fieldTag().dataLayout().name(2) : "";
-  TEUCHOS_TEST_FOR_EXCEPTION (useCollapsedSidesets && dims.size()>1 && tag1!=PHX::print<Node>() && tag1!=PHX::print<Dim>() && tag1!=PHX::print<VecDim>(), std::logic_error,
-                              "Error! Invalid field layout in SaveSideSetStateField.\n");
-  TEUCHOS_TEST_FOR_EXCEPTION (!useCollapsedSidesets && dims.size()>2 && tag2!=PHX::print<Node>() && tag2!=PHX::print<Dim>() && tag2!=PHX::print<VecDim>(), std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (dims.size()>1 && tag1!=PHX::print<Node>() && tag1!=PHX::print<Dim>() && tag1!=PHX::print<VecDim>(), std::logic_error,
                               "Error! Invalid field layout in SaveSideSetStateField.\n");
 
   // Loop on the sides of this sideSet that are in this workset
@@ -215,106 +203,54 @@ saveElemState(typename Traits::EvalData workset)
     field.dimensions(dims);
     int size = dims.size();
 
-    if (useCollapsedSidesets) {
-      switch (size)
-      {
-        case 1:
-          // side set cell scalar
-          state(ss_cell) = field(sideSet_idx);
-          break;
+    switch (size)
+    {
+      case 1:
+        // side set cell scalar
+        state(ss_cell) = field(sideSet_idx);
+        break;
 
-        case 2:
-          if (tag1==PHX::print<Node>())
+      case 2:
+        if (tag1==PHX::print<Node>())
+        {
+          // side set node scalar
+          for (unsigned int node=0; node<dims[1]; ++node)
           {
-            // side set node scalar
-            for (unsigned int node=0; node<dims[1]; ++node)
-            {
-              state(ss_cell,nodeMap[node]) = field(sideSet_idx,node);
-            }
-          } else {
-            // side set cell vector/gradient
-            for (unsigned int idim=0; idim<dims[1]; ++idim)
-            {
-              state(ss_cell,(int) idim) = field(sideSet_idx,idim);
-            }
+            state(ss_cell,nodeMap[node]) = field(sideSet_idx,node);
           }
-          break;
+        } else {
+          // side set cell vector/gradient
+          for (unsigned int idim=0; idim<dims[1]; ++idim)
+          {
+            state(ss_cell,(int) idim) = field(sideSet_idx,idim);
+          }
+        }
+        break;
 
-        case 3:
-          if (tag1==PHX::print<Node>())
+      case 3:
+        if (tag1==PHX::print<Node>())
+        {
+          // side set node vector/gradient
+          for (unsigned int node=0; node<dims[1]; ++node)
           {
-            // side set node vector/gradient
-            for (unsigned int node=0; node<dims[1]; ++node)
-            {
-              for (unsigned int dim=0; dim<dims[2]; ++dim)
-                state(ss_cell,nodeMap[node],(int) dim) = field(sideSet_idx,node,dim);
-            }
+            for (unsigned int dim=0; dim<dims[2]; ++dim)
+              state(ss_cell,nodeMap[node],(int) dim) = field(sideSet_idx,node,dim);
           }
-          else
+        }
+        else
+        {
+          // side set cell tensor
+          for (unsigned int idim=0; idim<dims[1]; ++idim)
           {
-            // side set cell tensor
-            for (unsigned int idim=0; idim<dims[1]; ++idim)
-            {
-              for (unsigned int jdim=0; jdim<dims[2]; ++jdim)
-                state(ss_cell,(int) idim,(int) jdim) = field(sideSet_idx,idim,jdim);
-            }
+            for (unsigned int jdim=0; jdim<dims[2]; ++jdim)
+              state(ss_cell,(int) idim,(int) jdim) = field(sideSet_idx,idim,jdim);
           }
-          break;
+        }
+        break;
 
-        default:
-          TEUCHOS_TEST_FOR_EXCEPTION (true, std::logic_error,
-                                      "Error! Unexpected array dimensions in SaveSideSetStateField: " << size << ".\n");
-      }
-    } else {
-      switch (size)
-      {
-        case 2:
-          // side set cell scalar
-          state(ss_cell) = field(cell,side);
-          break;
-
-        case 3:
-          if (tag2==PHX::print<Node>())
-          {
-            // side set node scalar
-            for (unsigned int node=0; node<dims[2]; ++node)
-            {
-              state(ss_cell,nodeMap[node]) = field(cell,side,node);
-            }
-          } else {
-            // side set cell vector/gradient
-            for (unsigned int idim=0; idim<dims[2]; ++idim)
-            {
-              state(ss_cell,(int) idim) = field(cell,side,idim);
-            }
-          }
-          break;
-
-        case 4:
-          if (tag2==PHX::print<Node>())
-          {
-            // side set node vector/gradient
-            for (unsigned int node=0; node<dims[2]; ++node)
-            {
-              for (unsigned int dim=0; dim<dims[3]; ++dim)
-                state(ss_cell,nodeMap[node],(int) dim) = field(cell,side,node,dim);
-            }
-          }
-          else
-          {
-            // side set cell tensor
-            for (unsigned int idim=0; idim<dims[2]; ++idim)
-            {
-              for (unsigned int jdim=0; jdim<dims[3]; ++jdim)
-                state(ss_cell,(int) idim,(int) jdim) = field(cell,side,idim,jdim);
-            }
-          }
-          break;
-
-        default:
-          TEUCHOS_TEST_FOR_EXCEPTION (true, std::logic_error,
-                                      "Error! Unexpected array dimensions in SaveSideSetStateField: " << size << ".\n");
-      }
+      default:
+        TEUCHOS_TEST_FOR_EXCEPTION (true, std::logic_error,
+                                    "Error! Unexpected array dimensions in SaveSideSetStateField: " << size << ".\n");
     }
 
   }
@@ -399,87 +335,44 @@ saveNodeState(typename Traits::EvalData workset)
 
     // Loop on the sides of this sideSet that are in this workset
     sideSet = workset.sideSetViews->at(sideSetName);
-    if (useCollapsedSidesets) {
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the data that corresponds to the side
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
+    for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+    {
+      // Get the data that corresponds to the side
+      const int cell = sideSet.elem_LID(sideSet_idx);
+      const int side = sideSet.side_local_id(sideSet_idx);
 
-        // Notice: in the following, we retrieve the id of the stk node using the 3d mesh.
-        //         This is because the id of entities is the same (please don't change that)
-        //         and it is easier to retrieve the id from the 3d discretization.
-        //         Then, we use the id to extract the node from the 2d mesh.
-        switch (dims.size())
-        {
-          case 2:   // node_scalar
-            scalar_field = metaData.get_field<SFT> (stk::topology::NODE_RANK, stateName);
-            TEUCHOS_TEST_FOR_EXCEPTION (scalar_field==0, std::runtime_error, "Error! Field not found.\n");
-            for (size_t node=0; node<dims[1]; ++node)
-            {
-              nodeId3d = ElNodeID[cell][sideNodes(side,node)];
-              stk::mesh::EntityKey key(stk::topology::NODE_RANK, nodeId3d+1);
-              e = bulkData.get_entity(key);
-              values = stk::mesh::field_data(*scalar_field, e);
-              values[0] = field(sideSet_idx,node);
-            }
-            break;
-          case 3:   // node_vector
-            vector_field = metaData.get_field<VFT> (stk::topology::NODE_RANK, stateName);
-            TEUCHOS_TEST_FOR_EXCEPTION (vector_field==0, std::runtime_error, "Error! Field not found.\n");
-            for (size_t node=0; node<dims[1]; ++node)
-            {
-              nodeId3d = ElNodeID[cell][sideNodes(side,node)];
-              e = bulkData.get_entity(stk::topology::NODE_RANK, nodeId3d+1);
-              values = stk::mesh::field_data(*vector_field, e);
-              for (unsigned int i=0; i<dims[2]; ++i)
-                values[i] = field(sideSet_idx,node,i);
-            }
-            break;
-          default:  // error!
-            TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error! Unexpected field dimension (only node_scalar/node_vector for now).\n");
-        }
-      }
-    } else {
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+      // Notice: in the following, we retrieve the id of the stk node using the 3d mesh.
+      //         This is because the id of entities is the same (please don't change that)
+      //         and it is easier to retrieve the id from the 3d discretization.
+      //         Then, we use the id to extract the node from the 2d mesh.
+      switch (dims.size())
       {
-        // Get the data that corresponds to the side
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
-
-        // Notice: in the following, we retrieve the id of the stk node using the 3d mesh.
-        //         This is because the id of entities is the same (please don't change that)
-        //         and it is easier to retrieve the id from the 3d discretization.
-        //         Then, we use the id to extract the node from the 2d mesh.
-        switch (dims.size())
-        {
-          case 3:   // node_scalar
-            scalar_field = metaData.get_field<SFT> (stk::topology::NODE_RANK, stateName);
-            TEUCHOS_TEST_FOR_EXCEPTION (scalar_field==0, std::runtime_error, "Error! Field not found.\n");
-            for (size_t node=0; node<dims[2]; ++node)
-            {
-              nodeId3d = ElNodeID[cell][sideNodes(side,node)];
-              stk::mesh::EntityKey key(stk::topology::NODE_RANK, nodeId3d+1);
-              e = bulkData.get_entity(key);
-              values = stk::mesh::field_data(*scalar_field, e);
-              values[0] = field(cell,side,node);
-            }
-            break;
-          case 4:   // node_vector
-            vector_field = metaData.get_field<VFT> (stk::topology::NODE_RANK, stateName);
-            TEUCHOS_TEST_FOR_EXCEPTION (vector_field==0, std::runtime_error, "Error! Field not found.\n");
-            for (size_t node=0; node<dims[2]; ++node)
-            {
-              nodeId3d = ElNodeID[cell][sideNodes(side,node)];
-              e = bulkData.get_entity(stk::topology::NODE_RANK, nodeId3d+1);
-              values = stk::mesh::field_data(*vector_field, e);
-              for (unsigned int i=0; i<dims[3]; ++i)
-                values[i] = field(cell,side,node,i);
-            }
-            break;
-          default:  // error!
-            TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error! Unexpected field dimension (only node_scalar/node_vector for now).\n");
-        }
+        case 2:   // node_scalar
+          scalar_field = metaData.get_field<SFT> (stk::topology::NODE_RANK, stateName);
+          TEUCHOS_TEST_FOR_EXCEPTION (scalar_field==0, std::runtime_error, "Error! Field not found.\n");
+          for (size_t node=0; node<dims[1]; ++node)
+          {
+            nodeId3d = ElNodeID[cell][sideNodes(side,node)];
+            stk::mesh::EntityKey key(stk::topology::NODE_RANK, nodeId3d+1);
+            e = bulkData.get_entity(key);
+            values = stk::mesh::field_data(*scalar_field, e);
+            values[0] = field(sideSet_idx,node);
+          }
+          break;
+        case 3:   // node_vector
+          vector_field = metaData.get_field<VFT> (stk::topology::NODE_RANK, stateName);
+          TEUCHOS_TEST_FOR_EXCEPTION (vector_field==0, std::runtime_error, "Error! Field not found.\n");
+          for (size_t node=0; node<dims[1]; ++node)
+          {
+            nodeId3d = ElNodeID[cell][sideNodes(side,node)];
+            e = bulkData.get_entity(stk::topology::NODE_RANK, nodeId3d+1);
+            values = stk::mesh::field_data(*vector_field, e);
+            for (unsigned int i=0; i<dims[2]; ++i)
+              values[i] = field(sideSet_idx,node,i);
+          }
+          break;
+        default:  // error!
+          TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error! Unexpected field dimension (only node_scalar/node_vector for now).\n");
       }
     }
   }
@@ -492,88 +385,45 @@ saveNodeState(typename Traits::EvalData workset)
 
     // Loop on the sides of this sideSet that are in this workset
     sideSet = workset.sideSetViews->at(sideSetName);
-    if (useCollapsedSidesets) { 
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the data that corresponds to the side
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
+    for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+    {
+      // Get the data that corresponds to the side
+      const int cell = sideSet.elem_LID(sideSet_idx);
+      const int side = sideSet.side_local_id(sideSet_idx);
 
-        switch (dims.size())
-        {
-          case 2:   // node_scalar
-            scalar_field = metaData.get_field<SFT> (stk::topology::NODE_RANK, stateName);
-            TEUCHOS_TEST_FOR_EXCEPTION (scalar_field==0, std::runtime_error, "Error! Field not found.\n");
-            for (size_t node=0; node<dims[1]; ++node)
-            {
-              nodeId3d = ElNodeID[cell][sideNodes(side,node)];
-              nodeId2d = layeredMeshNumbering->getColumnId(nodeId3d);
-              stk::mesh::EntityKey key(stk::topology::NODE_RANK, nodeId2d+1);
-              e = bulkData.get_entity(key);
-              values = stk::mesh::field_data(*scalar_field, e);
-              values[0] = field(sideSet_idx,node);
-            }
-            break;
-          case 3:   // node_vector
-            vector_field = metaData.get_field<VFT> (stk::topology::NODE_RANK, stateName);
-            TEUCHOS_TEST_FOR_EXCEPTION (vector_field==0, std::runtime_error, "Error! Field not found.\n");
-            for (size_t node=0; node<dims[1]; ++node)
-            {
-              nodeId3d = ElNodeID[cell][sideNodes(side,node)];
-              nodeId2d = layeredMeshNumbering->getColumnId(nodeId3d);
-              stk::mesh::EntityKey key(stk::topology::NODE_RANK, nodeId2d+1);
-              e = bulkData.get_entity(key);
-              values = stk::mesh::field_data(*vector_field, e);
-              for (size_t i=0; i<dims[2]; ++i)
-                values[i] = field(sideSet_idx,node,i);
-            }
-            break;
-          default:  // error!
-            TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error! Unexpected field dimension (only node_scalar/node_vector for now).\n");
-        }
-      }
-    } else {
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+      switch (dims.size())
       {
-        // Get the data that corresponds to the side
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
-
-        switch (dims.size())
-        {
-          case 3:   // node_scalar
-            scalar_field = metaData.get_field<SFT> (stk::topology::NODE_RANK, stateName);
-            TEUCHOS_TEST_FOR_EXCEPTION (scalar_field==0, std::runtime_error, "Error! Field not found.\n");
-            for (size_t node=0; node<dims[2]; ++node)
-            {
-              nodeId3d = ElNodeID[cell][sideNodes(side,node)];
-              nodeId2d = layeredMeshNumbering->getColumnId(nodeId3d);
-              stk::mesh::EntityKey key(stk::topology::NODE_RANK, nodeId2d+1);
-              e = bulkData.get_entity(key);
-              values = stk::mesh::field_data(*scalar_field, e);
-              values[0] = field(cell,side,node);
-            }
-            break;
-          case 4:   // node_vector
-            vector_field = metaData.get_field<VFT> (stk::topology::NODE_RANK, stateName);
-            TEUCHOS_TEST_FOR_EXCEPTION (vector_field==0, std::runtime_error, "Error! Field not found.\n");
-            for (size_t node=0; node<dims[2]; ++node)
-            {
-              nodeId3d = ElNodeID[cell][sideNodes(side,node)];
-              nodeId2d = layeredMeshNumbering->getColumnId(nodeId3d);
-              stk::mesh::EntityKey key(stk::topology::NODE_RANK, nodeId2d+1);
-              e = bulkData.get_entity(key);
-              values = stk::mesh::field_data(*vector_field, e);
-              for (size_t i=0; i<dims[3]; ++i)
-                values[i] = field(cell,side,node,i);
-            }
-            break;
-          default:  // error!
-            TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error! Unexpected field dimension (only node_scalar/node_vector for now).\n");
-        }
+        case 2:   // node_scalar
+          scalar_field = metaData.get_field<SFT> (stk::topology::NODE_RANK, stateName);
+          TEUCHOS_TEST_FOR_EXCEPTION (scalar_field==0, std::runtime_error, "Error! Field not found.\n");
+          for (size_t node=0; node<dims[1]; ++node)
+          {
+            nodeId3d = ElNodeID[cell][sideNodes(side,node)];
+            nodeId2d = layeredMeshNumbering->getColumnId(nodeId3d);
+            stk::mesh::EntityKey key(stk::topology::NODE_RANK, nodeId2d+1);
+            e = bulkData.get_entity(key);
+            values = stk::mesh::field_data(*scalar_field, e);
+            values[0] = field(sideSet_idx,node);
+          }
+          break;
+        case 3:   // node_vector
+          vector_field = metaData.get_field<VFT> (stk::topology::NODE_RANK, stateName);
+          TEUCHOS_TEST_FOR_EXCEPTION (vector_field==0, std::runtime_error, "Error! Field not found.\n");
+          for (size_t node=0; node<dims[1]; ++node)
+          {
+            nodeId3d = ElNodeID[cell][sideNodes(side,node)];
+            nodeId2d = layeredMeshNumbering->getColumnId(nodeId3d);
+            stk::mesh::EntityKey key(stk::topology::NODE_RANK, nodeId2d+1);
+            e = bulkData.get_entity(key);
+            values = stk::mesh::field_data(*vector_field, e);
+            for (size_t i=0; i<dims[2]; ++i)
+              values[i] = field(sideSet_idx,node,i);
+          }
+          break;
+        default:  // error!
+          TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error! Unexpected field dimension (only node_scalar/node_vector for now).\n");
       }
     }
-
   }
 }
 

--- a/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide.hpp
+++ b/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide.hpp
@@ -83,8 +83,6 @@ private:
 
   Albany::LocalSideSetInfo sideSet;
 
-  bool useCollapsedSidesets;
-
 public:
 
   typedef Kokkos::View<int***, PHX::Device>::execution_space ExecutionSpace;

--- a/src/evaluators/utility/PHAL_MapToPhysicalFrameSide.hpp
+++ b/src/evaluators/utility/PHAL_MapToPhysicalFrameSide.hpp
@@ -58,8 +58,6 @@ private:
 
   Albany::LocalSideSetInfo sideSet;
 
-  bool useCollapsedSidesets;
-
   // Input:
   // TODO: restore layout template arguments when removing old sideset layout
   //! Values at vertices

--- a/src/problems/Albany_SideLaplacianProblem.cpp
+++ b/src/problems/Albany_SideLaplacianProblem.cpp
@@ -91,7 +91,7 @@ void SideLaplacian::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpe
     numSideQPs      = sideCubature->getNumPoints();
 
     dl_side = Teuchos::rcp(new Albany::Layouts(worksetSize,numSideVertices,numSideNodes,
-                                               numSideQPs,numDim-1,numDim,numCellSides,2));
+                                               numSideQPs,numDim-1,numDim,numCellSides,2,true,sideMeshSpecs.worksetSize));
     dl->side_layouts[sideSetName] = dl_side;
   }
 

--- a/src/problems/Albany_SideLaplacianProblem.hpp
+++ b/src/problems/Albany_SideLaplacianProblem.hpp
@@ -272,11 +272,11 @@ SideLaplacian::constructEvaluators3D (PHX::FieldManager<PHAL::AlbanyTraits>& fm0
   fm0.template registerEvaluator<EvalT> (ev);
 
   // -------- Restriction of Solution to Side Field -------- /
-  ev = evalUtils.constructDOFCellToSideEvaluator(dof_names[0],sideSetName,"Node Scalar",cellType);
+  ev = evalUtils.constructDOFCellToSideEvaluator(dof_names[0],sideSetName,"Node Scalar Sideset",cellType);
   fm0.template registerEvaluator<EvalT>(ev);
 
   //---- Restrict vertex coordinates from cell-based to cell-side-based
-  ev = evalUtils.getMSTUtils().constructDOFCellToSideEvaluator("Coord Vec",sideSetName,"Vertex Vector",cellType,"Coord Vec " + sideSetName);
+  ev = evalUtils.getMSTUtils().constructDOFCellToSideEvaluator("Coord Vec",sideSetName,"Vertex Vector Sideset",cellType,"Coord Vec " + sideSetName);
   fm0.template registerEvaluator<EvalT> (ev);
 
   // ------- Side Laplacian Residual -------- //


### PR DESCRIPTION
This pull request removes the duplicated implementations for collapsed and non-collapsed layouts from the majority of sideset evaluators. The LaplacianSampling and SideLaplacian problem files were also updated to use the new sideset layouts.

Additionally, the following evaluators were ported to have Kokkos implementations:

- w_Resid
- LaplacianRegularizationResidual
- SideLaplacianResidual

Sorry that the PR is fairly big. It is a bit misleading though since the majority of changes are deletions.