### PR TITLE
Reduced sideset allocation size for single workset case

### DIFF
--- a/src/LandIce/problems/LandIce_Enthalpy.cpp
+++ b/src/LandIce/problems/LandIce_Enthalpy.cpp
@@ -135,7 +135,7 @@ buildProblem(Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpecsStruct> >  meshSpec
 	           << ", SideNodes= " << numBasalSideNodes
 	           << ", SideQuadPts= " << numBasalSideQPs << std::endl;
 
-	      dl_basal = rcp(new Albany::Layouts(worksetSize,numBasalSideVertices,numBasalSideNodes,numBasalSideQPs,numDim-1,numDim,numCellSides,vecDim,true,basalMeshSpecs.worksetSize));
+	      dl_basal = rcp(new Albany::Layouts(worksetSize,numBasalSideVertices,numBasalSideNodes,numBasalSideQPs,numDim-1,numDim,numCellSides,vecDim,true,basalMeshSpecs.singleWorksetSizeAllocation,basalMeshSpecs.worksetSize));
 
 	      dl->side_layouts[basalSideName] = dl_basal;
 	  }

--- a/src/LandIce/problems/LandIce_LaplacianSampling.cpp
+++ b/src/LandIce/problems/LandIce_LaplacianSampling.cpp
@@ -84,7 +84,7 @@ void LandIce::LaplacianSampling::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Al
     auto numSideQPs      = sideCubature->getNumPoints();
 
 
-    dl_side = rcp(new Albany::Layouts(worksetSize,numSideVertices,numSideNodes, numSideQPs,numDim-1,numDim,numCellSides,1,true,sideMeshSpecs.worksetSize));
+    dl_side = rcp(new Albany::Layouts(worksetSize,numSideVertices,numSideNodes, numSideQPs,numDim-1,numDim,numCellSides,1,true,sideMeshSpecs.singleWorksetSizeAllocation,sideMeshSpecs.worksetSize));
     dl->side_layouts[sideName] = dl_side;
   }
 

--- a/src/LandIce/problems/LandIce_StokesFOBase.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.cpp
@@ -187,8 +187,6 @@ void StokesFOBase::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpec
     int numSurfaceSideNodes    = sideBasis[surfaceSideName]->getCardinality();
     int numSurfaceSideQPs      = sideCubature[surfaceSideName]->getNumPoints();
 
-    if(Teuchos::GlobalMPISession::getRank() == 0) printf("Layout %s: worksetSize = %d, sideMeshSpecs.worksetSize = %d\n", surfaceSideName.c_str(), worksetSize, surfaceMeshSpecs.worksetSize);
-
     dl->side_layouts[surfaceSideName] = rcp(new Albany::Layouts(worksetSize,numSurfaceSideVertices,numSurfaceSideNodes,
                                                                 numSurfaceSideQPs,sideDim,numDim,numCellSides,vecDimFO,
                                                                 useCollapsedSidesets,surfaceMeshSpecs.worksetSize));
@@ -212,8 +210,6 @@ void StokesFOBase::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpec
     int numbasalSideVertices = sideType[basalSideName]->getNodeCount();
     int numbasalSideNodes    = sideBasis[basalSideName]->getCardinality();
     int numbasalSideQPs      = sideCubature[basalSideName]->getNumPoints();
-
-    if(Teuchos::GlobalMPISession::getRank() == 0) printf("Layout %s: worksetSize = %d, sideMeshSpecs.worksetSize = %d\n", basalSideName.c_str(), worksetSize, basalMeshSpecs.worksetSize);
 
     dl->side_layouts[basalSideName] = rcp(new Albany::Layouts(worksetSize,numbasalSideVertices,numbasalSideNodes,
                                                               numbasalSideQPs,sideDim,numDim,numCellSides,vecDimFO,

--- a/src/LandIce/problems/LandIce_StokesFOBase.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.cpp
@@ -164,7 +164,8 @@ void StokesFOBase::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpec
 
       dl->side_layouts[ssName] = rcp(new Albany::Layouts(worksetSize,numSideVertices,numSideNodes,
                                                          numSideQPs,sideDim,numDim,numCellSides,vecDimFO,
-                                                         useCollapsedSidesets,sideMeshSpecs.worksetSize));
+                                                         useCollapsedSidesets,sideMeshSpecs.singleWorksetSizeAllocation,
+                                                         sideMeshSpecs.worksetSize));
     }
   }
 
@@ -189,7 +190,8 @@ void StokesFOBase::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpec
 
     dl->side_layouts[surfaceSideName] = rcp(new Albany::Layouts(worksetSize,numSurfaceSideVertices,numSurfaceSideNodes,
                                                                 numSurfaceSideQPs,sideDim,numDim,numCellSides,vecDimFO,
-                                                                useCollapsedSidesets,surfaceMeshSpecs.worksetSize));
+                                                                useCollapsedSidesets,surfaceMeshSpecs.singleWorksetSizeAllocation,
+                                                                surfaceMeshSpecs.worksetSize));
   }
 
   // If we have thickness or surface velocity diagnostics, we may need basal side stuff
@@ -213,7 +215,8 @@ void StokesFOBase::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpec
 
     dl->side_layouts[basalSideName] = rcp(new Albany::Layouts(worksetSize,numbasalSideVertices,numbasalSideNodes,
                                                               numbasalSideQPs,sideDim,numDim,numCellSides,vecDimFO,
-                                                              useCollapsedSidesets,basalMeshSpecs.worksetSize));
+                                                              useCollapsedSidesets,basalMeshSpecs.singleWorksetSizeAllocation,
+                                                              basalMeshSpecs.worksetSize));
   }
 
 #ifdef OUTPUT_TO_SCREEN

--- a/src/disc/Albany_DiscretizationFactory.cpp
+++ b/src/disc/Albany_DiscretizationFactory.cpp
@@ -105,12 +105,14 @@ DiscretizationFactory::createMeshStruct(Teuchos::RCP<Teuchos::ParameterList> dis
         int extruded_ws_size = disc_params->get("Workset Size", 50);
         int basal_ws_size = -1;
         if(extruded_ws_size != -1) {
-          basal_ws_size =  extruded_ws_size/ (disc_params->get<int>("NumLayers") * ((disc_params->get<std::string>("Element Shape") == "Tetrahedron") ? 3 : 1));
+          const int num_cells_per_layer = disc_params->get<std::string>("Element Shape") == "Tetrahedron" ? 3 : 1;
+          const int num_cells_per_column = num_cells_per_layer * disc_params->get<int>("NumLayers");
+          basal_ws_size = extruded_ws_size / num_cells_per_column;
           basal_ws_size = std::max(basal_ws_size,1); //makes sure is at least 1.
         }
         if (disc_params->isSublist("Side Set Discretizations") && disc_params->sublist("Side Set Discretizations").isSublist("basalside")) {
             basal_params = Teuchos::rcp(new Teuchos::ParameterList(disc_params->sublist("Side Set Discretizations").sublist("basalside")));
-            if(!disc_params->sublist("Side Set Discretizations").isParameter("Workset Size"))
+            if(!disc_params->sublist("Side Set Discretizations").isParameter("Workset Size") || extruded_ws_size == -1)
               basal_params->set("Workset Size", basal_ws_size);
         } else {
             // Backward compatibility: Ioss, with parameters mixed with the extruded mesh ones

--- a/src/disc/Albany_DiscretizationFactory.cpp
+++ b/src/disc/Albany_DiscretizationFactory.cpp
@@ -105,14 +105,17 @@ DiscretizationFactory::createMeshStruct(Teuchos::RCP<Teuchos::ParameterList> dis
         int extruded_ws_size = disc_params->get("Workset Size", 50);
         int basal_ws_size = -1;
         if(extruded_ws_size != -1) {
-          const int num_cells_per_layer = disc_params->get<std::string>("Element Shape") == "Tetrahedron" ? 3 : 1;
-          const int num_cells_per_column = num_cells_per_layer * disc_params->get<int>("NumLayers");
+          const int num_cells_per_column_per_layer = disc_params->get<std::string>("Element Shape") ==
+              "Tetrahedron" ? 3 : 1; // number of 3D cells in one extruded 2D cell
+          const int num_cells_per_column = num_cells_per_column_per_layer * disc_params->get<int>("NumLayers");
           basal_ws_size = extruded_ws_size / num_cells_per_column;
           basal_ws_size = std::max(basal_ws_size,1); //makes sure is at least 1.
         }
         if (disc_params->isSublist("Side Set Discretizations") && disc_params->sublist("Side Set Discretizations").isSublist("basalside")) {
             basal_params = Teuchos::rcp(new Teuchos::ParameterList(disc_params->sublist("Side Set Discretizations").sublist("basalside")));
-            if(!disc_params->sublist("Side Set Discretizations").isParameter("Workset Size") || extruded_ws_size == -1)
+            if (extruded_ws_size == -1)
+              basal_params->set("Workset Size", -1);
+            else if (!disc_params->sublist("Side Set Discretizations").isParameter("Workset Size"))
               basal_params->set("Workset Size", basal_ws_size);
         } else {
             // Backward compatibility: Ioss, with parameters mixed with the extruded mesh ones

--- a/src/disc/Albany_DiscretizationFactory.cpp
+++ b/src/disc/Albany_DiscretizationFactory.cpp
@@ -100,30 +100,32 @@ DiscretizationFactory::createMeshStruct(Teuchos::RCP<Teuchos::ParameterList> dis
     }
     else if (method == "Extruded") {
         Teuchos::RCP<AbstractMeshStruct> basalMesh;
+
+        // Get basal_params
         Teuchos::RCP<Teuchos::ParameterList> basal_params;
-        //compute basal Workset size starting from Discretization
-        int extruded_ws_size = disc_params->get("Workset Size", 50);
-        int basal_ws_size = -1;
-        if(extruded_ws_size != -1) {
-          const int num_cells_per_column_per_layer = disc_params->get<std::string>("Element Shape") ==
-              "Tetrahedron" ? 3 : 1; // number of 3D cells in one extruded 2D cell
-          const int num_cells_per_column = num_cells_per_column_per_layer * disc_params->get<int>("NumLayers");
-          basal_ws_size = extruded_ws_size / num_cells_per_column;
-          basal_ws_size = std::max(basal_ws_size,1); //makes sure is at least 1.
-        }
         if (disc_params->isSublist("Side Set Discretizations") && disc_params->sublist("Side Set Discretizations").isSublist("basalside")) {
             basal_params = Teuchos::rcp(new Teuchos::ParameterList(disc_params->sublist("Side Set Discretizations").sublist("basalside")));
-            if (extruded_ws_size == -1)
-              basal_params->set("Workset Size", -1);
-            else if (!disc_params->sublist("Side Set Discretizations").isParameter("Workset Size"))
-              basal_params->set("Workset Size", basal_ws_size);
         } else {
             // Backward compatibility: Ioss, with parameters mixed with the extruded mesh ones
             basal_params->set("Method", "Ioss");
             basal_params->set("Use Serial Mesh", disc_params->get("Use Serial Mesh", false));
             basal_params->set("Exodus Input File Name", disc_params->get("Exodus Input File Name", "basalmesh.exo"));
-            basal_params->set("Workset Size", basal_ws_size);
         }
+
+        // Set basal workset size
+        int extruded_ws_size = disc_params->get("Workset Size", 50);
+        if (extruded_ws_size == -1) {
+          basal_params->set("Workset Size", -1);
+        } else if (!basal_params->isParameter("Workset Size")) {
+          // Compute basal workset size based on extruded workset size
+          const int num_cells_per_column_per_layer = disc_params->get<std::string>("Element Shape") ==
+              "Tetrahedron" ? 3 : 1; // number of 3D cells in one extruded 2D cell
+          const int num_cells_per_column = num_cells_per_column_per_layer * disc_params->get<int>("NumLayers");
+          int basal_ws_size = extruded_ws_size / num_cells_per_column;
+          basal_ws_size = std::max(basal_ws_size,1); //makes sure is at least 1.
+          basal_params->set("Workset Size", basal_ws_size);
+        }
+
         basalMesh = createMeshStruct(basal_params, comm, numParams);
         return Teuchos::rcp(new ExtrudedSTKMeshStruct(disc_params, comm, basalMesh, numParams));
     }

--- a/src/disc/Albany_MeshSpecs.hpp
+++ b/src/disc/Albany_MeshSpecs.hpp
@@ -64,6 +64,7 @@ struct MeshSpecsStruct
   // Side Sets Names
   std::vector<std::string> ssNames;
   int                      worksetSize;
+  bool                     singleWorksetSizeAllocation = false;
   // Element block name for the EB that this struct corresponds to
   std::string ebName;
 

--- a/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
@@ -516,15 +516,13 @@ void GenericSTKMeshStruct::initializeSideSetMeshStructs (const Teuchos::RCP<cons
         if (!params_ss->isParameter("Number Of Time Derivatives"))
           params_ss->set<int>("Number Of Time Derivatives",num_time_deriv);
 
-        // If workset size is -1, set sideset discretization workset size based on sideset mesh spec
-        // Note: this should be set to either the maximum size or -1
-        if (params->get<int>("Workset Size", DEFAULT_WORKSET_SIZE) == -1) {
-          const auto &sideSetMeshSpecs = this->meshSpecs[0]->sideSetMeshSpecs;
-          auto sideSetMeshSpecIter = sideSetMeshSpecs.find(ss_name);
-          TEUCHOS_TEST_FOR_EXCEPTION(sideSetMeshSpecIter == sideSetMeshSpecs.end(), std::runtime_error,
-              "Cannot find " << ss_name << " in sideSetMeshSpecs!\n");
+        // Set sideset discretization workset size based on sideset mesh spec if a single workset is used
+        const auto &sideSetMeshSpecs = this->meshSpecs[0]->sideSetMeshSpecs;
+        auto sideSetMeshSpecIter = sideSetMeshSpecs.find(ss_name);
+        TEUCHOS_TEST_FOR_EXCEPTION(sideSetMeshSpecIter == sideSetMeshSpecs.end(), std::runtime_error,
+            "Cannot find " << ss_name << " in sideSetMeshSpecs!\n");
+        if (sideSetMeshSpecIter->second[0]->singleWorksetSizeAllocation)
           params_ss->set<int>("Workset Size", sideSetMeshSpecIter->second[0]->worksetSize);
-        }
 
         std::string method = params_ss->get<std::string>("Method");
         if (method=="SideSetSTK") {
@@ -532,10 +530,6 @@ void GenericSTKMeshStruct::initializeSideSetMeshStructs (const Teuchos::RCP<cons
           TEUCHOS_TEST_FOR_EXCEPTION (meshSpecs.size()!=1, std::logic_error,
                                       "Error! So far, side set mesh extraction is allowed only from STK meshes with 1 element block.\n");
 
-          const auto &sideSetMeshSpecs = this->meshSpecs[0]->sideSetMeshSpecs;
-          auto sideSetMeshSpecIter = sideSetMeshSpecs.find(ss_name);
-          TEUCHOS_TEST_FOR_EXCEPTION(sideSetMeshSpecIter == sideSetMeshSpecs.end(), std::runtime_error,
-              "Cannot find " << ss_name << " in sideSetMeshSpecs!\n");
           this->sideSetMeshStructs[ss_name] =
               Teuchos::rcp(new SideSetSTKMeshStruct(
                   *this->meshSpecs[0], *sideSetMeshSpecIter->second[0],

--- a/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
@@ -511,6 +511,11 @@ void GenericSTKMeshStruct::initializeSideSetMeshStructs (const Teuchos::RCP<cons
       if (!params_ss->isParameter("Number Of Time Derivatives"))
         params_ss->set<int>("Number Of Time Derivatives",num_time_deriv);
 
+      if (!params_ss->isParameter("Workset Size")) {
+        int worksetSizeMax = params->get<int>("Workset Size", DEFAULT_WORKSET_SIZE);
+        params_ss->set("Workset Size", worksetSizeMax);
+      }
+
       std::string method = params_ss->get<std::string>("Method");
       if (method=="SideSetSTK") {
         // The user said this mesh is extracted from a higher dimensional one

--- a/src/disc/stk/Albany_GmshSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GmshSTKMeshStruct.cpp
@@ -135,6 +135,10 @@ Albany::GmshSTKMeshStruct::GmshSTKMeshStruct (const Teuchos::RCP<Teuchos::Parame
                                    worksetSize, partVec[0]->name(),
                                    ebNameToIndex, this->interleavedOrdering));
 
+  // Create a mesh specs object for EACH side set
+  this->initializeSideSetMeshSpecs(commT);
+
+  // Initialize the requested sideset mesh struct in the mesh
   this->initializeSideSetMeshStructs(commT);
 }
 

--- a/src/disc/stk/Albany_IossSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_IossSTKMeshStruct.cpp
@@ -230,7 +230,7 @@ Albany::IossSTKMeshStruct::IossSTKMeshStruct(
     this->meshSpecs[0] = Teuchos::rcp(new Albany::MeshSpecsStruct(
         ctd, numDim, cub, nsNames, ssNames, worksetSize, partVec[0]->name(),
         ebNameToIndex, this->interleavedOrdering, false, cub_rule));
-    if (worksetSizeMax == -1) this->meshSpecs[0]->singleWorksetSizeAllocation = true;
+    if (worksetSize == ebSizeMax) this->meshSpecs[0]->singleWorksetSizeAllocation = true;
   } else {
     *out << "MULTIPLE Elem Block in Ioss: DO worksetSize[eb] max?? " << std::endl;
     this->allElementBlocksHaveSamePhysics=false;
@@ -240,7 +240,7 @@ Albany::IossSTKMeshStruct::IossSTKMeshStruct(
       this->meshSpecs[eb] = Teuchos::rcp(new Albany::MeshSpecsStruct(
           ctd, numDim, cub, nsNames, ssNames, worksetSize, partVec[eb]->name(),
           ebNameToIndex, this->interleavedOrdering, true, cub_rule));
-      if (worksetSizeMax == -1) this->meshSpecs[eb]->singleWorksetSizeAllocation = true;
+      if (worksetSize == ebSizeMax) this->meshSpecs[eb]->singleWorksetSizeAllocation = true;
     }
   }
 
@@ -263,7 +263,7 @@ Albany::IossSTKMeshStruct::IossSTKMeshStruct(
   this->initializeSideSetMeshSpecs(commT);
 
   // Get upper bound on sideset workset sizes by using Ioss element counts on side blocks
-  if (worksetSizeMax == -1) {
+  if (worksetSize == ebSizeMax) {
     if (!params->get("Separate Evaluators by Element Block",false)) {
       for (auto ss : sss) {
         // Get maximum sideset size from Ioss

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -1806,6 +1806,8 @@ STKDiscretization::computeSideSets()
     if (stkMeshStruct->getMeshSpecs()[0]->sideSetMeshSpecs[ss->first].size() > 0) {
       int ssWorksetSize = stkMeshStruct->getMeshSpecs()[0]->sideSetMeshSpecs[ss->first][0]->worksetSize;
       bool ssSingleWorksetSizeAllocation = stkMeshStruct->getMeshSpecs()[0]->sideSetMeshSpecs[ss->first][0]->singleWorksetSizeAllocation;
+      if (ssSingleWorksetSizeAllocation)
+        *out << "STKDisc: sideset " << ss->first << " set to single workset size allocation." << std::endl;
 
       // Slim sideset alloction is automatically activated when using a single workset and Ioss,
       //  therefore we need to make sure that the meshspecs for each sideset have a large enough

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -1799,6 +1799,25 @@ STKDiscretization::computeSideSets()
     *out << "STKDisc: sideset " << ss->first << " has size " << sides.size()
          << "  on Proc 0." << std::endl;
 
+    // If the sideSet has mesh specs, then we need to check if slim allocation is valid. There
+    //   are some cases where mesh specs for a sideset haven't been created (see Albany_GenericSTKMeshStruct.cpp:482)
+    //   but we don't need to check slim allocation for these because if they are used in an evaluator,
+    //   other exceptions will be thrown.
+    if (stkMeshStruct->getMeshSpecs()[0]->sideSetMeshSpecs[ss->first].size() > 0) {
+      int ssWorksetSize = stkMeshStruct->getMeshSpecs()[0]->sideSetMeshSpecs[ss->first][0]->worksetSize;
+      bool ssSingleWorksetSizeAllocation = stkMeshStruct->getMeshSpecs()[0]->sideSetMeshSpecs[ss->first][0]->singleWorksetSizeAllocation;
+
+      // Slim sideset alloction is automatically activated when using a single workset and Ioss,
+      //  therefore we need to make sure that the meshspecs for each sideset have a large enough
+      //  workset size to avoid writing or reading out of bounds.
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        ssSingleWorksetSizeAllocation && ssWorksetSize != (int) sides.size(),
+        std::logic_error,
+        "STKDisc: MeshSpec workset size should be the same as sideset size for slim sideset allocation on sideset "
+          << ss->first << ", (sideSetMeshStructs[" << ss->first << "] = " << ssWorksetSize 
+          << ", ssSingleWorksetSizeAllocation = " << ssSingleWorksetSizeAllocation << ")" << std::endl);
+    }
+
     // loop over the sides to see what they are, then fill in the data holder
     // for side set options, look at
     // $TRILINOS_DIR/packages/stk/stk_usecases/mesh/UseCase_13.cpp

--- a/src/disc/stk/Albany_SideSetSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_SideSetSTKMeshStruct.cpp
@@ -25,9 +25,10 @@ namespace Albany
 {
 
 SideSetSTKMeshStruct::SideSetSTKMeshStruct (const MeshSpecsStruct& inputMeshSpecs,
+                                            const MeshSpecsStruct& inputSideMeshSpecs,
                                             const Teuchos::RCP<Teuchos::ParameterList>& params,
                                             const Teuchos::RCP<const Teuchos_Comm>& commT,
-					    const int numParams) :
+                                            const int numParams) :
   GenericSTKMeshStruct(params, -1, numParams)
 {
 
@@ -84,8 +85,10 @@ SideSetSTKMeshStruct::SideSetSTKMeshStruct (const MeshSpecsStruct& inputMeshSpec
 
   std::vector<std::string> ssNames; // Empty
   int cub = params->get("Cubature Degree", 3);
+
   int worksetSizeMax = params->get<int>("Workset Size", DEFAULT_WORKSET_SIZE);
-  int worksetSize = this->computeWorksetSize(worksetSizeMax,inputMeshSpecs.worksetSize);
+  int worksetSize = this->computeWorksetSize(worksetSizeMax,
+      inputSideMeshSpecs.singleWorksetSizeAllocation ? inputSideMeshSpecs.worksetSize : inputMeshSpecs.worksetSize);
 
   std::string ebn = "Element Block 0";
   partVec.push_back(&metaData->declare_part_with_topology(ebn, etopology));
@@ -100,6 +103,7 @@ SideSetSTKMeshStruct::SideSetSTKMeshStruct (const MeshSpecsStruct& inputMeshSpec
 
   this->meshSpecs[0] = Teuchos::rcp(new Albany::MeshSpecsStruct(ctd, this->numDim, cub, nsNames, ssNames, worksetSize,
                                                                 ebn, ebNameToIndex, this->interleavedOrdering));
+  if (inputSideMeshSpecs.singleWorksetSizeAllocation) this->meshSpecs[0]->singleWorksetSizeAllocation = true;
 
   const Teuchos::MpiComm<int>* mpiComm = dynamic_cast<const Teuchos::MpiComm<int>* > (commT.get());
   bulkData = Teuchos::rcp(new stk::mesh::BulkData(*metaData, *mpiComm->getRawMpiComm(),

--- a/src/disc/stk/Albany_SideSetSTKMeshStruct.hpp
+++ b/src/disc/stk/Albany_SideSetSTKMeshStruct.hpp
@@ -4,8 +4,8 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#ifndef ALBANY_SIDE_SET_STK_MESH_STRUCT_HPP
-#define ALBANY_SIDE_SET_STK_MESH_STRUCT_HPP
+#ifndef SRC_DISC_STK_ALBANY_SIDESETSTKMESHSTRUCT_HPP_
+#define SRC_DISC_STK_ALBANY_SIDESETSTKMESHSTRUCT_HPP_
 
 #include "Albany_GenericSTKMeshStruct.hpp"
 
@@ -17,9 +17,10 @@ class SideSetSTKMeshStruct : public GenericSTKMeshStruct
 public:
 
   SideSetSTKMeshStruct (const MeshSpecsStruct& inputMeshSpecs,
+                        const MeshSpecsStruct& inputSideMeshSpecs,
                         const Teuchos::RCP<Teuchos::ParameterList>& params,
                         const Teuchos::RCP<const Teuchos_Comm>& commT,
-			const int numParams);
+                        const int numParams);
 
   virtual ~SideSetSTKMeshStruct();
 
@@ -55,4 +56,4 @@ private:
 
 } // Namespace Albany
 
-#endif // ALBANY_SIDE_SET_STK_MESH_STRUCT_HPP
+#endif /* SRC_DISC_STK_ALBANY_SIDESETSTKMESHSTRUCT_HPP_ */

--- a/src/problems/Albany_Layouts.cpp
+++ b/src/problems/Albany_Layouts.cpp
@@ -105,7 +105,7 @@ Albany::Layouts::Layouts (int worksetSize, int numVertices, int numNodes, int nu
   // have separate node_vector and node_gradient layouts.
 }
 
-Albany::Layouts::Layouts (int worksetSize, int numVertices, int numNodes, int numQPts, int numSideDim, int numSpaceDim, int numSides, int vecDim, bool collapsed_sidesets, int sidesetWorksetSize)
+Albany::Layouts::Layouts (int worksetSize, int numVertices, int numNodes, int numQPts, int numSideDim, int numSpaceDim, int numSides, int vecDim, bool collapsed_sidesets, bool singleWorksetSizeAllocation, int sidesetWorksetSize)
 // numSideDim is the number of spatial dimensions
 // vecDim is the length of a vector quantity
 // -- For many problems, numSideDim is used for both since there are
@@ -202,7 +202,7 @@ Albany::Layouts::Layouts (int worksetSize, int numVertices, int numNodes, int nu
 
   // Collapsed sideset layouts to ensure contiguous memory access for efficient GPU evaluation
   // TODO: using meshspecs struct to set sideset workset size doesn't work yet for extruded boundaries
-  sidesetWorksetSize = (sidesetWorksetSize > 0) ? sidesetWorksetSize : worksetSize*numSides;
+  sidesetWorksetSize = singleWorksetSizeAllocation ? sidesetWorksetSize : worksetSize*numSides;
   qp_scalar_sideset       = rcp(new MDALayout<Side,QuadPoint>(sidesetWorksetSize,numQPts));
   node_scalar_sideset     = rcp(new MDALayout<Side,Node>(sidesetWorksetSize,numNodes));
   node_vector_sideset     = rcp(new MDALayout<Side,Node,Dim>(sidesetWorksetSize,numNodes,vecDim));

--- a/src/problems/Albany_Layouts.cpp
+++ b/src/problems/Albany_Layouts.cpp
@@ -200,8 +200,9 @@ Albany::Layouts::Layouts (int worksetSize, int numVertices, int numNodes, int nu
   // This flag lets evaluators know to use the collapsed sideset layouts
   useCollapsedSidesets = collapsed_sidesets;
 
-  // Collapsed sideset layouts to ensure contiguous memory access for efficient GPU evaluation 
-  sidesetWorksetSize = worksetSize*numSides;
+  // Collapsed sideset layouts to ensure contiguous memory access for efficient GPU evaluation
+  // TODO: using meshspecs struct to set sideset workset size doesn't work yet for extruded boundaries
+  sidesetWorksetSize = (sidesetWorksetSize > 0) ? sidesetWorksetSize : worksetSize*numSides;
   qp_scalar_sideset       = rcp(new MDALayout<Side,QuadPoint>(sidesetWorksetSize,numQPts));
   node_scalar_sideset     = rcp(new MDALayout<Side,Node>(sidesetWorksetSize,numNodes));
   node_vector_sideset     = rcp(new MDALayout<Side,Node,Dim>(sidesetWorksetSize,numNodes,vecDim));

--- a/src/problems/Albany_Layouts.hpp
+++ b/src/problems/Albany_Layouts.hpp
@@ -20,7 +20,7 @@ namespace Albany {
   struct Layouts {
 
     Layouts (int worksetSize, int numVertices, int numNodes, int numQPts, int numCellDim, int vecDim=-1, int numFace=0);
-    Layouts (int worksetSize, int numVertices, int numNodes, int numQPts, int numSideDim, int numSpaceDim, int numSides, int vecDim, bool collapsed_sidesets=false, int sidesetWorksetSize=1);
+    Layouts (int worksetSize, int numVertices, int numNodes, int numQPts, int numSideDim, int numSpaceDim, int numSides, int vecDim, bool collapsed_sidesets=false, bool singleWorksetSizeAllocation=false, int sidesetWorksetSize=1);
 
     //! Data Layout for scalar quantity that lives at nodes
     Teuchos::RCP<PHX::DataLayout> node_scalar;

--- a/src/problems/Albany_SideLaplacianProblem.cpp
+++ b/src/problems/Albany_SideLaplacianProblem.cpp
@@ -91,7 +91,8 @@ void SideLaplacian::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpe
     numSideQPs      = sideCubature->getNumPoints();
 
     dl_side = Teuchos::rcp(new Albany::Layouts(worksetSize,numSideVertices,numSideNodes,
-                                               numSideQPs,numDim-1,numDim,numCellSides,2,true,sideMeshSpecs.worksetSize));
+                                               numSideQPs,numDim-1,numDim,numCellSides,2,true,
+                                               sideMeshSpecs.singleWorksetSizeAllocation,sideMeshSpecs.worksetSize));
     dl->side_layouts[sideSetName] = dl_side;
   }
 

--- a/tests/unit/disc/UnitTest_BlockedDOFManager.cpp
+++ b/tests/unit/disc/UnitTest_BlockedDOFManager.cpp
@@ -103,7 +103,7 @@ tests are a beginning, "work in progress."
       const std::map<std::string, Teuchos::RCP<Albany::StateInfoStruct>> side_set_sis;
       const std::map<std::string, AbstractFieldContainer::FieldContainerRequirements> side_set_req;
 
-      ms->setFieldAndBulkData(comm, discParams, req, sis, AbstractMeshStruct::DEFAULT_WORKSET_SIZE,
+      ms->setFieldAndBulkData(comm, discParams, req, sis, meshStruct->getMeshSpecs()[0]->worksetSize,
                               side_set_sis, side_set_req);
 
       // Null for this test
@@ -384,7 +384,7 @@ This is just a start, to serve as an example. This has not been thought through 
       const std::map<std::string, Teuchos::RCP<Albany::StateInfoStruct>> side_set_sis;
       const std::map<std::string, AbstractFieldContainer::FieldContainerRequirements> side_set_req;
 
-      ms->setFieldAndBulkData(comm, discParams, req, sis, AbstractMeshStruct::DEFAULT_WORKSET_SIZE);
+      ms->setFieldAndBulkData(comm, discParams, req, sis, meshStruct->getMeshSpecs()[0]->worksetSize);
 
       // Use the Albany STK interface as it is used elsewhere in the code
       auto stkDisc = Teuchos::rcp(new BlockedSTKDiscretization(blockedDiscParams, ms, comm));


### PR DESCRIPTION
This reduces the sideset allocation size in the case of a single workset by setting the correct full workset sizes in mesh specs. It's controlled by a mesh specs parameter called `singleWorksetSizeAllocation`. It currently only works for `IossSTKMeshStruct`, `ExtrudedSTKMeshStruct` and `SideSetSTKMeshStruct` but it should be easy to extend to other mesh structs as long as the mesh struct knows the exact sideset sizes. If this is not known, the sidesets will be set to the original larger size.

Some notable changes:
1. if a single workset is used in the top level discretization, all sideset structs will also use a single workset
2. initializing the sideset mesh specs is now required before initializing the sideset mesh structs (i.e. it will throw). I think this is what was originally intended anyways?

@mcarlson801 