### PR TITLE
Sideset Refactor Cleanup - Phase 2

### DIFF
--- a/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient.hpp
@@ -45,9 +45,6 @@ public:
 
 private:
 
-  void evaluateFieldsSide (typename Traits::EvalData d, ScalarT mu, ScalarT lambda, ScalarT power);
-  void evaluateFieldsCell (typename Traits::EvalData d, ScalarT mu, ScalarT lambda, ScalarT power);
-
   // Coefficients for computing beta (if not given)
   double n;                                             // [adim] exponent of Glen's law
   PHX::MDField<const ScalarT,Dim> muPowerLaw;           // [yr^q m^{-q}], friction coefficient of the power Law with exponent q
@@ -119,123 +116,12 @@ public:
 
   typedef Kokkos::View<int***, PHX::Device>::execution_space ExecutionSpace;
 
-  struct GivenFieldParam_Tag{};
-  struct GivenField_Tag{};
-  struct PowerLaw_DistributedMu_Tag{};
-  struct PowerLaw_Tag{};
-  struct RegularizedCoulomb_DistributedLambda_DistributedMu_Tag{};
-  struct RegularizedCoulomb_DistributedLambda_Tag{};
-  struct RegularizedCoulomb_DistributedMu_Tag{};
-  struct RegularizedCoulomb_Tag{};
-  struct ExpGivenFieldParam_Nodal_Tag{};
-  struct ExpGivenFieldParam_Tag{};
-  struct ExpGivenField_Nodal_Tag{};
-  struct ExpGivenField_Tag{};
-  struct StereographicMapCorrection_Tag{};
+  struct BasalFrictionCoefficient_Tag{};
 
-  struct Side_GivenFieldParam_Tag{};
-  struct Side_GivenField_Tag{};
-  struct Side_PowerLaw_DistributedMu_Tag{};
-  struct Side_PowerLaw_Tag{};
-  struct Side_RegularizedCoulomb_DistributedLambda_DistributedMu_Tag{};
-  struct Side_RegularizedCoulomb_DistributedLambda_Tag{};
-  struct Side_RegularizedCoulomb_DistributedMu_Tag{};
-  struct Side_RegularizedCoulomb_Tag{};
-  struct Side_ExpGivenFieldParam_Nodal_Tag{};
-  struct Side_ExpGivenFieldParam_Tag{};
-  struct Side_ExpGivenField_Nodal_Tag{};
-  struct Side_ExpGivenField_Tag{};
-  struct Side_ZeroOnFloatingParam_Tag{};
-  struct Side_ZeroOnFloating_Tag{};
-  struct Side_StereographicMapCorrection_Tag{};
-
-  typedef Kokkos::RangePolicy<ExecutionSpace,GivenFieldParam_Tag> GivenFieldParam_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,GivenField_Tag> GivenField_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,PowerLaw_DistributedMu_Tag> PowerLaw_DistributedMu_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,PowerLaw_Tag> PowerLaw_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,RegularizedCoulomb_DistributedLambda_DistributedMu_Tag> RegularizedCoulomb_DistributedLambda_DistributedMu_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,RegularizedCoulomb_DistributedLambda_Tag> RegularizedCoulomb_DistributedLambda_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,RegularizedCoulomb_DistributedMu_Tag> RegularizedCoulomb_DistributedMu_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,RegularizedCoulomb_Tag> RegularizedCoulomb_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,ExpGivenFieldParam_Nodal_Tag> ExpGivenFieldParam_Nodal_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,ExpGivenFieldParam_Tag> ExpGivenFieldParam_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,ExpGivenField_Nodal_Tag> ExpGivenField_Nodal_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,ExpGivenField_Tag> ExpGivenField_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,StereographicMapCorrection_Tag> StereographicMapCorrection_Policy;
-
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_GivenFieldParam_Tag> Side_GivenFieldParam_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_GivenField_Tag> Side_GivenField_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_PowerLaw_DistributedMu_Tag> Side_PowerLaw_DistributedMu_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_PowerLaw_Tag> Side_PowerLaw_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_RegularizedCoulomb_DistributedLambda_DistributedMu_Tag> Side_RegularizedCoulomb_DistributedLambda_DistributedMu_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_RegularizedCoulomb_DistributedLambda_Tag> Side_RegularizedCoulomb_DistributedLambda_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_RegularizedCoulomb_DistributedMu_Tag> Side_RegularizedCoulomb_DistributedMu_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_RegularizedCoulomb_Tag> Side_RegularizedCoulomb_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_ExpGivenFieldParam_Nodal_Tag> Side_ExpGivenFieldParam_Nodal_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_ExpGivenFieldParam_Tag> Side_ExpGivenFieldParam_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_ExpGivenField_Nodal_Tag> Side_ExpGivenField_Nodal_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_ExpGivenField_Tag> Side_ExpGivenField_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_ZeroOnFloatingParam_Tag> Side_ZeroOnFloatingParam_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_ZeroOnFloating_Tag> Side_ZeroOnFloating_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,Side_StereographicMapCorrection_Tag> Side_StereographicMapCorrection_Policy;
+  typedef Kokkos::RangePolicy<ExecutionSpace,BasalFrictionCoefficient_Tag> BasalFrictionCoefficient_Policy;
 
   KOKKOS_INLINE_FUNCTION
-  void operator() (const GivenFieldParam_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const GivenField_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const PowerLaw_DistributedMu_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const PowerLaw_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const RegularizedCoulomb_DistributedLambda_DistributedMu_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const RegularizedCoulomb_DistributedLambda_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const RegularizedCoulomb_DistributedMu_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const RegularizedCoulomb_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const ExpGivenFieldParam_Nodal_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const ExpGivenFieldParam_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const ExpGivenField_Nodal_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const ExpGivenField_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const StereographicMapCorrection_Tag& tag, const int& i) const;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_GivenFieldParam_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_GivenField_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_PowerLaw_DistributedMu_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_PowerLaw_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_RegularizedCoulomb_DistributedLambda_DistributedMu_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_RegularizedCoulomb_DistributedLambda_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_RegularizedCoulomb_DistributedMu_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_RegularizedCoulomb_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_ExpGivenFieldParam_Nodal_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_ExpGivenFieldParam_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_ExpGivenField_Nodal_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_ExpGivenField_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_ZeroOnFloatingParam_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_ZeroOnFloating_Tag& tag, const int& i) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const Side_StereographicMapCorrection_Tag& tag, const int& i) const;
+  void operator() (const BasalFrictionCoefficient_Tag& tag, const int& i) const;
 
 };
 

--- a/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient.hpp
@@ -96,6 +96,7 @@ private:
   unsigned int numNodes;
   unsigned int numQPs;
   unsigned int dim;
+  unsigned int worksetSize;
 
   bool logParameters;
   bool distributedLambda;

--- a/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient.hpp
@@ -100,8 +100,6 @@ private:
   unsigned int numQPs;
   unsigned int dim;
 
-  bool useCollapsedSidesets;
-
   bool logParameters;
   bool distributedLambda;
   bool distributedMu;

--- a/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient_Def.hpp
@@ -236,255 +236,133 @@ postRegistrationSetup (typename Traits::SetupData d,
 }
 
 // *********************************************************************
-// Kokkos functor (Cell)
+// Kokkos functor
 template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
 KOKKOS_INLINE_FUNCTION
 void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const GivenFieldParam_Tag& tag, const int& cell) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt)
-    beta(cell,ipt) = given_field_param(cell,ipt);
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const GivenField_Tag& tag, const int& cell) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt)
-    beta(cell,ipt) = given_field(cell,ipt);
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const PowerLaw_DistributedMu_Tag& tag, const int& cell) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt)
-    beta(cell,ipt) = muPowerLawField(cell,ipt) * N(cell,ipt) * std::pow (u_norm(cell,ipt), power-1);
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const PowerLaw_Tag& tag, const int& cell) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt)
-    beta(cell,ipt) = mu * N(cell,ipt) * std::pow (u_norm(cell,ipt), power-1);
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const RegularizedCoulomb_DistributedLambda_DistributedMu_Tag& tag, const int& cell) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    ScalarT q = u_norm(cell,ipt) / ( u_norm(cell,ipt) + lambdaField(cell,ipt)*ice_softness(cell)*std::pow(N(cell,ipt),n) );
-    beta(cell,ipt) = muCoulombField(cell,ipt) * N(cell,ipt) * std::pow( q, power) / u_norm(cell,ipt);
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const RegularizedCoulomb_DistributedLambda_Tag& tag, const int& cell) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    ScalarT q = u_norm(cell,ipt) / ( u_norm(cell,ipt) + lambdaField(cell,ipt)*ice_softness(cell)*std::pow(N(cell,ipt),n) );
-    beta(cell,ipt) = mu * N(cell,ipt) * std::pow( q, power) / u_norm(cell,ipt);
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const RegularizedCoulomb_DistributedMu_Tag& tag, const int& cell) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    ScalarT q = u_norm(cell,ipt) / ( u_norm(cell,ipt) + lambda*ice_softness(cell)*std::pow(N(cell,ipt),n) );
-    beta(cell,ipt) = muCoulombField(cell,ipt) * N(cell,ipt) * std::pow( q, power) / u_norm(cell,ipt);
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const RegularizedCoulomb_Tag& tag, const int& cell) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    ScalarT q = u_norm(cell,ipt) / ( u_norm(cell,ipt) + lambda*ice_softness(cell)*std::pow(N(cell,ipt),n) );
-    beta(cell,ipt) = mu * N(cell,ipt) * std::pow( q, power) / u_norm(cell,ipt);
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const ExpGivenFieldParam_Nodal_Tag& tag, const int& cell) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    beta(cell,ipt) = std::exp(given_field_param(cell,ipt));
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const ExpGivenField_Nodal_Tag& tag, const int& cell) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    beta(cell,ipt) = std::exp(given_field(cell,ipt));
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const ExpGivenFieldParam_Tag& tag, const int& cell) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    beta(cell,ipt) = 0;
-    for (unsigned int node=0; node<numNodes; ++node)
-      beta(cell,ipt) += std::exp(given_field_param(cell,node))*BF(cell,node,ipt);
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const ExpGivenField_Tag& tag, const int& cell) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    beta(cell,ipt) = 0;
-    for (unsigned int node=0; node<numNodes; ++node)
-      beta(cell,ipt) += std::exp(given_field(cell,node))*BF(cell,node,ipt);
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const StereographicMapCorrection_Tag& tag, const int& cell) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    MeshScalarT x = coordVec(cell,ipt,0) - x_0;
-    MeshScalarT y = coordVec(cell,ipt,1) - y_0;
-    MeshScalarT h = 4.0*R2/(4.0*R2 + x*x + y*y);
-    beta(cell,ipt) *= h*h;
-  }
-}
+operator() (const BasalFrictionCoefficient_Tag& tag, const int& cell_or_side_idx) const {
 
-// *********************************************************************
-// Kokkos functor (Side)
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_GivenFieldParam_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt)
-    beta(sideSet_idx,ipt) = given_field_param(sideSet_idx,ipt);
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_GivenField_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt)
-    beta(sideSet_idx,ipt) = given_field(sideSet_idx,ipt);
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_PowerLaw_DistributedMu_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    ScalarT Nval = KU::max(N(sideSet_idx,ipt),0.0);
-    beta(sideSet_idx,ipt) = muPowerLawField(sideSet_idx,ipt) * Nval * std::pow (u_norm(sideSet_idx,ipt), power-1);
+  switch(beta_type) {
+    case GIVEN_CONSTANT:
+    break;
+
+    case GIVEN_FIELD:
+      if (is_given_field_param) {
+        for (unsigned int ipt=0; ipt<dim; ++ipt)
+          beta(cell_or_side_idx,ipt) = given_field_param(cell_or_side_idx,ipt);
+      } else {
+        for (unsigned int ipt=0; ipt<dim; ++ipt)
+          beta(cell_or_side_idx,ipt) = given_field(cell_or_side_idx,ipt);
+      }
+    break;
+    
+    case POWER_LAW:
+      if (distributedMu) {
+        for (unsigned int ipt=0; ipt<dim; ++ipt) {
+          ScalarT Nval = N(cell_or_side_idx,ipt);
+          if (is_side_equation) Nval = KU::max(Nval, 0.0);
+          beta(cell_or_side_idx,ipt) = muPowerLawField(cell_or_side_idx,ipt) * Nval * std::pow (u_norm(cell_or_side_idx,ipt), power-1);
+        }
+      } else {
+        for (unsigned int ipt=0; ipt<dim; ++ipt) {
+          ScalarT Nval = N(cell_or_side_idx,ipt);
+          if (is_side_equation) Nval = KU::max(Nval, 0.0);
+          beta(cell_or_side_idx,ipt) = mu * Nval * std::pow (u_norm(cell_or_side_idx,ipt), power-1);
+        }
+      }
+    break;
+
+    case REGULARIZED_COULOMB:
+      if (distributedLambda) {
+        if (distributedMu) {
+          for (unsigned int ipt=0; ipt<dim; ++ipt) {
+            ScalarT Nval = N(cell_or_side_idx,ipt);
+            if (is_side_equation) Nval = KU::max(Nval, 0.0);
+            ScalarT q = u_norm(cell_or_side_idx,ipt) / ( u_norm(cell_or_side_idx,ipt) + lambdaField(cell_or_side_idx,ipt)*ice_softness(cell_or_side_idx)*std::pow(Nval,n) );
+            beta(cell_or_side_idx,ipt) = muCoulombField(cell_or_side_idx,ipt) * Nval * std::pow( q, power) / u_norm(cell_or_side_idx,ipt);
+          }
+        } else {
+          for (unsigned int ipt=0; ipt<dim; ++ipt) {
+            ScalarT Nval = N(cell_or_side_idx,ipt);
+            if (is_side_equation) Nval = KU::max(Nval, 0.0);
+            ScalarT q = u_norm(cell_or_side_idx,ipt) / ( u_norm(cell_or_side_idx,ipt) + lambdaField(cell_or_side_idx,ipt)*ice_softness(cell_or_side_idx)*std::pow(Nval,n) );
+            beta(cell_or_side_idx,ipt) = mu * Nval * std::pow( q, power) / u_norm(cell_or_side_idx,ipt);
+          }
+        }
+      } else {
+        if (distributedMu) {
+          for (unsigned int ipt=0; ipt<dim; ++ipt) {
+            ScalarT Nval = N(cell_or_side_idx,ipt);
+            if (is_side_equation) Nval = KU::max(Nval, 0.0);
+            ScalarT q = u_norm(cell_or_side_idx,ipt) / ( u_norm(cell_or_side_idx,ipt) + lambda*ice_softness(cell_or_side_idx)*std::pow(Nval,n) );
+            beta(cell_or_side_idx,ipt) = muCoulombField(cell_or_side_idx,ipt) * Nval * std::pow( q, power) / u_norm(cell_or_side_idx,ipt);
+          }
+        } else {
+          for (unsigned int ipt=0; ipt<dim; ++ipt) {
+            ScalarT Nval = N(cell_or_side_idx,ipt);
+            if (is_side_equation) Nval = KU::max(Nval, 0.0);
+            ScalarT q = u_norm(cell_or_side_idx,ipt) / ( u_norm(cell_or_side_idx,ipt) + lambda*ice_softness(cell_or_side_idx)*std::pow(Nval,n) );
+            beta(cell_or_side_idx,ipt) = mu * Nval * std::pow( q, power) / u_norm(cell_or_side_idx,ipt);
+          }
+        }
+      }
+    break;
+
+    case EXP_GIVEN_FIELD:
+      if(nodal || interpolate_then_exponentiate) {
+        if (is_given_field_param) {
+          for (unsigned int ipt=0; ipt<dim; ++ipt)
+            beta(cell_or_side_idx,ipt) = std::exp(given_field_param(cell_or_side_idx,ipt));
+        } else {
+          for (unsigned int ipt=0; ipt<dim; ++ipt)
+            beta(cell_or_side_idx,ipt) = std::exp(given_field(cell_or_side_idx,ipt));
+        }
+      } else {
+        if (is_given_field_param) {
+          unsigned int exp_dim = is_side_equation ? numQPs : dim;
+          for (unsigned int ipt=0; ipt<exp_dim; ++ipt) {
+            beta(cell_or_side_idx,ipt) = 0;
+            for (unsigned int node=0; node<numNodes; ++node)
+              beta(cell_or_side_idx,ipt) += std::exp(given_field_param(cell_or_side_idx,node))*BF(cell_or_side_idx,node,ipt);  
+          }
+        } else {
+          unsigned int exp_dim = is_side_equation ? numQPs : dim;
+          for (unsigned int ipt=0; ipt<exp_dim; ++ipt) {
+            beta(cell_or_side_idx,ipt) = 0;
+            for (unsigned int node=0; node<numNodes; ++node)
+              beta(cell_or_side_idx,ipt) += std::exp(given_field(cell_or_side_idx,node))*BF(cell_or_side_idx,node,ipt);
+          }
+        }
+      }
+    break;
+
+    default:
+    break;
   }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_PowerLaw_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    ScalarT Nval = KU::max(N(sideSet_idx,ipt),0.0);
-    beta(sideSet_idx,ipt) = mu * Nval * std::pow (u_norm(sideSet_idx,ipt), power-1);
+
+  if (is_side_equation && zero_on_floating) {
+    if (is_thickness_param) {
+      for (unsigned int ipt=0; ipt<dim; ++ipt) {
+        ParamScalarT isGrounded = rho_i*thickness_param_field(cell_or_side_idx,ipt) > -rho_w*bed_topo_field_mst(cell_or_side_idx,ipt);
+        beta(cell_or_side_idx,ipt) *=  isGrounded;
+      }
+    } else {
+      for (unsigned int ipt=0; ipt<dim; ++ipt) {
+        ParamScalarT isGrounded = rho_i*thickness_field(cell_or_side_idx,ipt) > -rho_w*bed_topo_field(cell_or_side_idx,ipt);
+        beta(cell_or_side_idx,ipt) *=  isGrounded;
+      }
+    }
   }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_RegularizedCoulomb_DistributedLambda_DistributedMu_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    ScalarT Nval = KU::max(N(sideSet_idx,ipt),0.0);
-    ScalarT q = u_norm(sideSet_idx,ipt) / ( u_norm(sideSet_idx,ipt) + lambdaField(sideSet_idx,ipt)*ice_softness(sideSet_idx)*std::pow(Nval,n) );
-    beta(sideSet_idx,ipt) = muCoulombField(sideSet_idx,ipt) * Nval * std::pow( q, power) / u_norm(sideSet_idx,ipt);
+
+  if (use_stereographic_map) {
+    for (unsigned int ipt=0; ipt<dim; ++ipt) {
+      MeshScalarT x = coordVec(cell_or_side_idx,ipt,0) - x_0;
+      MeshScalarT y = coordVec(cell_or_side_idx,ipt,1) - y_0;
+      MeshScalarT h = 4.0*R2/(4.0*R2 + x*x + y*y);
+      beta(cell_or_side_idx,ipt) *= h*h;
+    }
   }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_RegularizedCoulomb_DistributedLambda_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    ScalarT Nval = KU::max(N(sideSet_idx,ipt),0.0);
-    ScalarT q = u_norm(sideSet_idx,ipt) / ( u_norm(sideSet_idx,ipt) + lambdaField(sideSet_idx,ipt)*ice_softness(sideSet_idx)*std::pow(Nval,n) );
-    beta(sideSet_idx,ipt) = mu * Nval * std::pow( q, power) / u_norm(sideSet_idx,ipt);
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_RegularizedCoulomb_DistributedMu_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    ScalarT Nval = KU::max(N(sideSet_idx,ipt),0.0);
-    ScalarT q = u_norm(sideSet_idx,ipt) / ( u_norm(sideSet_idx,ipt) + lambda*ice_softness(sideSet_idx)*std::pow(Nval,n) );
-    beta(sideSet_idx,ipt) = muCoulombField(sideSet_idx,ipt) * Nval * std::pow( q, power) / u_norm(sideSet_idx,ipt);
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_RegularizedCoulomb_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    ScalarT Nval = KU::max(N(sideSet_idx,ipt),0.0);
-    ScalarT q = u_norm(sideSet_idx,ipt) / ( u_norm(sideSet_idx,ipt) + lambda*ice_softness(sideSet_idx)*std::pow(Nval,n) );
-    beta(sideSet_idx,ipt) = mu * Nval * std::pow( q, power) / u_norm(sideSet_idx,ipt);
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_ExpGivenFieldParam_Nodal_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt)
-    beta(sideSet_idx,ipt) = std::exp(given_field_param(sideSet_idx,ipt));
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_ExpGivenFieldParam_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int qp=0; qp<numQPs; ++qp) {
-    beta(sideSet_idx,qp) = 0;
-    for (unsigned int node=0; node<numNodes; ++node)
-      beta(sideSet_idx,qp) += std::exp(given_field_param(sideSet_idx,node))*BF(sideSet_idx,node,qp);  
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_ExpGivenField_Nodal_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt)
-    beta(sideSet_idx,ipt) = std::exp(given_field(sideSet_idx,ipt));
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_ExpGivenField_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int qp=0; qp<numQPs; ++qp) {
-    beta(sideSet_idx,qp) = 0;
-    for (unsigned int node=0; node<numNodes; ++node)
-      beta(sideSet_idx,qp) += std::exp(given_field(sideSet_idx,node))*BF(sideSet_idx,node,qp);
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_ZeroOnFloatingParam_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    ParamScalarT isGrounded = rho_i*thickness_param_field(sideSet_idx,ipt) > -rho_w*bed_topo_field_mst(sideSet_idx,ipt);
-    beta(sideSet_idx,ipt) *=  isGrounded;
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_ZeroOnFloating_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    ParamScalarT isGrounded = rho_i*thickness_field(sideSet_idx,ipt) > -rho_w*bed_topo_field(sideSet_idx,ipt);
-    beta(sideSet_idx,ipt) *=  isGrounded;
-  }
-}
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-KOKKOS_INLINE_FUNCTION
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const Side_StereographicMapCorrection_Tag& tag, const int& sideSet_idx) const {
-  for (unsigned int ipt=0; ipt<dim; ++ipt) {
-    MeshScalarT x = coordVec(sideSet_idx,ipt,0) - x_0;
-    MeshScalarT y = coordVec(sideSet_idx,ipt,1) - y_0;
-    MeshScalarT h = 4.0*R2/(4.0*R2 + x*x + y*y);
-    beta(sideSet_idx,ipt) *= h*h;
-  }
+
 }
 
 //**********************************************************************
@@ -576,156 +454,14 @@ evaluateFields (typename Traits::EvalData workset)
                                 "\nError in LandIce::BasalFrictionCoefficient: \"Bed Roughness\" must be >= 0.\n");
   }
 
-  if (is_side_equation)
-    evaluateFieldsSide(workset,mu,lambda,power);
-  else
-    evaluateFieldsCell(workset,mu,lambda,power);
-}
-
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-evaluateFieldsSide (typename Traits::EvalData workset, ScalarT mu, ScalarT lambda, ScalarT power)
-{
-  if (workset.sideSetViews->find(basalSideName)==workset.sideSetViews->end()) return;
-
-  sideSet = workset.sideSetViews->at(basalSideName);
-
   dim = nodal ? numNodes : numQPs;
 
-  switch (beta_type) {
-    case GIVEN_CONSTANT:
-      return;   // We can save ourself some useless iterations
-
-    case GIVEN_FIELD:
-      if (is_given_field_param) {
-        Kokkos::parallel_for(Side_GivenFieldParam_Policy(0, sideSet.size), *this);
-      } else {
-        Kokkos::parallel_for(Side_GivenField_Policy(0, sideSet.size), *this);
-      }
-      break;
-
-    case POWER_LAW:
-      if (distributedMu) {
-        Kokkos::parallel_for(Side_PowerLaw_DistributedMu_Policy(0, sideSet.size), *this);
-      } else {
-        Kokkos::parallel_for(Side_PowerLaw_Policy(0, sideSet.size), *this);
-      }
-
-      break;
-
-    case REGULARIZED_COULOMB:
-      if (distributedLambda) {
-        if (distributedMu) {
-          Kokkos::parallel_for(Side_RegularizedCoulomb_DistributedLambda_DistributedMu_Policy(0, sideSet.size), *this);
-        } else {
-          Kokkos::parallel_for(Side_RegularizedCoulomb_DistributedLambda_Policy(0, sideSet.size), *this);
-        }
-      } else {
-        if (distributedMu) {
-          Kokkos::parallel_for(Side_RegularizedCoulomb_DistributedMu_Policy(0, sideSet.size), *this);
-        } else {
-          Kokkos::parallel_for(Side_RegularizedCoulomb_Policy(0, sideSet.size), *this);
-        }
-      }
-      break;
-
-    case EXP_GIVEN_FIELD:
-      if(nodal || interpolate_then_exponentiate) {
-        if (is_given_field_param) {
-          Kokkos::parallel_for(Side_ExpGivenFieldParam_Nodal_Policy(0, sideSet.size), *this);
-        } else {
-          Kokkos::parallel_for(Side_ExpGivenField_Nodal_Policy(0, sideSet.size), *this);
-        }
-      } else {
-        if (is_given_field_param) {
-          Kokkos::parallel_for(Side_ExpGivenFieldParam_Policy(0, sideSet.size), *this);
-        } else {
-          Kokkos::parallel_for(Side_ExpGivenField_Policy(0, sideSet.size), *this);
-        }
-      }
-      break;
-
-    default:
-      break;
-    }
-
-    if(zero_on_floating) {
-    if (is_thickness_param) {
-      Kokkos::parallel_for(Side_ZeroOnFloatingParam_Policy(0, sideSet.size), *this);
-    } else {
-      Kokkos::parallel_for(Side_ZeroOnFloating_Policy(0, sideSet.size), *this);
-    }
-  }
-
-  // Correct the value if we are using a stereographic map
-  if (use_stereographic_map) {
-    Kokkos::parallel_for(Side_StereographicMapCorrection_Policy(0, sideSet.size), *this);
-  }
-}
-
-template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
-void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-evaluateFieldsCell (typename Traits::EvalData workset, ScalarT mu, ScalarT lambda, ScalarT power)
-{
-  dim = nodal ? numNodes : numQPs;
-  switch (beta_type)
-  {
-    case GIVEN_CONSTANT:
-      break;   // We don't have anything to do
-
-    case GIVEN_FIELD:
-      if (is_given_field_param) {
-        Kokkos::parallel_for(GivenFieldParam_Policy(0, workset.numCells), *this);
-      } else {
-        Kokkos::parallel_for(GivenField_Policy(0, workset.numCells), *this);
-      }
-      break;
-
-    case POWER_LAW:
-      if (distributedMu) {
-        Kokkos::parallel_for(PowerLaw_DistributedMu_Policy(0, workset.numCells), *this);
-      } else {
-        Kokkos::parallel_for(PowerLaw_Policy(0, workset.numCells), *this);
-      }
-      break;
-
-    case REGULARIZED_COULOMB:
-      if (distributedLambda) {
-        if (distributedMu) {
-          Kokkos::parallel_for(RegularizedCoulomb_DistributedLambda_DistributedMu_Policy(0, workset.numCells), *this);
-        } else {
-          Kokkos::parallel_for(RegularizedCoulomb_DistributedLambda_Policy(0, workset.numCells), *this);
-        }
-      } else {
-        if (distributedMu) {
-          Kokkos::parallel_for(RegularizedCoulomb_DistributedMu_Policy(0, workset.numCells), *this);
-        } else {
-          Kokkos::parallel_for(RegularizedCoulomb_Policy(0, workset.numCells), *this);
-        }
-      }
-      break;
-
-    case EXP_GIVEN_FIELD:
-      if(nodal || interpolate_then_exponentiate) {
-        if (is_given_field_param) {
-          Kokkos::parallel_for(ExpGivenFieldParam_Nodal_Policy(0, workset.numCells), *this);
-        } else {
-          Kokkos::parallel_for(ExpGivenField_Nodal_Policy(0, workset.numCells), *this);
-        } 
-      } else {
-        if (is_given_field_param) {
-          Kokkos::parallel_for(ExpGivenFieldParam_Policy(0, workset.numCells), *this);
-        } else {
-          Kokkos::parallel_for(ExpGivenField_Policy(0, workset.numCells), *this);
-        }
-      }
-      break;
-  }
-
-  // Correct the value if we are using a stereographic map
-  if (use_stereographic_map)
-  {
-    Kokkos::parallel_for(StereographicMapCorrection_Policy(0, workset.numCells), *this);
+  if (is_side_equation) {
+    if (workset.sideSetViews->find(basalSideName)==workset.sideSetViews->end()) return;
+    sideSet = workset.sideSetViews->at(basalSideName);
+    Kokkos::parallel_for(BasalFrictionCoefficient_Policy(0, sideSet.size), *this);
+  } else {
+    Kokkos::parallel_for(BasalFrictionCoefficient_Policy(0, workset.numCells), *this);
   }
 }
 

--- a/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient_Def.hpp
@@ -240,7 +240,7 @@ postRegistrationSetup (typename Traits::SetupData d,
 template<typename EvalT, typename Traits, typename EffPressureST, typename VelocityST, typename TemperatureST>
 KOKKOS_INLINE_FUNCTION
 void BasalFrictionCoefficient<EvalT, Traits, EffPressureST, VelocityST, TemperatureST>::
-operator() (const BasalFrictionCoefficient_Tag& tag, const int& cell_or_side_idx) const {
+operator() (const BasalFrictionCoefficient_Tag& tag, const int& cell) const {
 
   switch(beta_type) {
     case GIVEN_CONSTANT:
@@ -249,25 +249,25 @@ operator() (const BasalFrictionCoefficient_Tag& tag, const int& cell_or_side_idx
     case GIVEN_FIELD:
       if (is_given_field_param) {
         for (unsigned int ipt=0; ipt<dim; ++ipt)
-          beta(cell_or_side_idx,ipt) = given_field_param(cell_or_side_idx,ipt);
+          beta(cell,ipt) = given_field_param(cell,ipt);
       } else {
         for (unsigned int ipt=0; ipt<dim; ++ipt)
-          beta(cell_or_side_idx,ipt) = given_field(cell_or_side_idx,ipt);
+          beta(cell,ipt) = given_field(cell,ipt);
       }
     break;
     
     case POWER_LAW:
       if (distributedMu) {
         for (unsigned int ipt=0; ipt<dim; ++ipt) {
-          ScalarT Nval = N(cell_or_side_idx,ipt);
+          ScalarT Nval = N(cell,ipt);
           if (is_side_equation) Nval = KU::max(Nval, 0.0);
-          beta(cell_or_side_idx,ipt) = muPowerLawField(cell_or_side_idx,ipt) * Nval * std::pow (u_norm(cell_or_side_idx,ipt), power-1);
+          beta(cell,ipt) = muPowerLawField(cell,ipt) * Nval * std::pow (u_norm(cell,ipt), power-1);
         }
       } else {
         for (unsigned int ipt=0; ipt<dim; ++ipt) {
-          ScalarT Nval = N(cell_or_side_idx,ipt);
+          ScalarT Nval = N(cell,ipt);
           if (is_side_equation) Nval = KU::max(Nval, 0.0);
-          beta(cell_or_side_idx,ipt) = mu * Nval * std::pow (u_norm(cell_or_side_idx,ipt), power-1);
+          beta(cell,ipt) = mu * Nval * std::pow (u_norm(cell,ipt), power-1);
         }
       }
     break;
@@ -276,33 +276,33 @@ operator() (const BasalFrictionCoefficient_Tag& tag, const int& cell_or_side_idx
       if (distributedLambda) {
         if (distributedMu) {
           for (unsigned int ipt=0; ipt<dim; ++ipt) {
-            ScalarT Nval = N(cell_or_side_idx,ipt);
+            ScalarT Nval = N(cell,ipt);
             if (is_side_equation) Nval = KU::max(Nval, 0.0);
-            ScalarT q = u_norm(cell_or_side_idx,ipt) / ( u_norm(cell_or_side_idx,ipt) + lambdaField(cell_or_side_idx,ipt)*ice_softness(cell_or_side_idx)*std::pow(Nval,n) );
-            beta(cell_or_side_idx,ipt) = muCoulombField(cell_or_side_idx,ipt) * Nval * std::pow( q, power) / u_norm(cell_or_side_idx,ipt);
+            ScalarT q = u_norm(cell,ipt) / ( u_norm(cell,ipt) + lambdaField(cell,ipt)*ice_softness(cell)*std::pow(Nval,n) );
+            beta(cell,ipt) = muCoulombField(cell,ipt) * Nval * std::pow( q, power) / u_norm(cell,ipt);
           }
         } else {
           for (unsigned int ipt=0; ipt<dim; ++ipt) {
-            ScalarT Nval = N(cell_or_side_idx,ipt);
+            ScalarT Nval = N(cell,ipt);
             if (is_side_equation) Nval = KU::max(Nval, 0.0);
-            ScalarT q = u_norm(cell_or_side_idx,ipt) / ( u_norm(cell_or_side_idx,ipt) + lambdaField(cell_or_side_idx,ipt)*ice_softness(cell_or_side_idx)*std::pow(Nval,n) );
-            beta(cell_or_side_idx,ipt) = mu * Nval * std::pow( q, power) / u_norm(cell_or_side_idx,ipt);
+            ScalarT q = u_norm(cell,ipt) / ( u_norm(cell,ipt) + lambdaField(cell,ipt)*ice_softness(cell)*std::pow(Nval,n) );
+            beta(cell,ipt) = mu * Nval * std::pow( q, power) / u_norm(cell,ipt);
           }
         }
       } else {
         if (distributedMu) {
           for (unsigned int ipt=0; ipt<dim; ++ipt) {
-            ScalarT Nval = N(cell_or_side_idx,ipt);
+            ScalarT Nval = N(cell,ipt);
             if (is_side_equation) Nval = KU::max(Nval, 0.0);
-            ScalarT q = u_norm(cell_or_side_idx,ipt) / ( u_norm(cell_or_side_idx,ipt) + lambda*ice_softness(cell_or_side_idx)*std::pow(Nval,n) );
-            beta(cell_or_side_idx,ipt) = muCoulombField(cell_or_side_idx,ipt) * Nval * std::pow( q, power) / u_norm(cell_or_side_idx,ipt);
+            ScalarT q = u_norm(cell,ipt) / ( u_norm(cell,ipt) + lambda*ice_softness(cell)*std::pow(Nval,n) );
+            beta(cell,ipt) = muCoulombField(cell,ipt) * Nval * std::pow( q, power) / u_norm(cell,ipt);
           }
         } else {
           for (unsigned int ipt=0; ipt<dim; ++ipt) {
-            ScalarT Nval = N(cell_or_side_idx,ipt);
+            ScalarT Nval = N(cell,ipt);
             if (is_side_equation) Nval = KU::max(Nval, 0.0);
-            ScalarT q = u_norm(cell_or_side_idx,ipt) / ( u_norm(cell_or_side_idx,ipt) + lambda*ice_softness(cell_or_side_idx)*std::pow(Nval,n) );
-            beta(cell_or_side_idx,ipt) = mu * Nval * std::pow( q, power) / u_norm(cell_or_side_idx,ipt);
+            ScalarT q = u_norm(cell,ipt) / ( u_norm(cell,ipt) + lambda*ice_softness(cell)*std::pow(Nval,n) );
+            beta(cell,ipt) = mu * Nval * std::pow( q, power) / u_norm(cell,ipt);
           }
         }
       }
@@ -312,25 +312,25 @@ operator() (const BasalFrictionCoefficient_Tag& tag, const int& cell_or_side_idx
       if(nodal || interpolate_then_exponentiate) {
         if (is_given_field_param) {
           for (unsigned int ipt=0; ipt<dim; ++ipt)
-            beta(cell_or_side_idx,ipt) = std::exp(given_field_param(cell_or_side_idx,ipt));
+            beta(cell,ipt) = std::exp(given_field_param(cell,ipt));
         } else {
           for (unsigned int ipt=0; ipt<dim; ++ipt)
-            beta(cell_or_side_idx,ipt) = std::exp(given_field(cell_or_side_idx,ipt));
+            beta(cell,ipt) = std::exp(given_field(cell,ipt));
         }
       } else {
         if (is_given_field_param) {
           unsigned int exp_dim = is_side_equation ? numQPs : dim;
           for (unsigned int ipt=0; ipt<exp_dim; ++ipt) {
-            beta(cell_or_side_idx,ipt) = 0;
+            beta(cell,ipt) = 0;
             for (unsigned int node=0; node<numNodes; ++node)
-              beta(cell_or_side_idx,ipt) += std::exp(given_field_param(cell_or_side_idx,node))*BF(cell_or_side_idx,node,ipt);  
+              beta(cell,ipt) += std::exp(given_field_param(cell,node))*BF(cell,node,ipt);  
           }
         } else {
           unsigned int exp_dim = is_side_equation ? numQPs : dim;
           for (unsigned int ipt=0; ipt<exp_dim; ++ipt) {
-            beta(cell_or_side_idx,ipt) = 0;
+            beta(cell,ipt) = 0;
             for (unsigned int node=0; node<numNodes; ++node)
-              beta(cell_or_side_idx,ipt) += std::exp(given_field(cell_or_side_idx,node))*BF(cell_or_side_idx,node,ipt);
+              beta(cell,ipt) += std::exp(given_field(cell,node))*BF(cell,node,ipt);
           }
         }
       }
@@ -343,23 +343,23 @@ operator() (const BasalFrictionCoefficient_Tag& tag, const int& cell_or_side_idx
   if (is_side_equation && zero_on_floating) {
     if (is_thickness_param) {
       for (unsigned int ipt=0; ipt<dim; ++ipt) {
-        ParamScalarT isGrounded = rho_i*thickness_param_field(cell_or_side_idx,ipt) > -rho_w*bed_topo_field_mst(cell_or_side_idx,ipt);
-        beta(cell_or_side_idx,ipt) *=  isGrounded;
+        ParamScalarT isGrounded = rho_i*thickness_param_field(cell,ipt) > -rho_w*bed_topo_field_mst(cell,ipt);
+        beta(cell,ipt) *=  isGrounded;
       }
     } else {
       for (unsigned int ipt=0; ipt<dim; ++ipt) {
-        ParamScalarT isGrounded = rho_i*thickness_field(cell_or_side_idx,ipt) > -rho_w*bed_topo_field(cell_or_side_idx,ipt);
-        beta(cell_or_side_idx,ipt) *=  isGrounded;
+        ParamScalarT isGrounded = rho_i*thickness_field(cell,ipt) > -rho_w*bed_topo_field(cell,ipt);
+        beta(cell,ipt) *=  isGrounded;
       }
     }
   }
 
   if (use_stereographic_map) {
     for (unsigned int ipt=0; ipt<dim; ++ipt) {
-      MeshScalarT x = coordVec(cell_or_side_idx,ipt,0) - x_0;
-      MeshScalarT y = coordVec(cell_or_side_idx,ipt,1) - y_0;
+      MeshScalarT x = coordVec(cell,ipt,0) - x_0;
+      MeshScalarT y = coordVec(cell,ipt,1) - y_0;
       MeshScalarT h = 4.0*R2/(4.0*R2 + x*x + y*y);
-      beta(cell_or_side_idx,ipt) *= h*h;
+      beta(cell,ipt) *= h*h;
     }
   }
 
@@ -459,10 +459,12 @@ evaluateFields (typename Traits::EvalData workset)
   if (is_side_equation) {
     if (workset.sideSetViews->find(basalSideName)==workset.sideSetViews->end()) return;
     sideSet = workset.sideSetViews->at(basalSideName);
-    Kokkos::parallel_for(BasalFrictionCoefficient_Policy(0, sideSet.size), *this);
+    worksetSize = sideSet.size;
   } else {
-    Kokkos::parallel_for(BasalFrictionCoefficient_Policy(0, workset.numCells), *this);
+    worksetSize = workset.numCells;
   }
+
+  Kokkos::parallel_for(BasalFrictionCoefficient_Policy(0, worksetSize), *this);
 }
 
 } // Namespace LandIce

--- a/src/LandIce/evaluators/LandIce_IceOverburden.hpp
+++ b/src/LandIce/evaluators/LandIce_IceOverburden.hpp
@@ -43,9 +43,6 @@ public:
 
 private:
 
-  void evaluateFieldsCell(typename Traits::EvalData d);
-  void evaluateFieldsSide(typename Traits::EvalData d);
-
   // Input:
   PHX::MDField<const RealType>  H;
 

--- a/src/LandIce/evaluators/LandIce_IceOverburden.hpp
+++ b/src/LandIce/evaluators/LandIce_IceOverburden.hpp
@@ -59,8 +59,6 @@ private:
 
   double rho_i;
   double g;
-
-  bool useCollapsedSidesets;
   
   Albany::LocalSideSetInfo sideSet;
 

--- a/src/LandIce/evaluators/LandIce_IceOverburden_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_IceOverburden_Def.hpp
@@ -67,21 +67,12 @@ void IceOverburden<EvalT, Traits>::
 evaluateFields (typename Traits::EvalData workset)
 {
   if (eval_on_side) {
-    evaluateFieldsSide(workset);
+    if (workset.sideSetViews->find(sideSetName)==workset.sideSetViews->end()) return;
+    sideSet = workset.sideSetViews->at(sideSetName);
+    Kokkos::parallel_for(IceOverburden_Policy(0, sideSet.size), *this);
   } else {
     Kokkos::parallel_for(IceOverburden_Policy(0, workset.numCells), *this);
   }
-}
-
-template<typename EvalT, typename Traits>
-void IceOverburden<EvalT, Traits>::
-evaluateFieldsSide (typename Traits::EvalData workset)
-{
-  if (workset.sideSetViews->find(sideSetName)==workset.sideSetViews->end()) return;
-
-  sideSet = workset.sideSetViews->at(sideSetName);
-  
-  Kokkos::parallel_for(IceOverburden_Policy(0, sideSet.size), *this);
 }
 
 } // Namespace LandIce

--- a/src/LandIce/evaluators/LandIce_IceOverburden_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_IceOverburden_Def.hpp
@@ -16,8 +16,6 @@ IceOverburden<EvalT, Traits>::
 IceOverburden (const Teuchos::ParameterList& p,
                const Teuchos::RCP<Albany::Layouts>& dl)
 {
-  useCollapsedSidesets = (dl->isSideLayouts && dl->useCollapsedSidesets);
-
   // Check if it is a sideset evaluation
   eval_on_side = false;
   if (p.isParameter("Side Set Name")) {
@@ -29,12 +27,12 @@ IceOverburden (const Teuchos::ParameterList& p,
 
   Teuchos::RCP<PHX::DataLayout> layout;
   if (p.isParameter("Nodal") && p.get<bool>("Nodal")) {
-    layout = useCollapsedSidesets ? dl->node_scalar_sideset : dl->node_scalar;
+    layout = dl->node_scalar_sideset;
   } else {
-    layout = useCollapsedSidesets ? dl->qp_scalar_sideset : dl->qp_scalar;
+    layout = dl->qp_scalar_sideset;
   }
 
-  numPts = (eval_on_side && !useCollapsedSidesets) ? layout->extent(2) : layout->extent(1);
+  numPts = layout->extent(1);
 
   H   = PHX::MDField<const RealType>(p.get<std::string> ("Ice Thickness Variable Name"), layout);
   P_o = PHX::MDField<RealType>(p.get<std::string> ("Ice Overburden Variable Name"), layout);
@@ -79,25 +77,11 @@ template<typename EvalT, typename Traits>
 void IceOverburden<EvalT, Traits>::
 evaluateFieldsSide (typename Traits::EvalData workset)
 {
-  if (workset.sideSetViews->find(sideSetName)==workset.sideSetViews->end()) {
-    return;
-  }
+  if (workset.sideSetViews->find(sideSetName)==workset.sideSetViews->end()) return;
 
   sideSet = workset.sideSetViews->at(sideSetName);
-  if (useCollapsedSidesets) {
-    Kokkos::parallel_for(IceOverburden_Policy(0, sideSet.size), *this);
-  } else {
-    for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx) {
-
-      // Get the local data of side and cell
-      const int cell = sideSet.elem_LID(sideSet_idx);
-      const int side = sideSet.side_local_id(sideSet_idx);
-
-      for (unsigned int pt=0; pt<numPts; ++pt) {
-        P_o (cell,side,pt) = rho_i*g*H(cell,side,pt);
-      }
-    }
-  }
+  
+  Kokkos::parallel_for(IceOverburden_Policy(0, sideSet.size), *this);
 }
 
 } // Namespace LandIce

--- a/src/LandIce/evaluators/LandIce_IceOverburden_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_IceOverburden_Def.hpp
@@ -27,9 +27,9 @@ IceOverburden (const Teuchos::ParameterList& p,
 
   Teuchos::RCP<PHX::DataLayout> layout;
   if (p.isParameter("Nodal") && p.get<bool>("Nodal")) {
-    layout = dl->node_scalar_sideset;
+    layout = eval_on_side ? dl->node_scalar_sideset : dl->node_scalar;
   } else {
-    layout = dl->qp_scalar_sideset;
+    layout = eval_on_side ? dl->qp_scalar_sideset : dl->qp_scalar;
   }
 
   numPts = layout->extent(1);

--- a/src/LandIce/evaluators/LandIce_Temperature.hpp
+++ b/src/LandIce/evaluators/LandIce_Temperature.hpp
@@ -62,9 +62,9 @@ private:
 
   unsigned int numNodes;
 
-  std::string sideName;
-  std::vector<std::vector<int> >  sideNodes;
-  unsigned int numSideNodes;
+  // std::string sideName;
+  // std::vector<std::vector<int> >  sideNodes;
+  // unsigned int numSideNodes;
 
   double c_i;   //[J Kg^{-1} K^{-1}], Heat capacity of ice
   double rho_i; //[kg m^{-3}]

--- a/src/LandIce/evaluators/LandIce_Temperature_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_Temperature_Def.hpp
@@ -33,10 +33,10 @@ Temperature(const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>
   Teuchos::RCP<shards::CellTopology> cellType;
   cellType = p.get<Teuchos::RCP <shards::CellTopology> > ("Cell Type");
 
-  sideName = p.get<std::string> ("Side Set Name");
-  TEUCHOS_TEST_FOR_EXCEPTION (dl->side_layouts.find(sideName)==dl->side_layouts.end(), std::runtime_error,
-                              "Error! Basal side data layout not found.\n");
-  Teuchos::RCP<Albany::Layouts> dl_side = dl->side_layouts.at(sideName);
+  // sideName = p.get<std::string> ("Side Set Name");
+  // TEUCHOS_TEST_FOR_EXCEPTION (dl->side_layouts.find(sideName)==dl->side_layouts.end(), std::runtime_error,
+  //                             "Error! Basal side data layout not found.\n");
+  // Teuchos::RCP<Albany::Layouts> dl_side = dl->side_layouts.at(sideName);
 
   // dTdz = decltype(dTdz)(p.get<std::string> ("Basal dTdz Variable Name"), dl_side->node_scalar);
 
@@ -45,20 +45,20 @@ Temperature(const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>
 
   numNodes = dims[1];
 
-  numSideNodes  = dl_side->node_scalar->extent(2);
+  // numSideNodes  = dl_side->node_scalar->extent(2);
 
-  unsigned int numSides = dl_side->node_scalar->extent(1);
-  unsigned int sideDim  = cellType->getDimension()-1;
+  // unsigned int numSides = dl_side->node_scalar->extent(1);
+  // unsigned int sideDim  = cellType->getDimension()-1;
 
-  sideNodes.resize(numSides);
-  for (unsigned int side=0; side<numSides; ++side)
-  {
-    //Need to get the subcell exact count, since different sides may have different number of nodes (e.g., Wedge)
-    unsigned int thisSideNodes = cellType->getNodeCount(sideDim,side);
-    sideNodes[side].resize(thisSideNodes);
-    for (unsigned int node=0; node<thisSideNodes; ++node)
-      sideNodes[side][node] = cellType->getNodeMap(sideDim,side,node);
-  }
+  // sideNodes.resize(numSides);
+  // for (unsigned int side=0; side<numSides; ++side)
+  // {
+  //   //Need to get the subcell exact count, since different sides may have different number of nodes (e.g., Wedge)
+  //   unsigned int thisSideNodes = cellType->getNodeCount(sideDim,side);
+  //   sideNodes[side].resize(thisSideNodes);
+  //   for (unsigned int node=0; node<thisSideNodes; ++node)
+  //     sideNodes[side][node] = cellType->getNodeMap(sideDim,side,node);
+  // }
 
   this->addDependentField(meltingTemp);
   this->addDependentField(enthalpyHs);

--- a/src/LandIce/evaluators/hydrology/LandIce_EffectivePressure.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_EffectivePressure.hpp
@@ -54,7 +54,7 @@ private:
   PHX::MDField<HydroScalarT>  N;
 
   int numPts;
-  int worksetSize;
+  unsigned int worksetSize;
 
   bool eval_on_side;
   std::string sideSetName; // Needed if OnSide=true
@@ -67,16 +67,12 @@ private:
 public:
 
   typedef Kokkos::View<int***, PHX::Device>::execution_space ExecutionSpace;
-  struct Surrogate_Tag{};
-  struct NonSurrogate_Tag{};
+  struct EffectivePressure_Tag{};
 
-  typedef Kokkos::RangePolicy<ExecutionSpace, Surrogate_Tag> Surrogate_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace, NonSurrogate_Tag> NonSurrogate_Policy;
+  typedef Kokkos::RangePolicy<ExecutionSpace, EffectivePressure_Tag> EffectivePressure_Policy;
 
   KOKKOS_INLINE_FUNCTION
-  void operator() (const Surrogate_Tag& tag, const int& side_or_cell_idx) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const NonSurrogate_Tag& tag, const int& side_or_cell_idx) const;
+  void operator() (const EffectivePressure_Tag& tag, const int& cell) const;
   
 };
 

--- a/src/LandIce/evaluators/hydrology/LandIce_EffectivePressure.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_EffectivePressure.hpp
@@ -45,8 +45,6 @@ public:
   void evaluateFields(typename Traits::EvalData d);
 
 private:
-  void evaluateFieldsSide (typename Traits::EvalData workset);
-  void evaluateFieldsCell (typename Traits::EvalData workset);
 
   // Input:
   PHX::MDField<const RealType>      P_o;
@@ -56,6 +54,7 @@ private:
   PHX::MDField<HydroScalarT>  N;
 
   int numPts;
+  int worksetSize;
 
   bool eval_on_side;
   std::string sideSetName; // Needed if OnSide=true

--- a/src/LandIce/evaluators/hydrology/LandIce_EffectivePressure.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_EffectivePressure.hpp
@@ -62,8 +62,6 @@ private:
 
   PHX::MDField<const ScalarT,Dim> alphaParam;
   ScalarT printedAlpha;
-
-  bool useCollapsedSidesets;
   
   Albany::LocalSideSetInfo sideSet;
 

--- a/src/LandIce/evaluators/hydrology/LandIce_EffectivePressure_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_EffectivePressure_Def.hpp
@@ -92,33 +92,13 @@ void EffectivePressure<EvalT, Traits, Surrogate>::
 evaluateFields (typename Traits::EvalData workset)
 {
   if (eval_on_side) {
-    evaluateFieldsSide(workset);
+    if (workset.sideSetViews->find(sideSetName)==workset.sideSetViews->end()) return;
+    sideSet = workset.sideSetViews->at(sideSetName);
+    worksetSize = sideSet.size;
   } else {
-    evaluateFieldsCell(workset);
-  }
-}
-
-template<typename EvalT, typename Traits, bool Surrogate>
-void EffectivePressure<EvalT, Traits, Surrogate>::
-evaluateFieldsSide (typename Traits::EvalData workset)
-{
-  if (workset.sideSetViews->find(sideSetName)==workset.sideSetViews->end()) {
-    return;
+    worksetSize = workset.numCells;
   }
 
-  sideSet = workset.sideSetViews->at(sideSetName);
-
-  if (Surrogate) {
-    Kokkos::parallel_for(Surrogate_Policy(0, sideSet.size), *this);
-  } else {
-    Kokkos::parallel_for(NonSurrogate_Policy(0, sideSet.size), *this);
-  }
-}
-
-template<typename EvalT, typename Traits, bool Surrogate>
-void EffectivePressure<EvalT, Traits, Surrogate>::
-evaluateFieldsCell (typename Traits::EvalData workset)
-{
   if (Surrogate) {
 
 #ifdef OUTPUT_TO_SCREEN
@@ -130,9 +110,9 @@ evaluateFieldsCell (typename Traits::EvalData workset)
     }
 #endif
 
-    Kokkos::parallel_for(Surrogate_Policy(0, workset.numCells), *this);
+    Kokkos::parallel_for(Surrogate_Policy(0, worksetSize), *this);
   } else {
-    Kokkos::parallel_for(NonSurrogate_Policy(0, workset.numCells), *this);
+    Kokkos::parallel_for(NonSurrogate_Policy(0, worksetSize), *this);
   }
 }
 

--- a/src/LandIce/evaluators/hydrology/LandIce_EffectivePressure_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_EffectivePressure_Def.hpp
@@ -34,9 +34,9 @@ EffectivePressure (const Teuchos::ParameterList& p,
 
   Teuchos::RCP<PHX::DataLayout> layout;
   if (p.isParameter("Nodal") && p.get<bool>("Nodal")) {
-    layout = dl->node_scalar_sideset;
+    layout = eval_on_side ? dl->node_scalar_sideset : dl->node_scalar;
   } else {
-    layout = dl->qp_scalar_sideset;
+    layout = eval_on_side ? dl->qp_scalar_sideset : dl->qp_scalar;
   }
 
   numPts = layout->extent(1);

--- a/src/LandIce/evaluators/hydrology/LandIce_HydraulicPotential.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydraulicPotential.hpp
@@ -39,8 +39,7 @@ public:
 
 private:
 
-  void evaluateFieldsCell(typename Traits::EvalData d);
-  void evaluateFieldsSide(typename Traits::EvalData d);
+  void evaluatePotential(unsigned int cell);
 
   // Input:
   PHX::MDField<const ScalarT>   P_w;
@@ -56,6 +55,7 @@ private:
   Albany::LocalSideSetInfo sideSet;
 
   unsigned int numPts;
+  unsigned int worksetSize;
 
   bool use_h;
 

--- a/src/LandIce/evaluators/hydrology/LandIce_HydraulicPotential.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydraulicPotential.hpp
@@ -53,6 +53,8 @@ private:
   bool eval_on_side;
   std::string sideSetName;  // Only used if eval_on_side=true
 
+  Albany::LocalSideSetInfo sideSet;
+
   unsigned int numPts;
 
   bool use_h;

--- a/src/LandIce/evaluators/hydrology/LandIce_HydraulicPotential_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydraulicPotential_Def.hpp
@@ -69,40 +69,25 @@ void HydraulicPotential<EvalT, Traits>::
 evaluateFields (typename Traits::EvalData workset)
 {
   if (eval_on_side) {
-    evaluateFieldsSide(workset);
+    if (workset.sideSets->find(sideSetName)==workset.sideSets->end()) return;
+    sideSet = workset.sideSetViews->at(sideSetName);
+    worksetSize = sideSet.size;
   } else {
-    evaluateFieldsCell(workset);
+    worksetSize = workset.numCells;
+  }
+
+  for (int cell = 0; cell < worksetSize; ++cell) {
+    evaluatePotential(cell);
   }
 }
 
 template<typename EvalT, typename Traits>
 void HydraulicPotential<EvalT, Traits>::
-evaluateFieldsSide (typename Traits::EvalData workset)
+evaluatePotential (unsigned int cell)
 {
-  if (workset.sideSets->find(sideSetName)==workset.sideSets->end()) return;
-
-  ScalarT zero(0.0);
-  sideSet = workset.sideSetViews->at(sideSetName);
-  for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-  {
-    for (unsigned int pt=0; pt<numPts; ++pt) {
-      // Recall that phi is in kPa, but h is in m. Need to convert to km.
-      phi(sideSet_idx,pt) = P_w(sideSet_idx,pt) + phi_0(sideSet_idx,pt) + (use_h ? rho_w*g*h(sideSet_idx,pt)/1000 : zero);
-    }
-  }
-}
-
-//**********************************************************************
-template<typename EvalT, typename Traits>
-void HydraulicPotential<EvalT, Traits>::
-evaluateFieldsCell (typename Traits::EvalData workset)
-{
-  ScalarT zero(0.0);
-  for (unsigned int cell=0; cell<workset.numCells; ++cell) {
-    for (unsigned int pt=0; pt<numPts; ++pt) {
-      // Recall that phi is in kPa, but h is in m. Need to convert to km.
-      phi(cell,pt) = P_w(cell,pt) + phi_0(cell,pt) + (use_h ? rho_w*g*h(cell,pt)/1000 : zero);
-    }
+  for (unsigned int pt=0; pt<numPts; ++pt) {
+    // Recall that phi is in kPa, but h is in m. Need to convert to km.
+    phi(cell,pt) = P_w(cell,pt) + phi_0(cell,pt) + (use_h ? rho_w*g*h(cell,pt)/1000 : ScalarT(0.0));
   }
 }
 

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyBasalGravitationalWaterPotential.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyBasalGravitationalWaterPotential.hpp
@@ -51,6 +51,8 @@ private:
 
   bool eval_on_side;
 
+  Albany::LocalSideSetInfo sideSet;
+
   int numPts;
 
   double rho_w;

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyBasalGravitationalWaterPotential.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyBasalGravitationalWaterPotential.hpp
@@ -39,8 +39,7 @@ public:
 
 private:
 
-  void evaluateFieldsCell(typename Traits::EvalData d);
-  void evaluateFieldsSide(typename Traits::EvalData d);
+  void evaluatePotential(unsigned int cell);
 
   // Input:
   PHX::MDField<const RealType>  H;
@@ -54,6 +53,7 @@ private:
   Albany::LocalSideSetInfo sideSet;
 
   int numPts;
+  unsigned int worksetSize;
 
   double rho_w;
   double g;

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyBasalGravitationalWaterPotential_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyBasalGravitationalWaterPotential_Def.hpp
@@ -58,35 +58,24 @@ void BasalGravitationalWaterPotential<EvalT, Traits>::
 evaluateFields (typename Traits::EvalData workset)
 {
   if (eval_on_side) {
-    evaluateFieldsSide(workset);
+    if (workset.sideSets->find(sideSetName)==workset.sideSets->end()) return;
+    sideSet = workset.sideSetViews->at(sideSetName);
+    worksetSize = sideSet.size;
   } else {
-    evaluateFieldsCell(workset);
+    worksetSize = workset.numCells;
+  }
+
+  for (unsigned int cell=0; cell<worksetSize; ++cell) {
+    evaluatePotential(cell);
   }
 }
 
 template<typename EvalT, typename Traits>
 void BasalGravitationalWaterPotential<EvalT, Traits>::
-evaluateFieldsSide (typename Traits::EvalData workset)
+evaluatePotential (unsigned int cell)
 {
-  if (workset.sideSets->find(sideSetName)==workset.sideSets->end()) return;
-
-  sideSet = workset.sideSetViews->at(sideSetName);
-  for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-  {
-    for (int ipt=0; ipt<numPts; ++ipt) {
-      phi_0 (sideSet_idx,ipt) = rho_w*g*(z_s(sideSet_idx,ipt) - H(sideSet_idx,ipt));
-    }
-  }
-}
-
-template<typename EvalT, typename Traits>
-void BasalGravitationalWaterPotential<EvalT, Traits>::
-evaluateFieldsCell (typename Traits::EvalData workset)
-{
-  for (unsigned int cell=0; cell<workset.numCells; ++cell) {
-    for (int ipt=0; ipt<numPts; ++ipt) {
-      phi_0 (cell,ipt) = rho_w*g*(z_s(cell,ipt) - H(cell,ipt));
-    }
+  for (int ipt=0; ipt<numPts; ++ipt) {
+    phi_0 (cell,ipt) = rho_w*g*(z_s(cell,ipt) - H(cell,ipt));
   }
 }
 

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyBasalGravitationalWaterPotential_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyBasalGravitationalWaterPotential_Def.hpp
@@ -28,12 +28,12 @@ BasalGravitationalWaterPotential (const Teuchos::ParameterList& p,
 
   Teuchos::RCP<PHX::DataLayout> layout;
   if (p.isParameter("Nodal") && p.get<bool>("Nodal")) {
-    layout = dl->node_scalar;
+    layout = eval_on_side ? dl->node_scalar_sideset : dl->node_scalar;
   } else {
-    layout = dl->qp_scalar;
+    layout = eval_on_side ? dl->qp_scalar_sideset : dl->qp_scalar;
   }
 
-  numPts = eval_on_side ? layout->extent(2) : layout->extent(1);
+  numPts = layout->extent(1);
 
   z_s   = decltype(z_s)(p.get<std::string> ("Surface Height Variable Name"), layout);
   H     = decltype(H)(p.get<std::string> ("Ice Thickness Variable Name"), layout);
@@ -68,18 +68,13 @@ template<typename EvalT, typename Traits>
 void BasalGravitationalWaterPotential<EvalT, Traits>::
 evaluateFieldsSide (typename Traits::EvalData workset)
 {
-  if (workset.sideSets->find(sideSetName)==workset.sideSets->end()) {
-    return;
-  }
+  if (workset.sideSets->find(sideSetName)==workset.sideSets->end()) return;
 
-  const auto& sideSet = workset.sideSets->at(sideSetName);
-  for (const auto& it : sideSet) {
-    // Get the local data of side and cell
-    const int cell = it.elem_LID;
-    const int side = it.side_local_id;
-
+  sideSet = workset.sideSetViews->at(sideSetName);
+  for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+  {
     for (int ipt=0; ipt<numPts; ++ipt) {
-      phi_0 (cell,side,ipt) = rho_w*g*(z_s(cell,side,ipt) - H(cell,side,ipt));
+      phi_0 (sideSet_idx,ipt) = rho_w*g*(z_s(sideSet_idx,ipt) - H(sideSet_idx,ipt));
     }
   }
 }

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyMeltingRate.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyMeltingRate.hpp
@@ -49,6 +49,8 @@ public:
 
 private:
 
+  void evaluateMeltingRate(unsigned int cell);
+
   // Input:
   PHX::MDField<const IceScalarT>    u_b;    // [ m yr^-1 ]
   PHX::MDField<const ScalarT>       beta;   // [ kPa yr m^-1 ]
@@ -63,9 +65,13 @@ private:
   bool              m_given;
   bool              G_given;
 
-  unsigned int               numQPs;
-  unsigned int               numNodes;
+  unsigned int      numQPs;
+  unsigned int      numNodes;
+  unsigned int      dim;
+  unsigned int      worksetSize;
+  
   double            latent_heat;  // Ice Latent Heat [J kg^-1]
+  double            L;            // Scaled Ice Latent Heat [L/1000] = kJ/kg = kPa m^3 / kg, and [G] = kPa m/yr
   double            scaling_G;    // Used internally
   double            m_value;      // Used if this->m_given is true
   double            G_value;      // Used if this->G_given is true

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyMeltingRate.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyMeltingRate.hpp
@@ -71,6 +71,8 @@ private:
   double            G_value;      // Used if this->G_given is true
 
   std::string       sideSetName;  // Only needed if IsStokes=true
+
+  Albany::LocalSideSetInfo sideSet; // Only needed if IsStokes=true
 };
 
 } // Namespace LandIce

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyResidualCavitiesEqn.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyResidualCavitiesEqn.hpp
@@ -101,6 +101,7 @@ private:
   bool                            stokes_coupling;
   std::string                     sideSetName;
   std::vector<std::vector<int> >  sideNodes;
+  Albany::LocalSideSetInfo sideSet;
 };
 
 } // Namespace LandIce

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyResidualMassEqn.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyResidualMassEqn.hpp
@@ -66,7 +66,7 @@ private:
   PHX::MDField<const ScalarT>       h_till_dot;
 
   // Input only needed if equation is on a sideset
-  PHX::MDField<const MeshScalarT,Cell,Side,QuadPoint,Dim,Dim>   metric;
+  PHX::MDField<const MeshScalarT,Side,QuadPoint,Dim,Dim>   metric;
 
   // Output:
   PHX::MDField<ScalarT>       residual;
@@ -89,6 +89,7 @@ private:
   bool eval_on_side;
 
   std::string    sideSetName; // Only needed if eval_on_side=true
+  Albany::LocalSideSetInfo sideSet;
 };
 
 } // Namespace LandIce

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyResidualTillStorageEqn.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyResidualTillStorageEqn.hpp
@@ -78,6 +78,7 @@ private:
   bool eval_on_side;
 
   std::string   sideSetName; // Only needed if eval_on_side=true
+  Albany::LocalSideSetInfo sideSet; // Only needed if eval_on_side=true
 };
 
 } // Namespace LandIce

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologySurfaceWaterInput.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologySurfaceWaterInput.hpp
@@ -55,6 +55,7 @@ private:
   bool eval_on_side;
 
   std::string sideSetName;  // Needed only if eval_on_side=true
+  Albany::LocalSideSetInfo sideSet; // Needed only if eval_on_side=true
 };
 
 } // Namespace LandIce

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyWaterDischarge.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyWaterDischarge.hpp
@@ -69,6 +69,7 @@ private:
 
   bool eval_on_side;
   std::string   sideSetName;  // Only used if eval_on_side=true
+  Albany::LocalSideSetInfo sideSet; // Needed only if eval_on_side=true
 
   double k_0;
   double alpha;

--- a/src/evaluators/gather/PHAL_GatherSolutionSide.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolutionSide.hpp
@@ -53,15 +53,16 @@ protected:
   typedef typename EvalT::ScalarT ScalarT;
 
   // For f,fdot,fdotdot, can either gather a bunch of scalar fields or one vector field
-  std::vector< PHX::MDField<ScalarT,Cell,Side,Node> > val;
-  std::vector< PHX::MDField<ScalarT,Cell,Side,Node> > val_dot;
-  std::vector< PHX::MDField<ScalarT,Cell,Side,Node> > val_dotdot;
-  PHX::MDField<ScalarT,Cell,Side,Node,VecDim> valvec;
-  PHX::MDField<ScalarT,Cell,Side,Node,VecDim> valvec_dot;
-  PHX::MDField<ScalarT,Cell,Side,Node,VecDim> valvec_dotdot;
+  std::vector< PHX::MDField<ScalarT,Side,Node> > val;
+  std::vector< PHX::MDField<ScalarT,Side,Node> > val_dot;
+  std::vector< PHX::MDField<ScalarT,Side,Node> > val_dotdot;
+  PHX::MDField<ScalarT,Side,Node,VecDim> valvec;
+  PHX::MDField<ScalarT,Side,Node,VecDim> valvec_dot;
+  PHX::MDField<ScalarT,Side,Node,VecDim> valvec_dotdot;
 
   std::string sideSetName;
-  std::vector<std::vector<int>> sideNodes;
+  Kokkos::View<int**, PHX::Device> sideNodes;
+  Albany::LocalSideSetInfo sideSet;
 
   int num_side_nodes;
 

--- a/src/evaluators/scatter/PHAL_ScatterSideEqnResidual.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterSideEqnResidual.hpp
@@ -53,10 +53,10 @@ protected:
   void buildSideSetNodeMap (typename Traits::EvalData workset);
 
   void doEvaluateFieldsCellResidual(typename Traits::EvalData d, int cell, int side);
-  void doEvaluateFieldsSideResidual(typename Traits::EvalData d, int cell, int side);
+  void doEvaluateFieldsSideResidual(typename Traits::EvalData d, int cell, int side, int sideSet_idx);
 
   virtual void doEvaluateFieldsCell(typename Traits::EvalData d, int cell, int side) = 0;
-  virtual void doEvaluateFieldsSide(typename Traits::EvalData d, int cell, int side) = 0;
+  virtual void doEvaluateFieldsSide(typename Traits::EvalData d, int cell, int side, int sideSet_idx) = 0;
   virtual void doPostEvaluate(typename Traits::EvalData d);
 
   typedef typename EvalT::ScalarT ScalarT;
@@ -66,6 +66,7 @@ protected:
   PHX::MDField<const ScalarT>  valTensor;
 
   std::string             sideSetName;        // The side set where the equation(s) are defined
+  Albany::LocalSideSetInfo sideSet;
 
   Teuchos::Array<int>     numSideNodes;   // Number of nodes on each side of a cell
   Teuchos::Array<Teuchos::Array<int> >  sideNodes;
@@ -107,7 +108,7 @@ public:
 
 protected:
   void doEvaluateFieldsCell(typename Traits::EvalData d, int cell, int side);
-  void doEvaluateFieldsSide(typename Traits::EvalData d, int cell, int side);
+  void doEvaluateFieldsSide(typename Traits::EvalData d, int cell, int side, int sideSet_idx);
 };
 
 // **************************************************************
@@ -125,7 +126,7 @@ public:
 
 protected:
   void doEvaluateFieldsCell(typename Traits::EvalData d, int cell, int side);
-  void doEvaluateFieldsSide(typename Traits::EvalData d, int cell, int side);
+  void doEvaluateFieldsSide(typename Traits::EvalData d, int cell, int side, int sideSet_idx);
   void doPostEvaluate(typename Traits::EvalData d);
 };
 
@@ -144,7 +145,7 @@ public:
 
 protected:
   void doEvaluateFieldsCell(typename Traits::EvalData d, int cell, int side);
-  void doEvaluateFieldsSide(typename Traits::EvalData d, int cell, int side);
+  void doEvaluateFieldsSide(typename Traits::EvalData d, int cell, int side, int sideSet_idx);
 };
 
 // **************************************************************
@@ -162,7 +163,7 @@ public:
 
 protected:
   void doEvaluateFieldsCell(typename Traits::EvalData d, int cell, int side);
-  void doEvaluateFieldsSide(typename Traits::EvalData d, int cell, int side);
+  void doEvaluateFieldsSide(typename Traits::EvalData d, int cell, int side, int sideSet_idx);
 };
 
 // **************************************************************
@@ -180,7 +181,7 @@ public:
 
 protected:
   void doEvaluateFieldsCell(typename Traits::EvalData d, int cell, int side);
-  void doEvaluateFieldsSide(typename Traits::EvalData d, int cell, int side);
+  void doEvaluateFieldsSide(typename Traits::EvalData d, int cell, int side, int sideSet_idx);
 };
 
 } // namespace PHAL

--- a/src/evaluators/utility/PHAL_FieldFrobeniusNorm.hpp
+++ b/src/evaluators/utility/PHAL_FieldFrobeniusNorm.hpp
@@ -39,6 +39,9 @@ public:
 
 private:
 
+  void evaluateFieldsCell (typename Traits::EvalData d);
+  void evaluateFieldsSide (typename Traits::EvalData d);
+
   // The parameter is always defined in terms of the
   // evaluation type native scalar type (otherwise
   // the evaluation manager does not update it).
@@ -58,8 +61,8 @@ private:
   // Output:
   PHX::MDField<ScalarT> field_norm;
 
+  bool eval_on_side;
   Albany::LocalSideSetInfo sideSet;
-  bool useCollapsedSidesets;
 
   std::string sideSetName;
   std::vector<PHX::DataLayout::size_type> dims;


### PR DESCRIPTION
For this phase of the cleanup, I've removed the duplicate implementations that use the old sideset layouts for all remaining evaluators that are used by Hydrology problems. At this point, all problems are now using the new sideset layouts so the third and final phase will be the removal of all old sideset layouts and cleanup of problem files.

A few things to note about this PR:
1) Temperature and FluxDivergenceResidual both have a bunch of sideset code that is commented out. Can these comments be safely removed? I commented out some other parts of these evaluators that were only used by the commented sideset implementation.
2) There are a few places where "useCollapsedSideset" style checks are still being done due to how I named the new sideset layouts. These checks will be removed when I remove the old layouts entirely and replace them with their "_sideset" counterparts.