### PR TITLE
Update matrix manipulation utilities.

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -1561,7 +1561,7 @@ Application::computeGlobalJacobianImpl(
   // Apply Dirichlet conditions using dfm (Dirchelt Field Manager)
   if (Teuchos::nonnull(dfm)) {
     // Re-open the jacobian
-    resumeFill(jac);
+    beginModify(jac);
 
     PHAL::Workset workset;
 
@@ -1600,7 +1600,7 @@ Application::computeGlobalJacobianImpl(
     dfm->evaluateFields<EvalT>(workset);
 
     // Close the jacobian
-    fillComplete(jac);
+    endModify(jac);
   }
 
   // Apply scaling to residual and Jacobian

--- a/src/responses/Albany_SolutionResponseFunction.cpp
+++ b/src/responses/Albany_SolutionResponseFunction.cpp
@@ -70,16 +70,15 @@ void Albany::SolutionResponseFunction::setup()
 
   // Create the culling operator
   cull_op = cull_op_factory->createOp();
+  beginModify(cull_op);
   assign(cull_op,1.0);
-  fillComplete(cull_op);
+  endModify(cull_op);
 }
 
 Teuchos::RCP<Thyra_LinearOp>
 SolutionResponseFunction::createGradientOp() const
 {
-  auto gradOp = cull_op_factory->createOp();
-  fillComplete(gradOp);
-  return gradOp;
+  return cull_op_factory->createOp();
 }
 
 void SolutionResponseFunction::

--- a/src/utility/Albany_EpetraThyraUtils.cpp
+++ b/src/utility/Albany_EpetraThyraUtils.cpp
@@ -138,7 +138,7 @@ createThyraLinearOp (const Teuchos::RCP<Epetra_Operator>& op)
 }
 
 Teuchos::RCP<Thyra_BlockedLinearOp>
-createThyraBlockedLinearOp (const Teuchos::RCP<Epetra_Operator>& op)
+createThyraBlockedLinearOp (const Teuchos::RCP<Epetra_Operator>& /* op */)
 {
   Teuchos::RCP<Thyra_BlockedLinearOp> lop;
 // GAH fill in functionality here

--- a/src/utility/Albany_ThyraCrsMatrixFactory.cpp
+++ b/src/utility/Albany_ThyraCrsMatrixFactory.cpp
@@ -305,8 +305,9 @@ Teuchos::RCP<Thyra_LinearOp> ThyraCrsMatrixFactory::createOp (const bool ignoreN
       // We want linear ops to be in assembly mode *only when explicitly requested*.
       // If the Thyra LinearOp is created with the matrix in assembly mode,
       // its range/domain vs's would be the overlapped ones.
+      fe_matrix->beginModify();
       fe_matrix->setAllToScalar(zero);
-      fe_matrix->endFill();
+      fe_matrix->endModify();
       matrix = fe_matrix;
     }
     op = createThyraLinearOp(Teuchos::rcp_implicit_cast<Tpetra_Operator>(matrix));

--- a/src/utility/Albany_ThyraCrsMatrixFactory.cpp
+++ b/src/utility/Albany_ThyraCrsMatrixFactory.cpp
@@ -205,7 +205,7 @@ void ThyraCrsMatrixFactory::fillComplete () {
     //       FE multivector does all the work for us, so just use that.
     Teuchos::RCP<Tpetra_Import> importer(new Tpetra_Import (t_range,t_ov_range));
     Tpetra::FEMultiVector<ST,LO,Tpetra_GO,KokkosNode> nnz(t_range,importer,1);
-    nnz.beginAssembly()
+    nnz.beginAssembly();
     for (const auto& it : m_graph->temp_graph) {
       LO lrow = t_ov_range->getLocalElement(static_cast<Tpetra_GO>(it.first));
       nnz.sumIntoLocalValue(lrow,0,it.second.size());

--- a/src/utility/Albany_ThyraUtils.hpp
+++ b/src/utility/Albany_ThyraUtils.hpp
@@ -77,10 +77,13 @@ Teuchos::RCP<const Thyra_VectorSpace>
 getColumnSpace (const Teuchos::RCP<const Thyra_LinearOp>& lop);
 
 // Fill related helpers
-void resumeFill (const Teuchos::RCP<Thyra_LinearOp>& lop);
-void fillComplete (const Teuchos::RCP<Thyra_LinearOp>& lop);
+// Note: the FEAssembly helpers perform global communication, to ship local contributions
+//       to the process owning the corresponding row(s). The Modify helpers only allow
+//       *local* modifications (e.g., prescribing Dirichlet BCs).
 void beginFEAssembly (const Teuchos::RCP<Thyra_LinearOp>& lop);
 void endFEAssembly (const Teuchos::RCP<Thyra_LinearOp>& lop);
+void beginModify (const Teuchos::RCP<Thyra_LinearOp>& lop);
+void endModify (const Teuchos::RCP<Thyra_LinearOp>& lop);
 
 // Entries manipulation helpers
 void assign (const Teuchos::RCP<Thyra_LinearOp>& lop, const ST value);

--- a/src/utility/Albany_TpetraThyraUtils.cpp
+++ b/src/utility/Albany_TpetraThyraUtils.cpp
@@ -83,7 +83,7 @@ createThyraLinearOp (const Teuchos::RCP<Tpetra_Operator>& op)
 }
 
 Teuchos::RCP<Thyra_BlockedLinearOp>
-createThyraBlockedLinearOp (const Teuchos::RCP<Tpetra_Operator>& op)
+createThyraBlockedLinearOp (const Teuchos::RCP<Tpetra_Operator>& /* op */)
 {
   Teuchos::RCP<Thyra_BlockedLinearOp> lop;
 // GAH fill in functionality here
@@ -234,6 +234,19 @@ getConstTpetraMatrix (const Teuchos::RCP<const Thyra_LinearOp>& lop,
   if (!lop.is_null()) {
     auto op = getConstTpetraOperator(lop,throw_if_not_tpetra);
     mat = Teuchos::rcp_dynamic_cast<const Tpetra_CrsMatrix>(op,throw_if_not_tpetra);
+  }
+
+  return mat;
+}
+
+Teuchos::RCP<Tpetra_FECrsMatrix>
+getTpetraFECrsMatrix (const Teuchos::RCP<Thyra_LinearOp>& lop,
+                      const bool throw_if_not_tpetra)
+{
+  Teuchos::RCP<Tpetra_FECrsMatrix> mat;
+  if (!lop.is_null()) {
+    auto op = getTpetraOperator(lop,throw_if_not_tpetra);
+    mat = Teuchos::rcp_dynamic_cast<Tpetra_FECrsMatrix>(op,throw_if_not_tpetra);
   }
 
   return mat;

--- a/src/utility/Albany_TpetraThyraUtils.hpp
+++ b/src/utility/Albany_TpetraThyraUtils.hpp
@@ -74,6 +74,12 @@ Teuchos::RCP<const Tpetra_CrsMatrix>
 getConstTpetraMatrix (const Teuchos::RCP<const Thyra_LinearOp>& lop,
                       const bool throw_if_not_tpetra = true);
 
+// Tpetra_FECrsMatrix has changed the way we modify its entries.
+// See https://github.com/trilinos/trilinos/pull/9000
+Teuchos::RCP<Tpetra_FECrsMatrix>
+getTpetraFECrsMatrix (const Teuchos::RCP<Thyra_LinearOp>& lop,
+                      const bool throw_if_not_tpetra);
+
 // --- Conversion from references rather than RCPs --- //
 
 Teuchos::RCP<Tpetra_Vector>


### PR DESCRIPTION
This PR adjusts the way we open/close matrices for manipulation, to accommodate upcoming changes in Trilinos. In particular, this pr requires trilinos/Trilinos#9000 in order to compile.

All tests pass on my laptop when building against the branch of the aforementioned Trilinos PR. I did not enable any of the funky scalar type options, but I doubt they would affect the linear algebra side of things (they should only affect the Phalanx side of Albany).