### PR TITLE
Use SI units for Glen's Law A parameter

### DIFF
--- a/src/LandIce/evaluators/LandIce_FlowRate_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_FlowRate_Def.hpp
@@ -79,13 +79,10 @@ void FlowRate<EvalT, Traits, TempST>::evaluateFields (typename Traits::EvalData 
       constexpr double switchingT (263.15);   // [K]
       constexpr double arrmlh (1.733e3);      // [Pa-3 s-1]
       constexpr double arrmll (3.613e-13);    // [Pa-3 s-1]
-      constexpr double k4scyr (3.1536e19);    // [s y-1]
-      constexpr double arrmh (k4scyr*arrmlh); // [Pa-3 yr-1]
-      constexpr double arrml (k4scyr*arrmll); // [Pa-3 yr-1]
 
       for (unsigned int cell=0; cell<workset.numCells; ++cell)
-        flowRate(cell) = (temperature(cell) < switchingT) ? arrml / std::exp (actenl / gascon / temperature(cell))
-                                                   : arrmh / std::exp (actenh / gascon / temperature(cell));
+        flowRate(cell) = (temperature(cell) < switchingT) ? arrmll / std::exp (actenl / gascon / temperature(cell))
+                                                   : arrmlh / std::exp (actenh / gascon / temperature(cell));
       break;
     }
 

--- a/src/LandIce/evaluators/LandIce_StokesBodyForce_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesBodyForce_Def.hpp
@@ -297,6 +297,12 @@ StokesBodyForce(const Teuchos::ParameterList& p,
   std::string type = bf_list->get("Type", "None");
   A = bf_list->get("Glen's Law A", 1.0);
   n = bf_list->get("Glen's Law n", 3.0);
+  // Turn A's units from [Pa^-n s^-1] to [k^-1 kPa^-n yr^-1]
+  // This makes the final units of viscosity kPa k yr, which makes [mu*Ugrad] = kPa
+  const auto scyr = 3.1536e7;      // [s y-1]
+  const auto knp1 = pow(1000,n+1);
+  A *= knp1*scyr;
+
   if (type == "None") {
     bf_type = NONE;
   }

--- a/src/LandIce/evaluators/LandIce_StokesFOBodyForce_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOBodyForce_Def.hpp
@@ -37,6 +37,12 @@ StokesFOBodyForce(const Teuchos::ParameterList& p,
   std::string type = bf_list->get("Type", "None");
   A = bf_list->get("Glen's Law A", 1.0);
   n = bf_list->get("Glen's Law n", 3.0);
+  // Turn A's units from [Pa^-n s^-1] to [k^-1 kPa^-n yr^-1]
+  // This makes the final units of viscosity kPa k yr, which makes [mu*Ugrad] = kPa
+  const auto scyr = 3.1536e7;      // [s y-1]
+  const auto knp1 = pow(1000,n+1);
+  A *= knp1*scyr;
+
   alpha = bf_list->get("LandIce alpha", 0.0);
 
   g = p_list->get("Gravity Acceleration", 9.8);

--- a/src/LandIce/evaluators/LandIce_ViscosityFO.hpp
+++ b/src/LandIce/evaluators/LandIce_ViscosityFO.hpp
@@ -49,7 +49,7 @@ private:
   TemperatureT flowRate(const TemperatureT& T) const;
 
   const double pi, actenh, actenl, gascon, switchingT;
-  const double arrmlh, arrmll, k4scyr;
+  const double arrmlh, arrmll, scyr, k4scyr;
   const double arrmh, arrml;
 
   bool extractStrainRateSq;
@@ -57,24 +57,20 @@ private:
   bool useStiffeningFactor;
   Teuchos::ParameterList* stereographicMapList;
 
-  //coefficients for Glen's law
-  double A;
-  double n;
+  // Coefficients for Glen's law
+  double A; // Pa^-n s^-1
+  double n; // nondimensional
 
   // Input:
   PHX::MDField<const VelT,Cell,QuadPoint,VecDim,Dim> Ugrad; //[(k yr)^{-1}], k=1000
   PHX::MDField<const VelT,Cell,QuadPoint,VecDim> U; //[m/yr]
   PHX::MDField<const MeshScalarT,Cell,QuadPoint, Dim> coordVec; // [Km]
   PHX::MDField<const TemprT,Cell> temperature; // [K]
-  //To distinguish it from the scalar flowFactor defined
-  //in the body of the function, it is called flowFactorA.
-  //Probably this should be changed at some point...
   PHX::MDField<const RealType,Cell> flowFactorA;  // [k^{-(n+1)} Pa^{-n} yr^{-1} ], k=1000.  This is the coefficient A.
   PHX::MDField<const ParamScalarT,Cell,QuadPoint> stiffeningFactor;
   PHX::MDField<const ScalarT> homotopyParam;
   bool performContinuousHomotopy;
   double expCoeff;
-
 
   // Output:
   PHX::MDField<OutputScalarT,Cell,QuadPoint> mu;  // [k^2 Pa yr], k=1000
@@ -84,7 +80,7 @@ private:
 
   unsigned int numQPs, numDims, numCells;
 
-  enum VISCTYPE {CONSTANT, EXPTRIG, GLENSLAW, GLENSLAW_XZ};
+  enum VISCTYPE {CONSTANT, EXPTRIG, GLENSLAW};
   enum FLOWRATETYPE {UNIFORM, TEMPERATUREBASED, FROMFILE, FROMCISM};
   VISCTYPE visc_type;
   FLOWRATETYPE flowRate_type;
@@ -100,20 +96,12 @@ public:
   struct ViscosityFO_GLENSLAW_UNIFORM_Tag{};
   struct ViscosityFO_GLENSLAW_TEMPERATUREBASED_Tag{};
   struct ViscosityFO_GLENSLAW_FROMFILE_Tag{};
-  struct ViscosityFO_GLENSLAW_XZ_UNIFORM_Tag{};
-  struct ViscosityFO_GLENSLAW_XZ_TEMPERATUREBASED_Tag{};
-  struct ViscosityFO_GLENSLAW_XZ_FROMFILE_Tag{};
-  struct ViscosityFO_GLENSLAW_XZ_FROMCISM_Tag{};
 
   typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_EXPTRIG_Tag> ViscosityFO_EXPTRIG_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_CONSTANT_Tag> ViscosityFO_CONSTANT_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_GLENSLAW_UNIFORM_Tag> ViscosityFO_GLENSLAW_UNIFORM_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_GLENSLAW_TEMPERATUREBASED_Tag> ViscosityFO_GLENSLAW_TEMPERATUREBASED_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_GLENSLAW_FROMFILE_Tag> ViscosityFO_GLENSLAW_FROMFILE_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_GLENSLAW_XZ_UNIFORM_Tag> ViscosityFO_GLENSLAW_XZ_UNIFORM_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_GLENSLAW_XZ_TEMPERATUREBASED_Tag> ViscosityFO_GLENSLAW_XZ_TEMPERATUREBASED_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_GLENSLAW_XZ_FROMFILE_Tag> ViscosityFO_GLENSLAW_XZ_FROMFILE_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_GLENSLAW_XZ_FROMCISM_Tag> ViscosityFO_GLENSLAW_XZ_FROMCISM_Policy;
 
   KOKKOS_INLINE_FUNCTION
   void operator() (const ViscosityFO_EXPTRIG_Tag& tag, const int& i) const;
@@ -131,25 +119,9 @@ public:
   void operator() (const ViscosityFO_GLENSLAW_FROMFILE_Tag& tag, const int& i) const;
 
   KOKKOS_INLINE_FUNCTION
-  void operator() (const ViscosityFO_GLENSLAW_XZ_UNIFORM_Tag& tag, const int& i) const;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const ViscosityFO_GLENSLAW_XZ_TEMPERATUREBASED_Tag& tag, const int& i) const;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const ViscosityFO_GLENSLAW_XZ_FROMFILE_Tag& tag, const int& i) const;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const ViscosityFO_GLENSLAW_XZ_FROMCISM_Tag& tag, const int& i) const;
-
-  KOKKOS_INLINE_FUNCTION
   void glenslaw (const ScalarT &flowFactorVec, const int& cell) const;
 
-  KOKKOS_INLINE_FUNCTION
-  void glenslaw_xz (const TemprT &flowFactorVec, const int& cell) const;
-
   double R, x_0, y_0, R2;
-
 };
 
 } // Namespace LandIce

--- a/src/LandIce/evaluators/LandIce_Viscosity_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_Viscosity_Def.hpp
@@ -41,6 +41,11 @@ Viscosity(const Teuchos::ParameterList& p,
   }
   else if (viscType == "Glen's Law"){
     visc_type = GLENSLAW;
+    const auto knp1 = pow(1000,n+1);
+    const auto scyr = 3.1536e7;
+    // Turn A's units from [Pa^-n s^-1] to [k^-1 kPa^-n yr^-1]
+    // This makes the final units of viscosity kPa k yr, which makes [mu*Ugrad] = kPa
+    A *= knp1*scyr;
     *out << "Glen's law viscosity!" << std::endl;
     *out << "A: " << A << std::endl;
     *out << "n: " << n << std::endl;

--- a/src/LandIce/interface_with_mpas/Interface.cpp
+++ b/src/LandIce/interface_with_mpas/Interface.cpp
@@ -586,8 +586,12 @@ void velocity_solver_extrude_3d_grid(int nLayers, int globalTrianglesStride,
   viscosityList.set("Type", viscosityList.get("Type", "Glen's Law"));
   double homotopy_param = (paramList->sublist("Problem").get("Solution Method", "Steady") == "Steady") ? 0.3 : 1.0;
   viscosityList.set("Glen's Law Homotopy Parameter", viscosityList.get("Glen's Law Homotopy Parameter", homotopy_param));
-  viscosityList.set("Glen's Law A", viscosityList.get("Glen's Law A", MPAS_flowParamA));
+  // Convert MPAS value for A from [k^-1 kPa^-n yr^-1] to [Pa^-n s^-1]
   viscosityList.set("Glen's Law n", viscosityList.get("Glen's Law n",  MPAS_flowLawExponent));
+  const auto spy = 3600*24*365;
+  const auto knp1 = std::pow(1000,MPAS_flowLawExponent+1);
+  const auto A = MPAS_flowParamA / knp1 / spy;
+  viscosityList.set("Glen's Law A", viscosityList.get("Glen's Law A", A));
   viscosityList.set("Flow Rate Type", viscosityList.get("Flow Rate Type", "Temperature Based"));
   viscosityList.set("Use Stiffening Factor", viscosityList.get("Use Stiffening Factor", true));
   viscosityList.set("Extract Strain Rate Sq", viscosityList.get("Extract Strain Rate Sq", true)); //set true if not defined

--- a/tests/large/LandIce/CismAlbany/inputFiles/input_cism-albanyT.yaml
+++ b/tests/large/LandIce/CismAlbany/inputFiles/input_cism-albanyT.yaml
@@ -10,12 +10,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.00000000000000011e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.00000000000000011e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: From CISM
     Response Functions:
       Response 2:
@@ -42,7 +42,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/large/LandIce/CismAlbany/inputFiles/input_standalone-albanyT.yaml
+++ b/tests/large/LandIce/CismAlbany/inputFiles/input_standalone-albanyT.yaml
@@ -17,17 +17,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.81000000000000049e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.00000000000000011e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.00000000000000011e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     LandIce BCs:
       Number: 1
@@ -123,7 +123,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/large/LandIce/CismAlbany/inputFiles/input_standalone-albanyT_withFlowRate.yaml
+++ b/tests/large/LandIce/CismAlbany/inputFiles/input_standalone-albanyT_withFlowRate.yaml
@@ -17,16 +17,16 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.81000000000000049e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.00000000000000011e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.00000000000000011e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     LandIce BCs:
       Number: 1
@@ -115,7 +115,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/large/LandIce/FO_GIS/input_fo_gis20km_refine.yaml
+++ b/tests/large/LandIce/FO_GIS/input_fo_gis20km_refine.yaml
@@ -12,12 +12,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
     Response Functions:
@@ -48,7 +48,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/AsciiMeshes/Dome/input_fo_dome_ascii.yaml
+++ b/tests/small/LandIce/AsciiMeshes/Dome/input_fo_dome_ascii.yaml
@@ -12,12 +12,12 @@ ANONYMOUS:
     Parameters: 
       Number Of Parameters: 1
       Parameter 0:
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity: 
       Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000000e+00
+      Glen's Law Homotopy Parameter: 1.00000000000000000e+00
       Flow Rate Type: From File
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law n: 3.00000000000000000e+00
     LandIce Physical Parameters: 
       Water Density: 1.00000000000000000e+03
       Ice Density: 9.10000000000000000e+02
@@ -91,7 +91,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/AsciiMeshes/Dome/input_fo_dome_restart.yaml
+++ b/tests/small/LandIce/AsciiMeshes/Dome/input_fo_dome_restart.yaml
@@ -12,12 +12,12 @@ ANONYMOUS:
     Parameters: 
       Number Of Parameters: 1
       Parameter 0:
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity: 
       Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000000e+00
+      Glen's Law Homotopy Parameter: 1.00000000000000000e+00
       Flow Rate Type: From File
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law n: 3.00000000000000000e+00
     LandIce Physical Parameters: 
       Water Density: 1.00000000000000000e+03
       Ice Density: 9.10000000000000000e+02
@@ -93,7 +93,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/Enthalpy/input_enthalpy_humboldt.yaml
+++ b/tests/small/LandIce/Enthalpy/input_enthalpy_humboldt.yaml
@@ -20,12 +20,12 @@ ANONYMOUS:
       DBC on NS top for DOF Enth prescribe Field: surface_enthalpy
     LandIce Viscosity:
       Extract Strain Rate Sq: true
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 0.5e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.5e+00
       Continuous Homotopy With Constant Initial Viscosity: true
       Coefficient For Continuous Homotopy: 8.00000000000000000e+00
-      'Glen''s Law A': 7.56960000000000016e-05
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law A: 2.400304414e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     LandIce Physical Parameters:
       Conductivity of ice: 2.1e+00
@@ -57,7 +57,7 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     Response Functions:
       #Collection Method: Sum Responses
       Number Of Responses: 1
@@ -341,7 +341,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 100
         Max Value: 4.00000000000000022e-01

--- a/tests/small/LandIce/Enthalpy/input_kleiner_A.yaml
+++ b/tests/small/LandIce/Enthalpy/input_kleiner_A.yaml
@@ -16,12 +16,12 @@ ANONYMOUS:
       DBC on NS top for DOF Enth prescribe Field: surface_enthalpy
     LandIce Viscosity:
       Extract Strain Rate Sq: true
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.0e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.0e+00
       Continuous Homotopy With Constant Initial Viscosity: true
       Coefficient For Continuous Homotopy: 8.00000000000000000e+00
-      'Glen''s Law A': 1.6725e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law A: 5.30346271e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     LandIce Physical Parameters:
       Conductivity of ice: 2.1e+00
@@ -53,7 +53,7 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     Response Functions:
       Number Of Responses: 1
       Response 0:
@@ -137,7 +137,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 100
         Max Value: 4.00000000000000022e-01

--- a/tests/small/LandIce/Enthalpy/input_kleiner_B.yaml
+++ b/tests/small/LandIce/Enthalpy/input_kleiner_B.yaml
@@ -16,12 +16,12 @@ ANONYMOUS:
       DBC on NS top for DOF Enth prescribe Field: surface_enthalpy
     LandIce Viscosity:
       Extract Strain Rate Sq: true
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.0e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.0e+00
       Continuous Homotopy With Constant Initial Viscosity: true
       Coefficient For Continuous Homotopy: 8.00000000000000000e+00
-      'Glen''s Law A': 1.6725e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law A: 5.30346271e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Uniform
     LandIce Physical Parameters:
       Conductivity of ice: 2.1e+00
@@ -53,7 +53,7 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     Response Functions:
       Number Of Responses: 1
       Response 0:
@@ -145,7 +145,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_AIS/inputML1.yaml
+++ b/tests/small/LandIce/FO_AIS/inputML1.yaml
@@ -30,17 +30,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 0.00000000000000000e+00
-      'Glen''s Law A': 5.00000000000000023e-05
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.00000000000000000e+00
+      Glen's Law A: 1.5854896e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -108,7 +108,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 15
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_AIS/inputML3.yaml
+++ b/tests/small/LandIce/FO_AIS/inputML3.yaml
@@ -34,17 +34,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 5.00000000000000023e-05
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 1.5854896e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -130,7 +130,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 15
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_AIS/inputMLRay.yaml
+++ b/tests/small/LandIce/FO_AIS/inputMLRay.yaml
@@ -29,17 +29,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 0.00000000000000000e+00
-      'Glen''s Law A': 5.00000000000000023e-05
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.00000000000000000e+00
+      Glen's Law A: 1.5854896e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -106,7 +106,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 15
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_AIS/inputMueLuLongRay.yaml
+++ b/tests/small/LandIce/FO_AIS/inputMueLuLongRay.yaml
@@ -29,17 +29,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 0.00000000000000000e+00
-      'Glen''s Law A': 5.00000000000000023e-05
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.00000000000000000e+00
+      Glen's Law A: 1.5854896e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -106,7 +106,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 15
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_AIS/inputMueLuShort1.yaml
+++ b/tests/small/LandIce/FO_AIS/inputMueLuShort1.yaml
@@ -30,17 +30,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 0.00000000000000000e+00
-      'Glen''s Law A': 5.00000000000000023e-05
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.00000000000000000e+00
+      Glen's Law A: 1.5854896e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -108,7 +108,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 15
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_AIS/inputMueLuShort3.yaml
+++ b/tests/small/LandIce/FO_AIS/inputMueLuShort3.yaml
@@ -34,17 +34,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 3.0e-01
-      'Glen''s Law A': 5.00000000000000023e-05
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 3.0e-01
+      Glen's Law A: 1.5854896e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -131,7 +131,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 15
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_AIS/inputMueLuShortRay.yaml
+++ b/tests/small/LandIce/FO_AIS/inputMueLuShortRay.yaml
@@ -29,17 +29,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 0.00000000000000000e+00
-      'Glen''s Law A': 5.00000000000000023e-05
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.00000000000000000e+00
+      Glen's Law A: 1.5854896e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -106,7 +106,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 15
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_AIS/input_FROSch.yaml
+++ b/tests/small/LandIce/FO_AIS/input_FROSch.yaml
@@ -37,17 +37,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 3.0e-01
-      'Glen''s Law A': 5.00000000000000023e-05
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 3.0e-01
+      Glen's Law A: 1.5854896e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -134,7 +134,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 15
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis10km.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis10km.yaml
@@ -12,12 +12,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
     Response Functions:
@@ -46,7 +46,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis10km_ascii.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis10km_ascii.yaml
@@ -12,12 +12,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
     Response Functions:
@@ -44,7 +44,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis20km.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis20km.yaml
@@ -12,12 +12,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
     Response Functions:
@@ -46,7 +46,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 15
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis20km_ascii.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis20km_ascii.yaml
@@ -12,12 +12,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
     LandIce Physical Parameters:
@@ -48,7 +48,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis20km_test.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis20km_test.yaml
@@ -19,16 +19,16 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Gravity Acceleration: 9.80000000000000071e+00
       Ice Density: 9.10000000000000000e+02
       Water Density: 1.02800000000000000e+03
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
     Response Functions:
@@ -77,7 +77,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 15
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis20km_testT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis20km_testT.yaml
@@ -19,12 +19,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
     Response Functions:
@@ -59,7 +59,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 15
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis2km.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis2km.yaml
@@ -12,12 +12,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
     Response Functions:
@@ -46,7 +46,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 15
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis2km_ascii.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis2km_ascii.yaml
@@ -12,12 +12,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
     Initial Condition:
@@ -47,7 +47,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 0
         Max Value: 0.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis5km.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis5km.yaml
@@ -12,12 +12,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
     Response Functions:
@@ -46,7 +46,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis5km_ascii.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis5km_ascii.yaml
@@ -12,12 +12,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
     Response Functions:
@@ -44,7 +44,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity.yaml
@@ -36,7 +36,7 @@ ANONYMOUS:
       Number Of Parameters: 2
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
       Parameter 1:
         Type: Distributed
         Name: basal_friction
@@ -46,10 +46,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -143,7 +143,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivityT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivityT.yaml
@@ -35,7 +35,7 @@ ANONYMOUS:
       Number Of Parameters: 2
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
       Parameter 1:
         Type: Distributed
         Name: basal_friction
@@ -45,10 +45,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity: 
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000006e-01
-      'Glen''s Law A': 1.00000000000000005e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000006e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force: 
       Type: FO INTERP SURF GRAD
@@ -150,7 +150,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 1.00000000000000006e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_beta.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_beta.yaml
@@ -46,10 +46,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -124,7 +124,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness.yaml
@@ -52,10 +52,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -175,7 +175,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thicknessT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thicknessT.yaml
@@ -58,10 +58,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.8e+00
       Clausius-Clapeyron Coefficient: 0.0e+02
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.0e-01
-      'Glen''s Law A': 1.0e-04
-      'Glen''s Law n': 3.0e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.0e-01
+      Glen's Law A: 3.17098e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.0e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -186,7 +186,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness_adjustSurfHeightT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness_adjustSurfHeightT.yaml
@@ -52,10 +52,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -175,7 +175,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta.yaml
@@ -57,10 +57,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     LandIce L2 Projected Boundary Laplacian:
       Mass Coefficient: 1.00000000000000005e-01
@@ -239,7 +239,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
@@ -55,10 +55,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     LandIce L2 Projected Boundary Laplacian:
       Mass Coefficient: 1.00000000000000005e-01
@@ -253,7 +253,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
@@ -48,10 +48,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     LandIce L2 Projected Boundary Laplacian:
       Mass Coefficient: 1.00000000000000005e-01
@@ -267,7 +267,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
@@ -56,10 +56,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     LandIce L2 Projected Boundary Laplacian:
       Mass Coefficient: 1.00000000000000005e-01
@@ -255,7 +255,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening.yaml
@@ -58,10 +58,10 @@ ANONYMOUS:
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
       Use Stiffening Factor: true
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -250,7 +250,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
@@ -58,10 +58,10 @@ ANONYMOUS:
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
       Use Stiffening Factor: true
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -255,7 +255,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening_memT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening_memT.yaml
@@ -59,10 +59,10 @@ ANONYMOUS:
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
       Use Stiffening Factor: true
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -268,7 +268,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_thickness.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_thickness.yaml
@@ -49,10 +49,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -223,7 +223,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_params.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_params.yaml
@@ -69,10 +69,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -277,7 +277,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_paramsT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_paramsT.yaml
@@ -69,10 +69,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -277,7 +277,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smb.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smb.yaml
@@ -51,17 +51,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -170,7 +170,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smbT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smbT.yaml
@@ -51,17 +51,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -171,7 +171,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smb_restart.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smb_restart.yaml
@@ -51,17 +51,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -150,7 +150,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_coupled.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_coupled.yaml
@@ -34,17 +34,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -133,7 +133,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_coupledT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_coupledT.yaml
@@ -35,17 +35,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -135,7 +135,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_coupled_shape_opt.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_coupled_shape_opt.yaml
@@ -35,17 +35,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -144,7 +144,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_coupled_shape_optT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_coupled_shape_optT.yaml
@@ -36,17 +36,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -144,7 +144,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_forward_sensitivityT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_forward_sensitivityT.yaml
@@ -36,17 +36,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -140,7 +140,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_manifold.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_manifold.yaml
@@ -34,17 +34,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -138,7 +138,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_sampling.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_sampling.yaml
@@ -133,7 +133,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_unstruct.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_unstruct.yaml
@@ -34,17 +34,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -129,7 +129,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_unstructT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_unstructT.yaml
@@ -35,17 +35,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000006e-01
-      'Glen''s Law A': 1.00000000000000005e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000006e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -137,7 +137,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000006e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_unstructT_FROSch.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_unstructT_FROSch.yaml
@@ -38,17 +38,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000006e-01
-      'Glen''s Law A': 1.00000000000000005e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000006e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -140,7 +140,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000006e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_unstruct_memT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_unstruct_memT.yaml
@@ -36,17 +36,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000006e-01
-      'Glen''s Law A': 1.00000000000000005e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000006e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -138,7 +138,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000006e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_unstruct_restart.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_unstruct_restart.yaml
@@ -34,17 +34,17 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Physical Parameters:
       Water Density: 1.02800000000000000e+03
       Ice Density: 9.10000000000000000e+02
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -109,7 +109,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_wedge_adjoint_sensitivity.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_wedge_adjoint_sensitivity.yaml
@@ -36,7 +36,7 @@ ANONYMOUS:
       Number Of Parameters: 2
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
       Parameter 1:
         Type: Distributed
         Name: basal_friction
@@ -47,10 +47,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.80000000000000071e+00
       Clausius-Clapeyron Coefficient: 0.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.00000000000000005e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.00000000000000005e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
@@ -144,7 +144,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 1.00000000000000005e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch.yaml
@@ -41,12 +41,12 @@ ANONYMOUS:
       Number Of Parameters: 0
     LandIce Viscosity:
       Extract Strain Rate Sq: true
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 0.3e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.3e+00
       Continuous Homotopy With Constant Initial Viscosity: true
       Coefficient For Continuous Homotopy: 8.00000000000000000e+00
-      'Glen''s Law A': 7.56960000000000016e-05
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law A: 2.400304414e-24            # [Pa^-n s^-1
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     LandIce Physical Parameters:
       Conductivity of ice: 2.10000000000000008e+00
@@ -400,7 +400,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 100
         Max Value: 4.00000000000000022e-01

--- a/tests/small/LandIce/FO_Hydrology/input_dome_steadyT.yaml
+++ b/tests/small/LandIce/FO_Hydrology/input_dome_steadyT.yaml
@@ -54,10 +54,10 @@ ANONYMOUS:
       Gravity Acceleration:             9.8
       Clausius-Clapeyron Coefficient:   0.0
     LandIce Viscosity:
-      Type: 'Glen''s Law'
+      Type: Glen's Law
       Homotopy Parameter: 1.00000000000000006e-01
       Glen's Law A: 3.1689e-24    # [ Pa^-3 s^-1 ]
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD

--- a/tests/small/LandIce/FO_Hydrology/input_slab_steadyT.yaml
+++ b/tests/small/LandIce/FO_Hydrology/input_slab_steadyT.yaml
@@ -53,10 +53,10 @@ ANONYMOUS:
       Gravity Acceleration:             9.8
       Clausius-Clapeyron Coefficient:   0.0
     LandIce Viscosity:
-      Type: 'Glen''s Law'
+      Type: Glen's Law
       Homotopy Parameter: 1.00000000000000006e-01
       Glen's Law A: 3.1689e-24    # [ Pa^-3 s^-1 ]
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD

--- a/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testA.yaml
+++ b/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testA.yaml
@@ -13,12 +13,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
       LandIce alpha: 5.00000000000000000e-01
@@ -64,7 +64,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testAT.yaml
+++ b/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testAT.yaml
@@ -13,12 +13,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
       LandIce alpha: 5.00000000000000000e-01
@@ -64,7 +64,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testB.yaml
+++ b/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testB.yaml
@@ -13,12 +13,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
       LandIce alpha: 5.00000000000000000e-01
@@ -73,7 +73,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testC.yaml
+++ b/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testC.yaml
@@ -33,12 +33,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
       LandIce alpha: 1.00000000000000005e-01
@@ -84,7 +84,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 20
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testCT.yaml
+++ b/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testCT.yaml
@@ -33,12 +33,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
       LandIce alpha: 1.00000000000000005e-01
@@ -84,7 +84,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 20
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testD.yaml
+++ b/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testD.yaml
@@ -16,12 +16,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
       LandIce alpha: 1.00000000000000005e-01
@@ -69,7 +69,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_fo_cosexp_basal.yaml
+++ b/tests/small/LandIce/FO_MMS/input_fo_cosexp_basal.yaml
@@ -17,7 +17,7 @@ ANONYMOUS:
     Parameters: 
       Number Of Parameters: 1
       Parameter 0:
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity: 
       Type: Constant
     Body Force: 
@@ -62,7 +62,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_fo_cosexp_basalT.yaml
+++ b/tests/small/LandIce/FO_MMS/input_fo_cosexp_basalT.yaml
@@ -17,7 +17,7 @@ ANONYMOUS:
     Parameters: 
       Number Of Parameters: 1
       Parameter 0:
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity: 
       Type: Constant
     Body Force: 
@@ -62,7 +62,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_fo_cosexp_basal_all_glensLaw.yaml
+++ b/tests/small/LandIce/FO_MMS/input_fo_cosexp_basal_all_glensLaw.yaml
@@ -60,16 +60,16 @@ ANONYMOUS:
     Parameters: 
       Number Of Parameters: 1
       Parameter 0:
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity: 
-      Type: 'Glen''s Law'
-      'Glen''s Law A': 1.00000000000000000e+00
-      'Glen''s Law n': 3.00000000000000000e+00
-      'Glen''s Law Homotopy Parameter': 9.99990000000000046e-01
+      Type: Glen's Law
+      Glen's Law A: 3.17098e-20    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
+      Glen's Law Homotopy Parameter: 9.99990000000000046e-01
     Body Force: 
       Type: FOCosExp2DAll
-      'Glen''s Law A': 1.00000000000000000e+00
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law A: 3.17098e-20    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Response Functions: 
       Number Of Responses: 3
       Response 0:
@@ -108,7 +108,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 9.99990000000000046e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_fo_cosexp_basal_all_glensLawT.yaml
+++ b/tests/small/LandIce/FO_MMS/input_fo_cosexp_basal_all_glensLawT.yaml
@@ -56,16 +56,16 @@ ANONYMOUS:
     Parameters: 
       Number Of Parameters: 1
       Parameter 0:
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity: 
-      Type: 'Glen''s Law'
-      'Glen''s Law A': 1.00000000000000000e+00
-      'Glen''s Law n': 3.00000000000000000e+00
-      'Glen''s Law Homotopy Parameter': 9.99990000000000046e-01
+      Type: Glen's Law
+      Glen's Law A: 3.17098e-20    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
+      Glen's Law Homotopy Parameter: 9.99990000000000046e-01
     Body Force: 
       Type: FOCosExp2DAll
-      'Glen''s Law A': 1.00000000000000000e+00
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law A: 3.17098e-20    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Response Functions: 
       Number Of Responses: 3
       Response 0:
@@ -104,7 +104,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 9.99990000000000046e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_fo_sincos2D.yaml
+++ b/tests/small/LandIce/FO_MMS/input_fo_sincos2D.yaml
@@ -14,16 +14,16 @@ ANONYMOUS:
     Parameters: 
       Number Of Parameters: 1
       Parameter 0:
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity: 
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999989e-01
-      'Glen''s Law A': 1.00000000000000000e+00
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999989e-01
+      Glen's Law A: 3.17098e-20    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force: 
       Type: FOSinCos2D
-      'Glen''s Law A': 1.00000000000000000e+00
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law A: 3.17098e-20    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Response Functions: 
       Number Of Responses: 3
       Response 0:
@@ -64,7 +64,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_fo_sincos2DT.yaml
+++ b/tests/small/LandIce/FO_MMS/input_fo_sincos2DT.yaml
@@ -14,16 +14,16 @@ ANONYMOUS:
     Parameters: 
       Number Of Parameters: 1
       Parameter 0:
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity: 
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999989e-01
-      'Glen''s Law A': 1.00000000000000000e+00
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999989e-01
+      Glen's Law A: 3.17098e-20    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force: 
       Type: FOSinCos2D
-      'Glen''s Law A': 1.00000000000000000e+00
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law A: 3.17098e-20    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Response Functions: 
       Number Of Responses: 3
       Response 0:
@@ -64,7 +64,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_fo_sinexp_neumann.yaml
+++ b/tests/small/LandIce/FO_MMS/input_fo_sinexp_neumann.yaml
@@ -18,7 +18,7 @@ ANONYMOUS:
     Parameters: 
       Number Of Parameters: 1
       Parameter 0:
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity: 
       Type: Constant
     Body Force: 
@@ -63,7 +63,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_fo_sinexp_neumannT.yaml
+++ b/tests/small/LandIce/FO_MMS/input_fo_sinexp_neumannT.yaml
@@ -18,7 +18,7 @@ ANONYMOUS:
     Parameters: 
       Number Of Parameters: 1
       Parameter 0:
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity: 
       Type: Constant
     Body Force: 
@@ -63,7 +63,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_glf_quad.yaml
+++ b/tests/small/LandIce/FO_MMS/input_glf_quad.yaml
@@ -43,10 +43,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.8e+00
       Clausius-Clapeyron Coefficient: 0.0e+00
     LandIce Viscosity: 
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.0e-01
-      'Glen''s Law A': 1.0e-04
-      'Glen''s Law n': 3.0e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.0e-01
+      Glen's Law A: 3.17098e-24    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.0e+00
       Flow Rate Type: Uniform
     Body Force: 
       Type: FO INTERP SURF GRAD
@@ -125,7 +125,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 1.00000000000000006e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_glf_tri.yaml
+++ b/tests/small/LandIce/FO_MMS/input_glf_tri.yaml
@@ -43,10 +43,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.8e+00
       Clausius-Clapeyron Coefficient: 0.0e+00
     LandIce Viscosity: 
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.0e-01
-      'Glen''s Law A': 1.0e-04
-      'Glen''s Law n': 3.0e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.0e-01
+      Glen's Law A: 3.17098e-24    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.0e+00
       Flow Rate Type: Uniform
     Body Force: 
       Type: FO INTERP SURF GRAD
@@ -125,7 +125,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 1.00000000000000006e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_glf_tri_edge_on_gl.yaml
+++ b/tests/small/LandIce/FO_MMS/input_glf_tri_edge_on_gl.yaml
@@ -43,10 +43,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.8e+00
       Clausius-Clapeyron Coefficient: 0.0e+00
     LandIce Viscosity: 
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.0e-01
-      'Glen''s Law A': 1.0e-04
-      'Glen''s Law n': 3.0e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.0e-01
+      Glen's Law A: 3.17098e-24    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.0e+00
       Flow Rate Type: Uniform
     Body Force: 
       Type: FO INTERP SURF GRAD
@@ -125,7 +125,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 1.00000000000000006e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_glf_tri_nonconst_vel.yaml
+++ b/tests/small/LandIce/FO_MMS/input_glf_tri_nonconst_vel.yaml
@@ -43,10 +43,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.8e+00
       Clausius-Clapeyron Coefficient: 0.0e+00
     LandIce Viscosity: 
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.0e-01
-      'Glen''s Law A': 1.0e-04
-      'Glen''s Law n': 3.0e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.0e-01
+      Glen's Law A: 3.17098e-24    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.0e+00
       Flow Rate Type: Uniform
     Body Force: 
       Type: FO INTERP SURF GRAD
@@ -127,7 +127,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 1.00000000000000006e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_smb_quad.yaml
+++ b/tests/small/LandIce/FO_MMS/input_smb_quad.yaml
@@ -55,10 +55,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.8e+00
       Clausius-Clapeyron Coefficient: 0.0e+00
     LandIce Viscosity: 
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.0e-01
-      'Glen''s Law A': 1.0e-04
-      'Glen''s Law n': 3.0e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.0e-01
+      Glen's Law A: 3.17098e-24    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.0e+00
       Flow Rate Type: Uniform
     Body Force: 
       Type: FO INTERP SURF GRAD
@@ -142,7 +142,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 1.00000000000000006e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_MMS/input_smb_tri.yaml
+++ b/tests/small/LandIce/FO_MMS/input_smb_tri.yaml
@@ -55,10 +55,10 @@ ANONYMOUS:
       Gravity Acceleration: 9.8e+00
       Clausius-Clapeyron Coefficient: 0.0e+00
     LandIce Viscosity: 
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 1.0e-01
-      'Glen''s Law A': 1.0e-04
-      'Glen''s Law n': 3.0e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 1.0e-01
+      Glen's Law A: 3.17098e-24    # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.0e+00
       Flow Rate Type: Uniform
     Body Force: 
       Type: FO INTERP SURF GRAD
@@ -143,7 +143,7 @@ ANONYMOUS:
         Method: Constant
       Stepper: 
         Initial Value: 1.00000000000000006e-01
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_Test/input_fo_circularShelf.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_circularShelf.yaml
@@ -23,12 +23,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 5.69999999999999963e-06
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 1.807458143e-25     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: None
     Response Functions:
@@ -64,7 +64,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_Test/input_fo_circularShelfT.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_circularShelfT.yaml
@@ -23,12 +23,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 5.69999999999999963e-06
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 1.807458143e-25     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: None
     Response Functions:
@@ -64,7 +64,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_Test/input_fo_confinedShelf.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_confinedShelf.yaml
@@ -28,12 +28,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 5.69999999999999963e-06
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 1.807458143e-25     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: None
     Response Functions:
@@ -75,7 +75,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_Test/input_fo_confinedShelfT.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_confinedShelfT.yaml
@@ -28,12 +28,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 5.69999999999999963e-06
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 1.807458143e-25     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: None
     Response Functions:
@@ -75,7 +75,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_Test/input_fo_confinedShelf_depthIntBC.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_confinedShelf_depthIntBC.yaml
@@ -19,12 +19,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 5.69999999999999963e-06
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 1.807458143e-25     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: None
     Response Functions:
@@ -66,7 +66,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_Test/input_fo_confinedShelf_depthIntBCT.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_confinedShelf_depthIntBCT.yaml
@@ -22,12 +22,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 5.69999999999999963e-06
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 1.807458143e-25     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: None
     Response Functions:
@@ -69,7 +69,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_Test/input_fo_dome.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_dome.yaml
@@ -15,12 +15,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.17098e-24     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO Dome
     Response Functions:
@@ -55,7 +55,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_Test/input_fo_domeAnalysis.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_domeAnalysis.yaml
@@ -26,10 +26,10 @@ ANONYMOUS:
         Type: Scalar
         Name: 'NBC on SS basalss for DOF all set basal[2]'
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.17098e-24     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO Dome
     Response Functions:
@@ -51,7 +51,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_Test/input_fo_domeForward.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_domeForward.yaml
@@ -25,10 +25,10 @@ ANONYMOUS:
         Type: Scalar
         Name: 'NBC on SS basalss for DOF all set basal[2]'
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.17098e-24     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO Dome
     Response Functions:
@@ -50,7 +50,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_Test/input_fo_dome_interpSurf.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_dome_interpSurf.yaml
@@ -15,12 +15,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.17098e-24     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
     Body Force:
       Type: FO INTERP SURF GRAD
     Response Functions:
@@ -55,7 +55,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
+++ b/tests/small/LandIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
@@ -52,12 +52,12 @@ ANONYMOUS:
         Upper Bound: 12.0
     LandIce Viscosity:
       Extract Strain Rate Sq: true
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 0.5e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.5e+00
       Continuous Homotopy With Constant Initial Viscosity: true
       Coefficient For Continuous Homotopy: 8.0
-      'Glen''s Law A': 7.56960000000000016e-05
-      'Glen''s Law n': 3.0
+      Glen's Law A: 2.400304414e-24     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.0
       Flow Rate Type: Temperature Based
     LandIce Physical Parameters:
       Conductivity of ice: 2.10000000000000008e+00
@@ -437,7 +437,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 100
         Max Value: 4.00000000000000022e-01

--- a/tests/small/LandIce/FO_Thermo/input_FO_Thermo_dry_bed_test.yaml
+++ b/tests/small/LandIce/FO_Thermo/input_FO_Thermo_dry_bed_test.yaml
@@ -27,15 +27,15 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
       Extract Strain Rate Sq: true
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 0.4e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.4e+00
       Continuous Homotopy With Constant Initial Viscosity: true
       Coefficient For Continuous Homotopy: 8.00000000000000000e+00
-      'Glen''s Law A': 7.56960000000000016e-05
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law A: 2.400304414e-24     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     LandIce Physical Parameters:
       Conductivity of ice: 2.10000000000000008e+00
@@ -150,7 +150,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 100
         Max Value: 4.00000000000000022e-01

--- a/tests/small/LandIce/FO_Thermo/input_FO_Thermo_wet_bed_test.yaml
+++ b/tests/small/LandIce/FO_Thermo/input_FO_Thermo_wet_bed_test.yaml
@@ -30,15 +30,15 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
       Extract Strain Rate Sq: true
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 0.4e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.4e+00
       Continuous Homotopy With Constant Initial Viscosity: true
       Coefficient For Continuous Homotopy: 8.00000000000000000e+00
-      'Glen''s Law A': 7.56960000000000016e-05
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law A: 2.400304414e-24     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     LandIce Physical Parameters:
       Conductivity of ice: 2.10000000000000008e+00
@@ -153,7 +153,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 100
         Max Value: 4.00000000000000022e-01

--- a/tests/small/LandIce/FO_Thermo/input_FO_Thermo_wet_bed_test_FROSch.yaml
+++ b/tests/small/LandIce/FO_Thermo/input_FO_Thermo_wet_bed_test_FROSch.yaml
@@ -29,15 +29,15 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
       Extract Strain Rate Sq: true
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 0.4e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.4e+00
       Continuous Homotopy With Constant Initial Viscosity: true
       Coefficient For Continuous Homotopy: 8.00000000000000000e+00
-      'Glen''s Law A': 7.56960000000000016e-05
-      'Glen''s Law n': 3.00000000000000000e+00
+      Glen's Law A: 2.400304414e-24     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.00000000000000000e+00
       Flow Rate Type: Temperature Based
     LandIce Physical Parameters:
       Conductivity of ice: 2.10000000000000008e+00
@@ -152,7 +152,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 100
         Max Value: 4.00000000000000022e-01

--- a/tests/small/LandIce/Stokes_ISMIP/input_ismip-hom_testA.yaml
+++ b/tests/small/LandIce/Stokes_ISMIP/input_ismip-hom_testA.yaml
@@ -14,10 +14,10 @@ ANONYMOUS:
     Body Force:
       Type: Gravity
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Tau M:
       Delta: 1.00000000000000005e-01
     Initial Condition:
@@ -27,7 +27,7 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     Response Functions:
       Response 4:
         Type: Scalar Response
@@ -72,7 +72,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/Stokes_MMS/input_sincos_glen.yaml
+++ b/tests/small/LandIce/Stokes_MMS/input_sincos_glen.yaml
@@ -16,13 +16,13 @@ ANONYMOUS:
       DBC on NS NodeSet99 for DOF p: 0.00000000000000000e+00
     Body Force:
       Type: SinSinGlen
-      'Glen''s Law A': 1.00000000000000000e+00
-      'Glen''s Law n': 1.00000000000000000e+00
+      Glen's Law A: 3.1709792e-14            # [Pa^-n s^-1]
+      Glen's Law n: 1.00000000000000000e+00
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000000e+00
-      'Glen''s Law n': 1.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-14            # [Pa^-n s^-1]
+      Glen's Law n: 1.00000000000000000e+00
     Tau M:
       Delta: 2.00000000000000000e+00
     Initial Condition:
@@ -32,7 +32,7 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     Response Functions:
       Response 2:
         Equation: 2
@@ -66,7 +66,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00

--- a/tests/small/LandIce/Stokes_Test/input_dome.yaml
+++ b/tests/small/LandIce/Stokes_Test/input_dome.yaml
@@ -17,12 +17,12 @@ ANONYMOUS:
       Number Of Parameters: 1
       Parameter 0:
         Type: Scalar
-        Name: 'Glen''s Law Homotopy Parameter'
+        Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
-      Type: 'Glen''s Law'
-      'Glen''s Law Homotopy Parameter': 2.99999999999999988e-01
-      'Glen''s Law A': 1.00000000000000004e-04
-      'Glen''s Law n': 3.00000000000000000e+00
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 2.99999999999999988e-01
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.00000000000000000e+00
     Tau M:
       Delta: 1.00000000000000005e-01
     Body Force:
@@ -61,7 +61,7 @@ ANONYMOUS:
         Method: Constant
       Stepper:
         Initial Value: 0.00000000000000000e+00
-        Continuation Parameter: 'Glen''s Law Homotopy Parameter'
+        Continuation Parameter: Glen's Law Homotopy Parameter
         Continuation Method: Natural
         Max Steps: 10
         Max Value: 1.00000000000000000e+00


### PR DESCRIPTION
The value of A in the input files for LandIce was in some funky units: `[k^-1 kPa^-n yr^-1]`. The reason was that these units perfectly canceled the ones coming from the fact that our meshes are in km, and our velocities in m/yr.

However, A is also needed in the Subglacial Hydrology problem, and the natural units there are different. In particular, the natural units for A in the hydrology would be `[ kPa^-n s^-1]`.

To keep things easy to understand, after talking with @mperego , we decided to settle for SI units: `[ Pa^-n s^-1]`. All evaluators can convert to whatever is needed in the particular equation to cancel out units and scaling factors.

I modified all input files to use these units, and a handful of evaluators to do the conversion back to what they were expecting before. Also, I modified input files to eliminate double quotes. E.g., I turned `'Glen''s Law A': xyz` into `Glen's Law A: xyz`.