### PR TITLE
Final Sideset Refactor Cleanup

### DIFF
--- a/src/Albany_StateManager.cpp
+++ b/src/Albany_StateManager.cpp
@@ -429,12 +429,10 @@ Albany::StateManager::registerSideSetStateVariable(
     const std::string&                   ebName,
     const bool                           outputToExodus,
     StateStruct::MeshFieldEntity const*  fieldEntity,
-    const std::string&                   meshPartName,
-    const bool                           useCollapsedLayout)
+    const std::string&                   meshPartName)
 
 {
-  if (useCollapsedLayout) {
-    return registerSideSetStateVariable_collapsed(
+  return registerSideSetStateVariable(
         sideSetName,
         stateName,
         fieldName,
@@ -447,25 +445,10 @@ Albany::StateManager::registerSideSetStateVariable(
         "",
         fieldEntity,
         meshPartName);
-  } else {
-    return registerSideSetStateVariable(
-        sideSetName,
-        stateName,
-        fieldName,
-        dl,
-        ebName,
-        "",
-        0.0,
-        false,
-        outputToExodus,
-        "",
-        fieldEntity,
-        meshPartName);
-  }
 }
 
 Teuchos::RCP<Teuchos::ParameterList>
-Albany::StateManager::registerSideSetStateVariable_collapsed(
+Albany::StateManager::registerSideSetStateVariable(
     const std::string&                   sideSetName,
     const std::string&                   stateName,
     const std::string&                   fieldName,
@@ -491,7 +474,6 @@ Albany::StateManager::registerSideSetStateVariable_collapsed(
   p->set<const std::string>("Field Name", fieldName);
   p->set<const std::string>("Side Set Name", sideSetName);
   p->set<const Teuchos::RCP<PHX::DataLayout>>("Field Layout", dl);
-  p->set<const bool>("Use Collapsed Layout", true);
 
   if (sideSetStatesToStore[sideSetName][ebName].find(stateName) !=
       sideSetStatesToStore[sideSetName][ebName].end()) {
@@ -579,174 +561,6 @@ Albany::StateManager::registerSideSetStateVariable_collapsed(
   }
   else {
     dl->dimensions(stateRef.dim);
-  }
-  stateRef.output              = outputToExodus;
-  stateRef.responseIDtoRequire = responseIDtoRequire;
-  stateRef.layered             = (dl->name(dl->rank() - 1) == "LayerDim");
-  TEUCHOS_TEST_FOR_EXCEPTION(
-      stateRef.layered && (dl->extent(dl->rank() - 1) <= 0),
-      std::logic_error,
-      "Error! Invalid number of layers for layered state " << stateName
-                                                           << ".\n");
-
-  // If space is needed for old state
-  if (registerOldState) {
-    stateRef.saveOldState = true;
-
-    std::string stateName_old = stateName + "_old";
-    sis_ptr->push_back(
-        Teuchos::rcp(new Albany::StateStruct(stateName_old, mfe_type)));
-    Albany::StateStruct& pstateRef = *sis_ptr->back();
-    pstateRef.initType             = init_type;
-    pstateRef.initValue            = init_val;
-    pstateRef.pParentStateStruct   = &stateRef;
-
-    pstateRef.output = false;
-    dl->dimensions(pstateRef.dim);
-  }
-
-  // insert
-  stateRef.nameMap[stateName] = ebName;
-
-  return p;
-}
-
-Teuchos::RCP<Teuchos::ParameterList>
-Albany::StateManager::registerSideSetStateVariable(
-    const std::string&                   sideSetName,
-    const std::string&                   stateName,
-    const std::string&                   fieldName,
-    const Teuchos::RCP<PHX::DataLayout>& dl,
-    const std::string&                   ebName,
-    const std::string&                   init_type,
-    const double                         init_val,
-    const bool                           registerOldState,
-    const bool                           outputToExodus,
-    const std::string&                   responseIDtoRequire,
-    StateStruct::MeshFieldEntity const*  fieldEntity,
-    const std::string&                   meshPartName)
-{
-  TEUCHOS_TEST_FOR_EXCEPT(stateVarsAreAllocated);
-  using Albany::StateStruct;
-
-  // Create param list for SaveSideSetStateField evaluator
-  Teuchos::RCP<Teuchos::ParameterList> p =
-      Teuchos::rcp(new Teuchos::ParameterList(
-          "Save Side Set State " + stateName + " to/from Side Set Field " +
-          fieldName));
-  p->set<const std::string>("State Name", stateName);
-  p->set<const std::string>("Field Name", fieldName);
-  p->set<const std::string>("Side Set Name", sideSetName);
-  p->set<const Teuchos::RCP<PHX::DataLayout>>("Field Layout", dl);
-  p->set<bool>("Use Collapsed Layout", false);
-
-  if (sideSetStatesToStore[sideSetName][ebName].find(stateName) !=
-      sideSetStatesToStore[sideSetName][ebName].end()) {
-    return p;  // Don't re-register the same state name
-  }
-
-  sideSetStatesToStore[sideSetName][ebName][stateName] = dl;
-
-  if (sideSetStateInfo.find(sideSetName) == sideSetStateInfo.end()) {
-    // It's the first time we register states on this side set, so we initiate
-    // the pointer
-    // TODO, when compiler allows, replace following with this for performance:
-    sideSetStateInfo.emplace(sideSetName,Teuchos::rcp(new StateInfoStruct()));
-  }
-
-  const Teuchos::RCP<StateInfoStruct>& sis_ptr =
-      sideSetStateInfo.at(sideSetName);
-
-  // Load into StateInfo
-  StateStruct::MeshFieldEntity mfe_type;
-  if (fieldEntity) {
-    mfe_type = *fieldEntity;
-  } else if (dl->rank() >= 1 && dl->name(0) == PHX::print<Node>())  // Nodal data
-  {
-    mfe_type = StateStruct::NodalData;                  // One value per node
-  } else if (dl->rank() == 2 && dl->name(1) == PHX::print<Side>())  // Element data
-  {
-    mfe_type = StateStruct::ElemData;  // One value per element
-  } else if (dl->rank() > 2) {
-    if (dl->name(2) == "Dim")
-      mfe_type = StateStruct::ElemData;   // One vector/tensor per element
-    else if (dl->name(2) == PHX::print<Node>())       // Element node data
-      mfe_type = StateStruct::ElemNode;   // One value per side node
-    else if (dl->name(2) == PHX::print<QuadPoint>())  // Quad point data
-      mfe_type = StateStruct::QuadPoint;  // One value per side quad point
-    else
-      TEUCHOS_TEST_FOR_EXCEPTION(
-          true, std::logic_error, "StateManager: Unknown Entity type.\n");
-  } else {
-    TEUCHOS_TEST_FOR_EXCEPTION(
-        true, std::logic_error, "StateManager: Unknown Entity type.\n");
-  }
-
-  sis_ptr->push_back(Teuchos::rcp(new StateStruct(stateName, mfe_type)));
-  StateStruct& stateRef = *sis_ptr->back();
-  stateRef.setInitType(init_type);
-  stateRef.setInitValue(init_val);
-  stateRef.setMeshPart(meshPartName);
-
-  if (stateRef.entity == StateStruct::NodalData) {
-    TEUCHOS_TEST_FOR_EXCEPTION(
-        dl->name(0) == PHX::print<Node>(),
-        std::logic_error,
-        "Error! NodalData states should have dl <Node,...>.\n");
-
-    dl->dimensions(stateRef.dim);
-
-    // Register the state with the nodalDataVector also.
-    Teuchos::RCP<Adapt::NodalDataBase> nodalDataBase =
-        getSideSetNodalDataBase(sideSetName);
-
-    if (dl->rank() == 1)  // node scalar
-      nodalDataBase->registerVectorState(stateName, 1);
-    else if (dl->rank() == 2)  // node vector
-      nodalDataBase->registerVectorState(stateName, stateRef.dim[1]);
-    else if (dl->rank() == 3)  // node tensor
-      nodalDataBase->registerVectorState(
-          stateName, stateRef.dim[1] * stateRef.dim[2]);
-  } else if (
-      stateRef.entity == StateStruct::NodalDataToElemNode ||
-      stateRef.entity == Albany::StateStruct::NodalDistParameter) {
-    // Strip one dimension out cause it's Side
-    TEUCHOS_TEST_FOR_EXCEPTION(
-        dl->rank() < 2,
-        std::logic_error,
-        "Error! The given layout does not appear to be that of a side set "
-        "field.\n");
-
-    stateRef.dim.resize(dl->rank() - 1);
-    stateRef.dim[0] = dl->extent(0);
-    for (size_t i(1); i < stateRef.dim.size(); ++i)
-      stateRef.dim[i] = dl->extent(i + 1);
-
-    // Register the state with the nodalDataVector also.
-    Teuchos::RCP<Adapt::NodalDataBase> nodalDataBase =
-        getSideSetNodalDataBase(sideSetName);
-
-    // These entities store data as <Cell,Side,Node,...>, so the dl has one more
-    // rank
-    if (dl->rank() == 3)  // node scalar
-      nodalDataBase->registerVectorState(stateName, 1);
-    else if (dl->rank() == 4)  // node vector
-      nodalDataBase->registerVectorState(stateName, stateRef.dim[2]);
-    else if (dl->rank() == 5)  // node tensor
-      nodalDataBase->registerVectorState(
-          stateName, stateRef.dim[2] * stateRef.dim[3]);
-  } else {
-    // Strip one dimension out cause it's Side
-    TEUCHOS_TEST_FOR_EXCEPTION(
-        dl->rank() < 2,
-        std::logic_error,
-        "Error! The given layout does not appear to be that of a side set "
-        "field.\n");
-
-    stateRef.dim.resize(dl->rank() - 1);
-    stateRef.dim[0] = dl->extent(0);
-    for (size_t i(1); i < stateRef.dim.size(); ++i)
-      stateRef.dim[i] = dl->extent(i + 1);
   }
   stateRef.output              = outputToExodus;
   stateRef.responseIDtoRequire = responseIDtoRequire;

--- a/src/Albany_StateManager.cpp
+++ b/src/Albany_StateManager.cpp
@@ -498,7 +498,7 @@ Albany::StateManager::registerSideSetStateVariable(
   } else if (dl->rank() >= 1 && dl->name(0) == PHX::print<Node>())  // Nodal data
   {
     mfe_type = StateStruct::NodalData;                  // One value per node
-  } else if (dl->rank() == 1 && dl->name(1) == PHX::print<Side>())  // Element data
+  } else if (dl->rank() == 1 && dl->name(0) == PHX::print<Side>())  // Element data
   {
     mfe_type = StateStruct::ElemData;  // One value per element
   } else if (dl->rank() > 1) {

--- a/src/Albany_StateManager.hpp
+++ b/src/Albany_StateManager.hpp
@@ -154,22 +154,6 @@ class StateManager
       const std::string&                   ebName,
       const bool                           outputToExodus,
       StateStruct::MeshFieldEntity const*  fieldEntity  = NULL,
-      const std::string&                   meshPartName = "",
-      const bool                           useCollapsedLayout = false);
-
-  Teuchos::RCP<Teuchos::ParameterList>
-  registerSideSetStateVariable_collapsed(
-      const std::string&                   sideSetName,
-      const std::string&                   stateName,
-      const std::string&                   fieldName,
-      const Teuchos::RCP<PHX::DataLayout>& dl,
-      const std::string&                   ebName,
-      const std::string&                   init_type,
-      const double                         init_val,
-      const bool                           registerOldState,
-      const bool                           outputToExodus,
-      const std::string&                   responseIDtoRequire,
-      StateStruct::MeshFieldEntity const*  fieldEntity,
       const std::string&                   meshPartName = "");
 
   Teuchos::RCP<Teuchos::ParameterList>

--- a/src/LandIce/evaluators/LandIce_BasalMeltRate_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalMeltRate_Def.hpp
@@ -20,24 +20,24 @@ namespace LandIce
 template<typename EvalT, typename Traits, typename VelocityST>
 BasalMeltRate<EvalT,Traits,VelocityST>::
 BasalMeltRate(const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>& dl_basal)
- : phi               (p.get<std::string> ("Water Content Side Variable Name"),dl_basal->node_scalar_sideset)
- , beta              (p.get<std::string> ("Basal Friction Coefficient Side Variable Name"),dl_basal->node_scalar_sideset)
- , velocity          (p.get<std::string> ("Velocity Side Variable Name"),dl_basal->node_vector_sideset)
- , geoFluxHeat       (p.get<std::string> ("Geothermal Flux Side Variable Name"),dl_basal->node_scalar_sideset)
- , Enthalpy          (p.get<std::string> ("Enthalpy Side Variable Name"),dl_basal->node_scalar_sideset)
- , EnthalpyHs        (p.get<std::string> ("Enthalpy Hs Side Variable Name"),dl_basal->node_scalar_sideset)
+ : phi               (p.get<std::string> ("Water Content Side Variable Name"),dl_basal->node_scalar)
+ , beta              (p.get<std::string> ("Basal Friction Coefficient Side Variable Name"),dl_basal->node_scalar)
+ , velocity          (p.get<std::string> ("Velocity Side Variable Name"),dl_basal->node_vector)
+ , geoFluxHeat       (p.get<std::string> ("Geothermal Flux Side Variable Name"),dl_basal->node_scalar)
+ , Enthalpy          (p.get<std::string> ("Enthalpy Side Variable Name"),dl_basal->node_scalar)
+ , EnthalpyHs        (p.get<std::string> ("Enthalpy Hs Side Variable Name"),dl_basal->node_scalar)
  , homotopy          (p.get<std::string> ("Continuation Parameter Name"),dl_basal->shared_param)
- , enthalpyBasalFlux     (p.get<std::string> ("Basal Melt Rate Variable Name"), dl_basal->node_scalar_sideset)
- , basalVertVelocity (p.get<std::string> ("Basal Vertical Velocity Variable Name"),dl_basal->node_scalar_sideset)
+ , enthalpyBasalFlux     (p.get<std::string> ("Basal Melt Rate Variable Name"), dl_basal->node_scalar)
+ , basalVertVelocity (p.get<std::string> ("Basal Vertical Velocity Variable Name"),dl_basal->node_scalar)
 {
   nodal = p.isParameter("Nodal") ? p.get<bool>("Nodal") : false;
   Teuchos::RCP<PHX::DataLayout> scalar_layout, vector_layout;
   if (nodal) {
-    scalar_layout = dl_basal->node_scalar_sideset;
-    vector_layout = dl_basal->node_vector_sideset;
+    scalar_layout = dl_basal->node_scalar;
+    vector_layout = dl_basal->node_vector;
   } else {
-    scalar_layout = dl_basal->qp_scalar_sideset;
-    vector_layout = dl_basal->qp_vector_sideset;
+    scalar_layout = dl_basal->qp_scalar;
+    vector_layout = dl_basal->qp_vector;
   }
 
   phi = decltype(phi)(p.get<std::string> ("Water Content Side Variable Name"),scalar_layout);
@@ -63,9 +63,9 @@ BasalMeltRate(const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layout
 
   std::vector<PHX::DataLayout::size_type> dims;
   dl_basal->node_qp_gradient->dimensions(dims);
-  numSideNodes = dims[2];
-  numSideQPs   = dims[3];
-  sideDim      = dims[4];
+  numSideNodes = dims[1];
+  numSideQPs   = dims[2];
+  sideDim      = dims[3];
   numCellNodes = basalVertVelocity.fieldTag().dataLayout().extent(1);
 
   basalSideName = p.get<std::string> ("Side Set Name");

--- a/src/LandIce/evaluators/LandIce_DOFDivInterpolationSide.hpp
+++ b/src/LandIce/evaluators/LandIce_DOFDivInterpolationSide.hpp
@@ -40,12 +40,11 @@ private:
   std::string sideSetName;
 
   // Input:
-  // TODO: restore layout template arguments when removing old sideset layout
   //! Values at nodes
-  PHX::MDField<const ScalarT> val_node;      // Side, Node, Dim
+  PHX::MDField<const ScalarT,Side,Node,Dim> val_node;
   //! Basis Functions and side tangents
-  PHX::MDField<const MeshScalarT> gradBF;    // Side, Node, QuadPoint, Dim
-  PHX::MDField<const MeshScalarT>  tangents; // Side, QuadPoint, Dim, Dim
+  PHX::MDField<const MeshScalarT,Side,Node,QuadPoint,Dim> gradBF;
+  PHX::MDField<const MeshScalarT,Side,QuadPoint,Dim,Dim>  tangents;
 
   // Output:
   //! Values at quadrature points

--- a/src/LandIce/evaluators/LandIce_DOFDivInterpolationSide_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_DOFDivInterpolationSide_Def.hpp
@@ -17,10 +17,10 @@ DOFDivInterpolationSideBase<EvalT, Traits, ScalarT>::
 DOFDivInterpolationSideBase(const Teuchos::ParameterList& p,
                             const Teuchos::RCP<Albany::Layouts>& dl_side) :
   sideSetName (p.get<std::string> ("Side Set Name")),
-  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_vector_sideset),
-  gradBF      (p.get<std::string> ("Gradient BF Name"), dl_side->node_qp_gradient_sideset),
-  tangents    (p.get<std::string> ("Tangents Name"), dl_side->qp_tensor_cd_sd_sideset),
-  val_qp      (p.get<std::string> ("Divergence Variable Name"), dl_side->qp_scalar_sideset)
+  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_vector),
+  gradBF      (p.get<std::string> ("Gradient BF Name"), dl_side->node_qp_gradient),
+  tangents    (p.get<std::string> ("Tangents Name"), dl_side->qp_tensor_cd_sd),
+  val_qp      (p.get<std::string> ("Divergence Variable Name"), dl_side->qp_scalar)
 {
   this->addDependentField(val_node);
   this->addDependentField(gradBF);
@@ -29,9 +29,9 @@ DOFDivInterpolationSideBase(const Teuchos::ParameterList& p,
 
   this->setName("DOFDivInterpolationSideBase" );
 
-  numSideNodes = dl_side->node_qp_gradient->extent(2);
-  numSideQPs   = dl_side->node_qp_gradient->extent(3);
-  numDims      = dl_side->node_qp_vector->extent(4);
+  numSideNodes = dl_side->node_qp_gradient->extent(1);
+  numSideQPs   = dl_side->node_qp_gradient->extent(2);
+  numDims      = dl_side->node_qp_vector->extent(3);
 }
 
 //**********************************************************************

--- a/src/LandIce/evaluators/LandIce_EnthalpyBasalResid_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_EnthalpyBasalResid_Def.hpp
@@ -30,9 +30,9 @@ EnthalpyBasalResid(const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::L
 
   Teuchos::RCP<Albany::Layouts> dl_basal = dl->side_layouts.at(basalSideName);
 
-  BF         = decltype(BF)(p.get<std::string> ("BF Side Name"), dl_basal->node_qp_scalar_sideset);
-  w_measure  = decltype(w_measure)(p.get<std::string> ("Weighted Measure Side Name"), dl_basal->qp_scalar_sideset);
-  basalMeltRateQP = decltype(basalMeltRateQP)(p.get<std::string> ("Basal Melt Rate Side QP Variable Name"), dl_basal->qp_scalar_sideset);
+  BF         = decltype(BF)(p.get<std::string> ("BF Side Name"), dl_basal->node_qp_scalar);
+  w_measure  = decltype(w_measure)(p.get<std::string> ("Weighted Measure Side Name"), dl_basal->qp_scalar);
+  basalMeltRateQP = decltype(basalMeltRateQP)(p.get<std::string> ("Basal Melt Rate Side QP Variable Name"), dl_basal->qp_scalar);
 
   this->addDependentField(BF);
   this->addDependentField(w_measure);
@@ -42,9 +42,8 @@ EnthalpyBasalResid(const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::L
 
   std::vector<PHX::DataLayout::size_type> dims;
   dl_basal->node_qp_gradient->dimensions(dims);
-  unsigned int numSides = dims[1];
-  numSideNodes = dims[2];
-  numSideQPs   = dims[3];
+  numSideNodes = dims[1];
+  numSideQPs   = dims[2];
   numCellNodes = enthalpyBasalResid.fieldTag().dataLayout().extent(1);
 
   dl->node_vector->dimensions(dims);
@@ -52,6 +51,7 @@ EnthalpyBasalResid(const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::L
 
   Teuchos::RCP<shards::CellTopology> cellType;
   cellType = p.get<Teuchos::RCP <shards::CellTopology> > ("Cell Type");
+  unsigned int numSides = cellType->getSideCount();
   sideDim      = cellType->getDimension()-1;
   unsigned int nodeMax = 0;
   for (unsigned int side=0; side<numSides; ++side) {

--- a/src/LandIce/evaluators/LandIce_FluxDiv.hpp
+++ b/src/LandIce/evaluators/LandIce_FluxDiv.hpp
@@ -50,16 +50,15 @@ private:
   using GradThicknessScalarT = typename Albany::StrongestScalarType<ThicknessScalarT,MeshScalarT>::type;
 
   // Input:
-  // TODO: restore layout template arguments when removing old sideset layout
-  PHX::MDField<const ScalarT>               field;
-  PHX::MDField<const ScalarT>               averaged_velocity;     // Side, QuadPoint, VecDim
-  PHX::MDField<const ScalarT>               div_averaged_velocity; // Side, QuadPoint
-  PHX::MDField<const ThicknessScalarT>      thickness;             // Side, QuadPoint
-  PHX::MDField<const GradThicknessScalarT>  grad_thickness;        // Side, QuadPoint, Dim
-  PHX::MDField<const MeshScalarT>           side_tangents;         // Side, QuadPoint, Dim, Dim
+  PHX::MDField<const ScalarT>                                 field;
+  PHX::MDField<const ScalarT,Side,QuadPoint,VecDim>           averaged_velocity;
+  PHX::MDField<const ScalarT,Side,QuadPoint>                  div_averaged_velocity;
+  PHX::MDField<const ThicknessScalarT,Side,QuadPoint>         thickness;
+  PHX::MDField<const GradThicknessScalarT,Side,QuadPoint,Dim> grad_thickness;
+  PHX::MDField<const MeshScalarT,Side,QuadPoint,Dim,Dim>      side_tangents;
 
   // Output:
-  PHX::MDField<ScalarT>                flux_div;              // Side, QuadPoint
+  PHX::MDField<ScalarT,Side,QuadPoint>                        flux_div;
 
   std::string sideSetName;
   unsigned int numSideQPs, numSideDims;

--- a/src/LandIce/evaluators/LandIce_FluxDiv_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_FluxDiv_Def.hpp
@@ -25,19 +25,19 @@ FluxDiv (const Teuchos::ParameterList& p,
   const std::string& grad_thickness_name        = p.get<std::string>("Thickness Gradient Name");
   const std::string& side_tangents_name         = p.get<std::string>("Side Tangents Name");
 
-  averaged_velocity     = decltype(averaged_velocity)(averaged_velocity_name, dl_basal->qp_vector_sideset);
-  div_averaged_velocity = decltype(div_averaged_velocity)(div_averaged_velocity_name, dl_basal->qp_scalar_sideset);
-  thickness             = decltype(thickness)(thickness_name, dl_basal->qp_scalar_sideset);
-  grad_thickness        = decltype(grad_thickness)(grad_thickness_name, dl_basal->qp_gradient_sideset);
-  side_tangents         = decltype(side_tangents)(side_tangents_name, dl_basal->qp_tensor_cd_sd_sideset);
+  averaged_velocity     = decltype(averaged_velocity)(averaged_velocity_name, dl_basal->qp_vector);
+  div_averaged_velocity = decltype(div_averaged_velocity)(div_averaged_velocity_name, dl_basal->qp_scalar);
+  thickness             = decltype(thickness)(thickness_name, dl_basal->qp_scalar);
+  grad_thickness        = decltype(grad_thickness)(grad_thickness_name, dl_basal->qp_gradient);
+  side_tangents         = decltype(side_tangents)(side_tangents_name, dl_basal->qp_tensor_cd_sd);
 
-  flux_div              = decltype(flux_div)(fieldName, dl_basal->qp_scalar_sideset);
+  flux_div              = decltype(flux_div)(fieldName, dl_basal->qp_scalar);
 
   // Get Dimensions
   std::vector<PHX::DataLayout::size_type> dims;
   dl_basal->qp_vector->dimensions(dims);
-  numSideQPs = dims[2];
-  numSideDims  = dims[3];
+  numSideQPs = dims[1];
+  numSideDims  = dims[2];
 
   sideSetName = p.get<std::string> ("Side Set Name");
 

--- a/src/LandIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
@@ -54,9 +54,9 @@ GatherVerticallyContractedSolutionBase(const Teuchos::ParameterList& p,
   Teuchos::RCP<Albany::Layouts> dl_side = dl->side_layouts.at(sideSetName);
 
   if(isVector)
-    contractedSol = decltype(contractedSol)(p.get<std::string>("Contracted Solution Name"), dl_side->node_vector_sideset);
+    contractedSol = decltype(contractedSol)(p.get<std::string>("Contracted Solution Name"), dl_side->node_vector);
   else
-    contractedSol = decltype(contractedSol)(p.get<std::string>("Contracted Solution Name"), dl_side->node_scalar_sideset);
+    contractedSol = decltype(contractedSol)(p.get<std::string>("Contracted Solution Name"), dl_side->node_scalar);
 
   this->addEvaluatedField(contractedSol);
 

--- a/src/LandIce/evaluators/LandIce_IceOverburden_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_IceOverburden_Def.hpp
@@ -27,9 +27,9 @@ IceOverburden (const Teuchos::ParameterList& p,
 
   Teuchos::RCP<PHX::DataLayout> layout;
   if (p.isParameter("Nodal") && p.get<bool>("Nodal")) {
-    layout = eval_on_side ? dl->node_scalar_sideset : dl->node_scalar;
+    layout = dl->node_scalar;
   } else {
-    layout = eval_on_side ? dl->qp_scalar_sideset : dl->qp_scalar;
+    layout = dl->qp_scalar;
   }
 
   numPts = layout->extent(1);

--- a/src/LandIce/evaluators/LandIce_L2ProjectedBoundaryLaplacianResidual.hpp
+++ b/src/LandIce/evaluators/LandIce_L2ProjectedBoundaryLaplacianResidual.hpp
@@ -45,14 +45,13 @@ private:
 
   Albany::LocalSideSetInfo sideSet;
 
-  // TODO: restore layout template arguments when removing old sideset layout
-  PHX::MDField<const ScalarT,Cell,Node> solution;
-  PHX::MDField<const FieldScalarT>      field;           // Side, Node
-  PHX::MDField<const FieldScalarT>      gradField;       // Side, QuadPoint, Dim
-  PHX::MDField<const MeshScalarT>       gradBF;          // Side, Node, QuadPoint, Dim
-  PHX::MDField<const MeshScalarT>       w_side_measure;  // Side, QuadPoint
-  PHX::MDField<const MeshScalarT>       side_tangents;   // Side, QuadPoint, Dim, Dim
-  PHX::MDField<const MeshScalarT>       coordVec;
+  PHX::MDField<const ScalarT,Cell,Node>                   solution;
+  PHX::MDField<const FieldScalarT,Side,Node>              field;
+  PHX::MDField<const FieldScalarT,Side,QuadPoint,Dim>     gradField;
+  PHX::MDField<const MeshScalarT,Side,Node,QuadPoint,Dim> gradBF;
+  PHX::MDField<const MeshScalarT,Side,QuadPoint>          w_side_measure;
+  PHX::MDField<const MeshScalarT,Side,QuadPoint,Dim,Dim>  side_tangents;
+  PHX::MDField<const MeshScalarT>                         coordVec;
 
   PHX::MDField<ScalarT,Cell,Node> bdLaplacian_L2Projection_res;
 

--- a/src/LandIce/evaluators/LandIce_L2ProjectedBoundaryLaplacianResidual_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_L2ProjectedBoundaryLaplacianResidual_Def.hpp
@@ -44,11 +44,11 @@ L2ProjectedBoundaryLaplacianResidualBase(Teuchos::ParameterList& p, const Teucho
   const std::string& coords_name         = p.get<std::string>("Coordinate Vector Variable Name");
 
   solution           = decltype(solution)(solution_name, dl->node_scalar);
-  field              = decltype(field)(field_name, dl_side->node_scalar_sideset);
-  gradField          = decltype(gradField)(gradField_name, dl_side->qp_gradient_sideset);
-  gradBF             = decltype(gradBF)(gradBFname, dl_side->node_qp_gradient_sideset),
-  w_side_measure     = decltype(w_side_measure)(w_side_measure_name, dl_side->qp_scalar_sideset);
-  side_tangents      = decltype(side_tangents)(side_tangents_name, dl_side->qp_tensor_cd_sd_sideset);
+  field              = decltype(field)(field_name, dl_side->node_scalar);
+  gradField          = decltype(gradField)(gradField_name, dl_side->qp_gradient);
+  gradBF             = decltype(gradBF)(gradBFname, dl_side->node_qp_gradient),
+  w_side_measure     = decltype(w_side_measure)(w_side_measure_name, dl_side->qp_scalar);
+  side_tangents      = decltype(side_tangents)(side_tangents_name, dl_side->qp_tensor_cd_sd);
   bdLaplacian_L2Projection_res = decltype(bdLaplacian_L2Projection_res)(residual_name, dl->node_scalar);
   coordVec = decltype(coordVec)(coords_name, dl->vertices_vector);
 
@@ -57,9 +57,9 @@ L2ProjectedBoundaryLaplacianResidualBase(Teuchos::ParameterList& p, const Teucho
   // Get Dimensions
   numNodes  = dl->node_scalar->extent(1);
 
-  numSideNodes  = dl_side->node_scalar->extent(2);
-  numBasalQPs = dl_side->qp_scalar->extent(2);
-  unsigned int numSides = dl_side->node_scalar->extent(1);
+  numSideNodes  = dl_side->node_scalar->extent(1);
+  numBasalQPs = dl_side->qp_scalar->extent(1);
+  unsigned int numSides = cellType->getSideCount();
   sideDim  = cellType->getDimension()-1;
 
   this->addDependentField(solution);

--- a/src/LandIce/evaluators/LandIce_LaplacianRegularizationResidual_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_LaplacianRegularizationResidual_Def.hpp
@@ -42,7 +42,7 @@ LaplacianRegularizationResidual(Teuchos::ParameterList& p, const Teuchos::RCP<Al
   gradBF         = decltype(gradBF)(gradBFname,dl->node_qp_gradient),
   w_measure      = decltype(w_measure)(w_measure_name, dl->qp_scalar);
   residual       = decltype(residual)(residual_name, dl->node_scalar);
-  w_side_measure = decltype(w_side_measure)(w_side_measure_name, dl_side->qp_scalar_sideset);
+  w_side_measure = decltype(w_side_measure)(w_side_measure_name, dl_side->qp_scalar);
 
   Teuchos::RCP<shards::CellTopology> cellType;
   cellType = p.get<Teuchos::RCP <shards::CellTopology> > ("Cell Type");
@@ -54,11 +54,11 @@ LaplacianRegularizationResidual(Teuchos::ParameterList& p, const Teuchos::RCP<Al
   numQPs = dl->qp_scalar->extent(1);
   cellDim  = cellType->getDimension();
 
-  numSideNodes  = dl_side->node_scalar->extent(2);
-  numSideQPs = dl_side->qp_scalar->extent(2);
+  numSideNodes  = dl_side->node_scalar->extent(1);
+  numSideQPs = dl_side->qp_scalar->extent(1);
 
 
-  unsigned int numSides = dl_side->node_scalar->extent(1);
+  unsigned int numSides = cellType->getSideCount();
   sideDim  = cellType->getDimension()-1;
 
   this->addDependentField(forcing);

--- a/src/LandIce/evaluators/LandIce_ResponseBoundarySquaredL2Norm.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseBoundarySquaredL2Norm.hpp
@@ -44,7 +44,6 @@ namespace LandIce {
     unsigned int numSideDims;
 
     Albany::LocalSideSetInfo sideSet;
-    bool useCollapsedSidesets;
 
     // TODO: restore layout template arguments when removing old sideset layout
     PHX::MDField<const ScalarT>          solution;        // Side, Node

--- a/src/LandIce/evaluators/LandIce_ResponseBoundarySquaredL2Norm.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseBoundarySquaredL2Norm.hpp
@@ -45,9 +45,8 @@ namespace LandIce {
 
     Albany::LocalSideSetInfo sideSet;
 
-    // TODO: restore layout template arguments when removing old sideset layout
-    PHX::MDField<const ScalarT>          solution;        // Side, Node
-    PHX::MDField<const MeshScalarT>      w_side_measure;  // Side, QuadPoint
+    PHX::MDField<const ScalarT,Side,Node>          solution;
+    PHX::MDField<const MeshScalarT,Side,QuadPoint> w_side_measure;
 
     ScalarT p_reg, reg;
     double scaling;

--- a/src/LandIce/evaluators/LandIce_ResponseGLFlux.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseGLFlux.hpp
@@ -48,11 +48,10 @@ private:
 
   using xyST = typename Albany::StrongestScalarType<MeshScalarT,ThicknessST>::type;
 
-  // TODO: restore layout template arguments when removing old sideset layout
-  PHX::MDField<const ScalarT>              avg_vel;     //[m yr^{-1}]; Side, Node, Dim
-  PHX::MDField<const ThicknessST>          thickness;   //[km]; Side, Node
-  PHX::MDField<const ThicknessST>          bed;         //[km]; Side, Node
-  PHX::MDField<const MeshScalarT>          coords;      //[km]; Side, Node, Dim
+  PHX::MDField<const ScalarT,Side,Node,Dim>         avg_vel;     //[m yr^{-1}]
+  PHX::MDField<const ThicknessST,Side,Node>         thickness;   //[km]
+  PHX::MDField<const ThicknessST,Side,Node>         bed;         //[km]
+  PHX::MDField<const MeshScalarT,Side,Node,Dim>     coords;      //[km]
 
   Kokkos::DynRankView<ThicknessST, PHX::Device>     gl_func,H;
   Kokkos::DynRankView<xyST, PHX::Device>            x,y;

--- a/src/LandIce/evaluators/LandIce_ResponseGLFlux.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseGLFlux.hpp
@@ -46,8 +46,6 @@ private:
   unsigned int numSideNodes;
   unsigned int numSideDims;
 
-  bool useCollapsedSidesets;
-
   using xyST = typename Albany::StrongestScalarType<MeshScalarT,ThicknessST>::type;
 
   // TODO: restore layout template arguments when removing old sideset layout

--- a/src/LandIce/evaluators/LandIce_ResponseGLFlux_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseGLFlux_Def.hpp
@@ -67,7 +67,7 @@ ResponseGLFlux(Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>& d
   p.set("Stand-alone Evaluator", false);
   std::string local_response_name = "Local Response GL Flux";
   std::string global_response_name = "Global Response GL Flux";
-  int worksetSize = dl_basal->node_scalar->extent(0);
+  int worksetSize = dl->node_scalar->extent(0);
   int responseSize = 1;
   auto local_response_layout = Teuchos::rcp(new MDALayout<Cell, Dim>(worksetSize, responseSize));
   auto global_response_layout = Teuchos::rcp(new MDALayout<Dim>(responseSize));

--- a/src/LandIce/evaluators/LandIce_ResponseSMBMismatch.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseSMBMismatch.hpp
@@ -51,16 +51,15 @@ namespace LandIce {
     unsigned int numBasalQPs;
     unsigned int numSideDims;
 
-    // TODO: restore layout template arguments when removing old sideset layout
-    PHX::MDField<const ScalarT>                   flux_div;        // Side, QuadPoint
-    PHX::MDField<const RealType>                  SMB;             // Side, QuadPoint
-    PHX::MDField<const RealType>                  SMBRMS;          // Side, QuadPoint
-    PHX::MDField<const RealType>                  obs_thickness;   // Side, QuadPoint
-    PHX::MDField<const RealType>                  thicknessRMS;    // Side, QuadPoint
-    PHX::MDField<const ThicknessScalarType>       thickness;       // Side, QuadPoint
-    PHX::MDField<const GradThicknessScalarType>   grad_thickness;  // Side, QuadPoint, Dim
-    PHX::MDField<const MeshScalarT>               w_measure_2d;    // Side, QuadPoint
-    PHX::MDField<const MeshScalarT>               tangents;        // Side, QuadPoint, Dim, Dim
+    PHX::MDField<const ScalarT,Side,QuadPoint>                     flux_div;
+    PHX::MDField<const RealType,Side,QuadPoint>                    SMB;
+    PHX::MDField<const RealType,Side,QuadPoint>                    SMBRMS;
+    PHX::MDField<const RealType,Side,QuadPoint>                    obs_thickness;
+    PHX::MDField<const RealType,Side,QuadPoint>                    thicknessRMS;
+    PHX::MDField<const ThicknessScalarType,Side,QuadPoint>         thickness;
+    PHX::MDField<const GradThicknessScalarType,Side,QuadPoint,Dim> grad_thickness;
+    PHX::MDField<const MeshScalarT,Side,QuadPoint>                 w_measure_2d;
+    PHX::MDField<const MeshScalarT,Side,QuadPoint,Dim,Dim>         tangents;
 
     ScalarT p_resp, p_reg, resp, reg, p_misH, misH;
     double scaling, alpha, alphaH, alphaSMB;

--- a/src/LandIce/evaluators/LandIce_ResponseSMBMismatch.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseSMBMismatch.hpp
@@ -46,7 +46,6 @@ namespace LandIce {
     std::string basalSideName;
 
     Albany::LocalSideSetInfo sideSet;
-    bool useCollapsedSidesets;
 
     unsigned int numSideNodes;
     unsigned int numBasalQPs;

--- a/src/LandIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
@@ -81,7 +81,7 @@ ResponseSMBMismatch(Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layout
   p.set("Stand-alone Evaluator", false);
   std::string local_response_name = "Local Response SMB Mismatch";
   std::string global_response_name = "Global SMB Mismatch";
-  int worksetSize = dl_basal->qp_scalar->extent(0);
+  int worksetSize = dl->qp_scalar->extent(0);
   int responseSize = 1;
   auto local_response_layout = Teuchos::rcp(new MDALayout<Cell, Dim>(worksetSize, responseSize));
   auto global_response_layout = Teuchos::rcp(new MDALayout<Dim>(responseSize));

--- a/src/LandIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
@@ -43,26 +43,24 @@ ResponseSMBMismatch(Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layout
 
   Teuchos::RCP<Albany::Layouts> dl_basal = dl->side_layouts.at(basalSideName);
 
-  useCollapsedSidesets = dl_basal->useCollapsedSidesets;
-
-  flux_div       = decltype(flux_div)(flux_div_name, useCollapsedSidesets ? dl_basal->qp_scalar_sideset : dl_basal->qp_scalar);
-  SMB            = decltype(SMB)(smb_name, useCollapsedSidesets ? dl_basal->qp_scalar_sideset : dl_basal->qp_scalar);
-  SMBRMS         = decltype(SMBRMS)(smbRMS_name, useCollapsedSidesets ? dl_basal->qp_scalar_sideset : dl_basal->qp_scalar);
-  thickness      = decltype(thickness)(thickness_name, useCollapsedSidesets ? dl_basal->qp_scalar_sideset : dl_basal->qp_scalar);
-  grad_thickness = decltype(grad_thickness)(grad_thickness_name, useCollapsedSidesets ? dl_basal->qp_gradient_sideset : dl_basal->qp_gradient);
-  obs_thickness  = decltype(obs_thickness)(obs_thickness_name, useCollapsedSidesets ? dl_basal->qp_scalar_sideset : dl_basal->qp_scalar);
-  thicknessRMS   = decltype(thicknessRMS)(thicknessRMS_name, useCollapsedSidesets ? dl_basal->qp_scalar_sideset : dl_basal->qp_scalar);
-  w_measure_2d   = decltype(w_measure_2d)(w_measure_2d_name, useCollapsedSidesets ? dl_basal->qp_scalar_sideset : dl_basal->qp_scalar);
-  tangents       = decltype(tangents)(tangents_name, useCollapsedSidesets ? dl_basal->qp_tensor_cd_sd_sideset : dl_basal->qp_tensor_cd_sd);
+  flux_div       = decltype(flux_div)(flux_div_name, dl_basal->qp_scalar);
+  SMB            = decltype(SMB)(smb_name, dl_basal->qp_scalar);
+  SMBRMS         = decltype(SMBRMS)(smbRMS_name, dl_basal->qp_scalar);
+  thickness      = decltype(thickness)(thickness_name, dl_basal->qp_scalar);
+  grad_thickness = decltype(grad_thickness)(grad_thickness_name, dl_basal->qp_gradient);
+  obs_thickness  = decltype(obs_thickness)(obs_thickness_name, dl_basal->qp_scalar);
+  thicknessRMS   = decltype(thicknessRMS)(thicknessRMS_name, dl_basal->qp_scalar);
+  w_measure_2d   = decltype(w_measure_2d)(w_measure_2d_name, dl_basal->qp_scalar);
+  tangents       = decltype(tangents)(tangents_name, dl_basal->qp_tensor_cd_sd);
 
   cell_topo = paramList->get<Teuchos::RCP<const CellTopologyData> >("Cell Topology");
   Teuchos::RCP<const Teuchos::ParameterList> reflist = this->getValidResponseParameters();
   plist->validateParameters(*reflist, 0);
 
   // Get Dimensions
-  numSideNodes = dl_basal->node_scalar->extent(2);
-  numSideDims  = dl_basal->qp_gradient->extent(3);
-  numBasalQPs  = dl_basal->qp_scalar->extent(2);
+  numSideNodes = dl_basal->node_scalar->extent(1);
+  numSideDims  = dl_basal->qp_gradient->extent(2);
+  numBasalQPs  = dl_basal->qp_scalar->extent(1);
 
   // add dependent fields
   this->addDependentField(flux_div);
@@ -136,99 +134,49 @@ void LandIce::ResponseSMBMismatch<EvalT, Traits, ThicknessScalarType>::evaluateF
   if (workset.sideSets->find(basalSideName) != workset.sideSets->end())
   {
     sideSet = workset.sideSetViews->at(basalSideName);
-    if (useCollapsedSidesets) {
+    for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+    {
+      // Get the local data of cell
+      const int cell = sideSet.elem_LID(sideSet_idx);
+
+      ScalarT t = 0;
+      for (unsigned int qp=0; qp<numBasalQPs; ++qp) {
+        ScalarT val = (flux_div(sideSet_idx,qp)-SMB(sideSet_idx,qp))/SMBRMS(sideSet_idx,qp);
+        t += val*val*w_measure_2d(sideSet_idx,qp);
+      }
+
+      this->local_response_eval(cell, 0) += t*scaling*alphaSMB;
+      this->global_response_eval(0) += t*scaling*alphaSMB;
+      p_resp += t*scaling*alphaSMB;
+    }
+
+    // --------------- Regularization term  ----------------- //
+    if (alpha!=0 || alphaH !=0)
+    {
       for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
       {
         // Get the local data of cell
         const int cell = sideSet.elem_LID(sideSet_idx);
-
-        ScalarT t = 0;
-        for (unsigned int qp=0; qp<numBasalQPs; ++qp) {
-          ScalarT val = (flux_div(sideSet_idx,qp)-SMB(sideSet_idx,qp))/SMBRMS(sideSet_idx,qp);
-          t += val*val*w_measure_2d(sideSet_idx,qp);
-        }
-
-        this->local_response_eval(cell, 0) += t*scaling*alphaSMB;
-        this->global_response_eval(0) += t*scaling*alphaSMB;
-        p_resp += t*scaling*alphaSMB;
-      }
-
-      // --------------- Regularization term  ----------------- //
-      if (alpha!=0 || alphaH !=0)
-      {
-        for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+        ScalarT tr = 0, tH =0;
+        for (unsigned int qp=0; qp<numBasalQPs; ++qp)
         {
-          // Get the local data of cell
-          const int cell = sideSet.elem_LID(sideSet_idx);
-          ScalarT tr = 0, tH =0;
-          for (unsigned int qp=0; qp<numBasalQPs; ++qp)
-          {
-            ScalarT sum=0;
-            ScalarT grad_thickness_tmp[2] = {0.0, 0.0};
-            for (unsigned int idim=0; idim<2; ++idim)
-              for (unsigned int itan=0; itan<2; ++itan)
-                grad_thickness_tmp[idim] += tangents(sideSet_idx,qp,idim,itan) * grad_thickness(sideSet_idx,qp,itan);
+          ScalarT sum=0;
+          ScalarT grad_thickness_tmp[2] = {0.0, 0.0};
+          for (unsigned int idim=0; idim<2; ++idim)
+            for (unsigned int itan=0; itan<2; ++itan)
+              grad_thickness_tmp[idim] += tangents(sideSet_idx,qp,idim,itan) * grad_thickness(sideSet_idx,qp,itan);
 
-            for (unsigned int idim=0; idim<2; ++idim)
-              sum += grad_thickness_tmp[idim] * grad_thickness_tmp[idim];
-            tr += sum * w_measure_2d(sideSet_idx,qp);
-            ScalarT val = (obs_thickness(sideSet_idx,qp)-thickness(sideSet_idx,qp))/thicknessRMS(sideSet_idx,qp); 
-            tH += val*val*w_measure_2d(sideSet_idx,qp);
-          }
-
-          this->local_response_eval(cell, 0) += (tr*alpha + tH*alphaH)*scaling;//*50.0;
-          this->global_response_eval(0) += (tr*alpha + tH*alphaH)*scaling;//*50.0;
-          p_reg += tr*scaling*alpha;
-          p_misH += tH*scaling*alphaH;
-        }
-      }
-    } else {
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the local data of side and cell
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
-
-        ScalarT t = 0;
-        for (unsigned int qp=0; qp<numBasalQPs; ++qp) {
-          ScalarT val = (flux_div(cell,side,qp)-SMB(cell,side,qp))/SMBRMS(cell,side,qp);
-          t += val*val*w_measure_2d(cell,side,qp);
+          for (unsigned int idim=0; idim<2; ++idim)
+            sum += grad_thickness_tmp[idim] * grad_thickness_tmp[idim];
+          tr += sum * w_measure_2d(sideSet_idx,qp);
+          ScalarT val = (obs_thickness(sideSet_idx,qp)-thickness(sideSet_idx,qp))/thicknessRMS(sideSet_idx,qp); 
+          tH += val*val*w_measure_2d(sideSet_idx,qp);
         }
 
-        this->local_response_eval(cell, 0) += t*scaling*alphaSMB;
-        this->global_response_eval(0) += t*scaling*alphaSMB;
-        p_resp += t*scaling*alphaSMB;
-      }
-
-      // --------------- Regularization term  ----------------- //
-      if (alpha!=0 || alphaH !=0)
-      {
-        for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-        {
-          // Get the local data of side and cell
-          const int cell = sideSet.elem_LID(sideSet_idx);
-          const int side = sideSet.side_local_id(sideSet_idx);
-          ScalarT tr = 0, tH =0;
-          for (unsigned int qp=0; qp<numBasalQPs; ++qp)
-          {
-            ScalarT sum=0;
-            ScalarT grad_thickness_tmp[2] = {0.0, 0.0};
-            for (unsigned int idim=0; idim<2; ++idim)
-              for (unsigned int itan=0; itan<2; ++itan)
-                grad_thickness_tmp[idim] += tangents(cell,side,qp,idim,itan) * grad_thickness(cell,side,qp,itan);
-
-            for (unsigned int idim=0; idim<2; ++idim)
-              sum += grad_thickness_tmp[idim] * grad_thickness_tmp[idim];
-            tr += sum * w_measure_2d(cell,side,qp);
-            ScalarT val = (obs_thickness(cell,side,qp)-thickness(cell,side,qp))/thicknessRMS(cell,side,qp); 
-            tH += val*val*w_measure_2d(cell,side,qp);
-          }
-
-          this->local_response_eval(cell, 0) += (tr*alpha + tH*alphaH)*scaling;//*50.0;
-          this->global_response_eval(0) += (tr*alpha + tH*alphaH)*scaling;//*50.0;
-          p_reg += tr*scaling*alpha;
-          p_misH += tH*scaling*alphaH;
-        }
+        this->local_response_eval(cell, 0) += (tr*alpha + tH*alphaH)*scaling;//*50.0;
+        this->global_response_eval(0) += (tr*alpha + tH*alphaH)*scaling;//*50.0;
+        p_reg += tr*scaling*alpha;
+        p_misH += tH*scaling*alphaH;
       }
     }
   }

--- a/src/LandIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch.hpp
@@ -36,8 +36,7 @@ namespace LandIce {
   private:
     Teuchos::RCP<const Teuchos::ParameterList> getValidResponseParameters() const;
 
-    std::string surfaceSideName;
-    bool useCollapsedSidesets;    
+    std::string surfaceSideName;    
     Albany::LocalSideSetInfo sideSet;
 
     unsigned int numSideNodes;

--- a/src/LandIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch.hpp
@@ -44,32 +44,31 @@ namespace LandIce {
     unsigned int numSurfaceQPs;
     unsigned int numSideDims;
 
-    // TODO: restore layout template arguments when removing old sideset layout
-    PHX::MDField<const ScalarT>      velocity;                     // Side, QuadPoint, VecDim
-    PHX::MDField<const RealType>     observedVelocity;             // Side, QuadPoint, VecDim
-    PHX::MDField<const RealType>     observedVelocityRMS;          // Side, QuadPoint, VecDim
-    PHX::MDField<const RealType>     observedVelocityMagnitudeRMS; // Side, QuadPoint
-    PHX::MDField<const MeshScalarT>  w_measure_surface;            // Side, QuadPoint
+    PHX::MDField<const ScalarT,Side,QuadPoint,VecDim>  velocity;
+    PHX::MDField<const RealType,Side,QuadPoint,VecDim> observedVelocity;
+    PHX::MDField<const RealType,Side,QuadPoint,VecDim> observedVelocityRMS;
+    PHX::MDField<const RealType,Side,QuadPoint>        observedVelocityMagnitudeRMS;
+    PHX::MDField<const MeshScalarT,Side,QuadPoint>     w_measure_surface;
 
     //PHX::MDField<const MeshScalarT,Cell,Side,QuadPoint,Dim,Dim>  metric_surface;
 
     // Stuff for stifferning regularization
     std::string basalSideName;
-    PHX::MDField<const ParamScalarT> grad_stiffening;  // Side, QuadPoint, Dim
-    PHX::MDField<const ParamScalarT> stiffening;       // Side, QuadPoint
-    PHX::MDField<const MeshScalarT>  w_measure_basal;  // Side, QuadPoint
-    PHX::MDField<const MeshScalarT>  metric_basal;     // Side, QuadPoint, Dim, Dim
+    PHX::MDField<const ParamScalarT,Side,QuadPoint,Dim>    grad_stiffening;
+    PHX::MDField<const ParamScalarT,Side,QuadPoint>        stiffening;
+    PHX::MDField<const MeshScalarT,Side,QuadPoint>         w_measure_basal;
+    PHX::MDField<const MeshScalarT,Side,QuadPoint,Dim,Dim> metric_basal;
 
     // Stuff for beta regularization
     std::vector<Teuchos::RCP<Teuchos::ParameterList>> beta_reg_params;
-    std::vector<PHX::MDField<const ParamScalarT>>     grad_beta_vec;      // Side, QuadPoint, Dim
-    std::vector<PHX::MDField<const MeshScalarT>>      w_measure_beta_vec; // Side, QuadPoint
-    std::vector<PHX::MDField<const MeshScalarT>>      metric_beta_vec;    // Side, QuadPoint, Dim, Dim
-    Teuchos::RCP<const CellTopologyData>              cell_topo;
+    std::vector<PHX::MDField<const ParamScalarT,Side,QuadPoint,Dim>>    grad_beta_vec;
+    std::vector<PHX::MDField<const MeshScalarT,Side,QuadPoint>>         w_measure_beta_vec;
+    std::vector<PHX::MDField<const MeshScalarT,Side,QuadPoint,Dim,Dim>> metric_beta_vec;
+    Teuchos::RCP<const CellTopologyData> cell_topo;
 
     PHX::MDField<const ParamScalarT> grad_beta;
-    PHX::MDField<const MeshScalarT> metric;
-    PHX::MDField<const MeshScalarT> w_measure;
+    PHX::MDField<const MeshScalarT>  metric;
+    PHX::MDField<const MeshScalarT>  w_measure;
 
     ScalarT p_resp, p_reg, resp, reg, p_reg_stiffening,reg_stiffening;
     double scaling, alpha, asinh_scaling, alpha_stiffening;

--- a/src/LandIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch_Def.hpp
@@ -43,22 +43,20 @@ ResponseSurfaceVelocityMismatch(Teuchos::ParameterList& p, const Teuchos::RCP<Al
 
   Teuchos::RCP<Albany::Layouts> dl_surface = dl->side_layouts.at(surfaceSideName);
 
-  useCollapsedSidesets = dl_surface->useCollapsedSidesets;
-
-  velocity            = decltype(velocity)(velocity_name, useCollapsedSidesets ? dl_surface->qp_vector_sideset : dl_surface->qp_vector);
-  observedVelocity    = decltype(observedVelocity)(obs_velocity_name, useCollapsedSidesets ? dl_surface->qp_vector_sideset : dl_surface->qp_vector);
-  w_measure_surface   = decltype(w_measure_surface)(w_measure_surface_name, useCollapsedSidesets ? dl_surface->qp_scalar_sideset : dl_surface->qp_scalar);
+  velocity            = decltype(velocity)(velocity_name, dl_surface->qp_vector);
+  observedVelocity    = decltype(observedVelocity)(obs_velocity_name, dl_surface->qp_vector);
+  w_measure_surface   = decltype(w_measure_surface)(w_measure_surface_name, dl_surface->qp_scalar);
   if(scalarRMS)
-    observedVelocityMagnitudeRMS = decltype(observedVelocityMagnitudeRMS)(obs_velocityRMS_name, useCollapsedSidesets ? dl_surface->qp_scalar_sideset : dl_surface->qp_scalar);
+    observedVelocityMagnitudeRMS = decltype(observedVelocityMagnitudeRMS)(obs_velocityRMS_name, dl_surface->qp_scalar);
   else
-    observedVelocityRMS = decltype(observedVelocityRMS)(obs_velocityRMS_name, useCollapsedSidesets ? dl_surface->qp_vector_sideset : dl_surface->qp_vector);
+    observedVelocityRMS = decltype(observedVelocityRMS)(obs_velocityRMS_name, dl_surface->qp_vector);
 
   //metric_surface      = decltype(metric_surface)(metric_surface_name, dl_surface->qp_tensor);
 
   // Get Dimensions
-  numSideNodes  = dl_surface->node_scalar->extent(2);
-  numSideDims   = dl_surface->node_gradient->extent(3);
-  numSurfaceQPs = dl_surface->qp_scalar->extent(2);
+  numSideNodes  = dl_surface->node_scalar->extent(1);
+  numSideDims   = dl_surface->node_gradient->extent(2);
+  numSurfaceQPs = dl_surface->qp_scalar->extent(1);
 
   // add dependent fields
   this->addDependentField(velocity);
@@ -83,18 +81,15 @@ ResponseSurfaceVelocityMismatch(Teuchos::ParameterList& p, const Teuchos::RCP<Al
                                   "Error! Basal side data layout not found.\n");
       Teuchos::RCP<Albany::Layouts> dl_basal = dl->side_layouts.at(ssName);
 
-      TEUCHOS_TEST_FOR_EXCEPTION (dl_basal->useCollapsedSidesets != useCollapsedSidesets, std::runtime_error, 
-                                  "Error! Basal and surface sidesets are using different layouts.\n");
-
       const std::string& grad_beta_name       = paramList->get<std::string>("Basal Friction Coefficient Name") + "_" + ssName + " Gradient";
       const std::string& w_measure_basal_name = Albany::weighted_measure_name + " " + ssName;
       const std::string& metric_basal_name    = Albany::metric_name + " " + ssName;
 
-      grad_beta_vec.emplace_back(grad_beta_name, useCollapsedSidesets ? dl_basal->qp_gradient_sideset : dl_basal->qp_gradient);
-      w_measure_beta_vec.emplace_back(w_measure_basal_name, useCollapsedSidesets ? dl_basal->qp_scalar_sideset : dl_basal->qp_scalar);
-      metric_beta_vec.emplace_back(metric_basal_name, useCollapsedSidesets ? dl_basal->qp_tensor_sideset : dl_basal->qp_tensor);
+      grad_beta_vec.emplace_back(grad_beta_name, dl_basal->qp_gradient);
+      w_measure_beta_vec.emplace_back(w_measure_basal_name, dl_basal->qp_scalar);
+      metric_beta_vec.emplace_back(metric_basal_name, dl_basal->qp_tensor);
 
-      numBasalQPs = dl_basal->qp_scalar->extent(2);
+      numBasalQPs = dl_basal->qp_scalar->extent(1);
 
       this->addDependentField(w_measure_beta_vec.back());
       this->addDependentField(metric_beta_vec.back());
@@ -111,20 +106,17 @@ ResponseSurfaceVelocityMismatch(Teuchos::ParameterList& p, const Teuchos::RCP<Al
                                 "Error! Basal side data layout not found.\n");
     Teuchos::RCP<Albany::Layouts> dl_basal = dl->side_layouts.at(basalSideName);
 
-    TEUCHOS_TEST_FOR_EXCEPTION (dl_basal->useCollapsedSidesets != useCollapsedSidesets, std::runtime_error, 
-                                  "Error! Basal and surface sidesets are using different layouts.\n");
-
     const std::string& stiffening_name      = paramList->get<std::string>("Stiffening Factor Name");
     const std::string& grad_stiffening_name = paramList->get<std::string>("Stiffening Factor Gradient Name");
     const std::string& w_measure_basal_name = paramList->get<std::string>("Weighted Measure Basal Name");
     const std::string& metric_basal_name    = paramList->get<std::string>("Metric Basal Name");
 
-    stiffening      = decltype(stiffening)(stiffening_name, useCollapsedSidesets ? dl_basal->qp_scalar_sideset : dl_basal->qp_scalar);
-    grad_stiffening = decltype(grad_stiffening)(grad_stiffening_name, useCollapsedSidesets ? dl_basal->qp_gradient_sideset : dl_basal->qp_gradient);
-    w_measure_basal = decltype(w_measure_basal)(w_measure_basal_name, useCollapsedSidesets ? dl_basal->qp_scalar_sideset : dl_basal->qp_scalar);
-    metric_basal    = decltype(metric_basal)(metric_basal_name, useCollapsedSidesets ? dl_basal->qp_tensor_sideset : dl_basal->qp_tensor);
+    stiffening      = decltype(stiffening)(stiffening_name, dl_basal->qp_scalar);
+    grad_stiffening = decltype(grad_stiffening)(grad_stiffening_name, dl_basal->qp_gradient);
+    w_measure_basal = decltype(w_measure_basal)(w_measure_basal_name, dl_basal->qp_scalar);
+    metric_basal    = decltype(metric_basal)(metric_basal_name, dl_basal->qp_tensor);
 
-    numBasalQPs = dl_basal->qp_scalar->extent(2);
+    numBasalQPs = dl_basal->qp_scalar->extent(1);
 
     this->addDependentField(w_measure_basal);
     this->addDependentField(metric_basal);
@@ -182,222 +174,110 @@ void LandIce::ResponseSurfaceVelocityMismatch<EvalT, Traits>::evaluateFields(typ
   // Zero out local response
   PHAL::set(this->local_response_eval, 0.0);
 
-  if (useCollapsedSidesets) {
-    // ----------------- Surface side ---------------- //
-    if (workset.sideSetViews->find(surfaceSideName) != workset.sideSetViews->end())
+  // ----------------- Surface side ---------------- //
+  if (workset.sideSetViews->find(surfaceSideName) != workset.sideSetViews->end())
+  {
+    sideSet = workset.sideSetViews->at(surfaceSideName);
+    for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
     {
-      sideSet = workset.sideSetViews->at(surfaceSideName);
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the local data of cell
-        const int cell = sideSet.elem_LID(sideSet_idx);
+      // Get the local data of cell
+      const int cell = sideSet.elem_LID(sideSet_idx);
 
-        ScalarT t = 0;
-        ScalarT data = 0;
-        if(scalarRMS)
-          for (unsigned int qp=0; qp<numSurfaceQPs; ++qp)
-          {
-            ScalarT diff2 = std::pow(velocity(sideSet_idx, qp, 0)  - observedVelocity (sideSet_idx, qp, 0),2) 
-                                + std::pow(velocity(sideSet_idx, qp, 1)  - observedVelocity (sideSet_idx, qp, 1),2);
-
-            // We have to add a small number to diff2, otherwise the derivative computations can generate NaNs.
-            diff2 += Teuchos::ScalarTraits<ScalarT>::eps();
-
-            ScalarT weightedDiff = std::sqrt(diff2)/observedVelocityMagnitudeRMS(sideSet_idx, qp);
-            ScalarT weightedDiff2 = std::pow(asinh(weightedDiff/ asinh_scaling)*asinh_scaling,2);
-            t += weightedDiff2 * w_measure_surface(sideSet_idx, qp);
-          }
-        else
-          for (unsigned int qp=0; qp<numSurfaceQPs; ++qp)
-          {
-            ParamScalarT refVel0 = asinh(observedVelocity (sideSet_idx, qp, 0) / observedVelocityRMS(sideSet_idx, qp, 0) / asinh_scaling);
-            ParamScalarT refVel1 = asinh(observedVelocity (sideSet_idx, qp, 1) / observedVelocityRMS(sideSet_idx, qp, 1) / asinh_scaling);
-            ScalarT vel0 = asinh(velocity(sideSet_idx, qp, 0) / observedVelocityRMS(sideSet_idx, qp, 0) / asinh_scaling);
-            ScalarT vel1 = asinh(velocity(sideSet_idx, qp, 1) / observedVelocityRMS(sideSet_idx, qp, 1) / asinh_scaling);
-            ScalarT diff0 = refVel0 - vel0;
-            ScalarT diff1 = refVel1 - vel1;
-            data = diff0 * diff0
-                + diff1 * diff1;
-            //data = diff0 * metric_surface(sideSet_idx,qp,0,0) * diff0
-            //     + diff0 * metric_surface(sideSet_idx,qp,0,1) * diff1
-            //     + diff1 * metric_surface(sideSet_idx,qp,1,0) * diff0;
-            //     + diff1 * metric_surface(sideSet_idx,qp,1,1) * diff1;
-            data *= asinh_scaling * asinh_scaling;
-            t += data * w_measure_surface(sideSet_idx,qp);
-          }
-
-        this->local_response_eval(cell, 0) += t*scaling;
-        this->global_response_eval(0) += t*scaling;
-        p_resp += t*scaling;
-      }
-    }
-
-    // --------------- Regularization term on the basal side ----------------- //
-    if (alpha!=0) {
-      for (size_t i=0; i<beta_reg_params.size(); ++i) {
-        Teuchos::RCP<Teuchos::ParameterList> pl = beta_reg_params[i];
-        std::string ssName = pl->get<std::string>("Side Set Name","");
-
-        grad_beta = grad_beta_vec[i];
-        metric = metric_beta_vec[i];
-        w_measure = w_measure_beta_vec[i];
-        if (workset.sideSetViews->find(ssName) != workset.sideSetViews->end()) {
-          sideSet = workset.sideSetViews->at(ssName);
-          for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-          {
-            // Get the local data of cell
-            const int cell = sideSet.elem_LID(sideSet_idx);\
-
-            ScalarT t = 0;
-            for (unsigned int qp=0; qp<numBasalQPs; ++qp)
-            {
-              ScalarT sum=0;
-              for (unsigned int idim=0; idim<numSideDims; ++idim)
-                for (unsigned int jdim=0; jdim<numSideDims; ++jdim)
-                  sum += grad_beta(sideSet_idx,qp,idim)*metric(sideSet_idx,qp,idim,jdim)*grad_beta(sideSet_idx,qp,jdim);
-
-              t += sum * w_measure(sideSet_idx,qp);
-            }
-            this->local_response_eval(cell, 0) += t*scaling*alpha;//*50.0;
-            this->global_response_eval(0) += t*scaling*alpha;//*50.0;
-            p_reg += t*scaling*alpha;
-          }
-        }
-      }
-    }
-
-    if (workset.sideSetViews->find(basalSideName) != workset.sideSetViews->end() && alpha_stiffening!=0)
-    {
-      sideSet = workset.sideSetViews->at(basalSideName);
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the local data of \cell
-        const int cell = sideSet.elem_LID(sideSet_idx);\
-
-        ScalarT t = 0;
-        for (unsigned int qp=0; qp<numBasalQPs; ++qp)
+      ScalarT t = 0;
+      ScalarT data = 0;
+      if(scalarRMS)
+        for (unsigned int qp=0; qp<numSurfaceQPs; ++qp)
         {
-          ScalarT sum = stiffening(sideSet_idx,qp)*stiffening(sideSet_idx,qp);
+          ScalarT diff2 = std::pow(velocity(sideSet_idx, qp, 0)  - observedVelocity (sideSet_idx, qp, 0),2) 
+                              + std::pow(velocity(sideSet_idx, qp, 1)  - observedVelocity (sideSet_idx, qp, 1),2);
+
+          // We have to add a small number to diff2, otherwise the derivative computations can generate NaNs.
+          diff2 += Teuchos::ScalarTraits<ScalarT>::eps();
+
+          ScalarT weightedDiff = std::sqrt(diff2)/observedVelocityMagnitudeRMS(sideSet_idx, qp);
+          ScalarT weightedDiff2 = std::pow(asinh(weightedDiff/ asinh_scaling)*asinh_scaling,2);
+          t += weightedDiff2 * w_measure_surface(sideSet_idx, qp);
+        }
+      else
+        for (unsigned int qp=0; qp<numSurfaceQPs; ++qp)
+        {
+          ParamScalarT refVel0 = asinh(observedVelocity (sideSet_idx, qp, 0) / observedVelocityRMS(sideSet_idx, qp, 0) / asinh_scaling);
+          ParamScalarT refVel1 = asinh(observedVelocity (sideSet_idx, qp, 1) / observedVelocityRMS(sideSet_idx, qp, 1) / asinh_scaling);
+          ScalarT vel0 = asinh(velocity(sideSet_idx, qp, 0) / observedVelocityRMS(sideSet_idx, qp, 0) / asinh_scaling);
+          ScalarT vel1 = asinh(velocity(sideSet_idx, qp, 1) / observedVelocityRMS(sideSet_idx, qp, 1) / asinh_scaling);
+          ScalarT diff0 = refVel0 - vel0;
+          ScalarT diff1 = refVel1 - vel1;
+          data = diff0 * diff0
+              + diff1 * diff1;
+          //data = diff0 * metric_surface(sideSet_idx,qp,0,0) * diff0
+          //     + diff0 * metric_surface(sideSet_idx,qp,0,1) * diff1
+          //     + diff1 * metric_surface(sideSet_idx,qp,1,0) * diff0;
+          //     + diff1 * metric_surface(sideSet_idx,qp,1,1) * diff1;
+          data *= asinh_scaling * asinh_scaling;
+          t += data * w_measure_surface(sideSet_idx,qp);
+        }
+
+      this->local_response_eval(cell, 0) += t*scaling;
+      this->global_response_eval(0) += t*scaling;
+      p_resp += t*scaling;
+    }
+  }
+
+  // --------------- Regularization term on the basal side ----------------- //
+  if (alpha!=0) {
+    for (size_t i=0; i<beta_reg_params.size(); ++i) {
+      Teuchos::RCP<Teuchos::ParameterList> pl = beta_reg_params[i];
+      std::string ssName = pl->get<std::string>("Side Set Name","");
+
+      grad_beta = grad_beta_vec[i];
+      metric = metric_beta_vec[i];
+      w_measure = w_measure_beta_vec[i];
+      if (workset.sideSetViews->find(ssName) != workset.sideSetViews->end()) {
+        sideSet = workset.sideSetViews->at(ssName);
+        for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+        {
+          // Get the local data of cell
+          const int cell = sideSet.elem_LID(sideSet_idx);\
+
+          ScalarT t = 0;
+          for (unsigned int qp=0; qp<numBasalQPs; ++qp)
+          {
+            ScalarT sum=0;
             for (unsigned int idim=0; idim<numSideDims; ++idim)
               for (unsigned int jdim=0; jdim<numSideDims; ++jdim)
-                sum += grad_stiffening(sideSet_idx,qp,idim)*metric_basal(sideSet_idx,qp,idim,jdim)*grad_stiffening(sideSet_idx,qp,jdim);
+                sum += grad_beta(sideSet_idx,qp,idim)*metric(sideSet_idx,qp,idim,jdim)*grad_beta(sideSet_idx,qp,jdim);
 
-            t += sum * w_measure_basal(sideSet_idx,qp);
+            t += sum * w_measure(sideSet_idx,qp);
+          }
+          this->local_response_eval(cell, 0) += t*scaling*alpha;//*50.0;
+          this->global_response_eval(0) += t*scaling*alpha;//*50.0;
+          p_reg += t*scaling*alpha;
         }
-        this->local_response_eval(cell, 0) += t*scaling*alpha_stiffening;//*50.0;
-        this->global_response_eval(0) += t*scaling*alpha_stiffening;//*50.0;
-        p_reg_stiffening += t*scaling*alpha_stiffening;
       }
     }
-  } else {
-    // ----------------- Surface side ---------------- //
-    if (workset.sideSetViews->find(surfaceSideName) != workset.sideSetViews->end())
+  }
+
+  if (workset.sideSetViews->find(basalSideName) != workset.sideSetViews->end() && alpha_stiffening!=0)
+  {
+    sideSet = workset.sideSetViews->at(basalSideName);
+    for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
     {
-      sideSet = workset.sideSetViews->at(surfaceSideName);
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+      // Get the local data of \cell
+      const int cell = sideSet.elem_LID(sideSet_idx);\
+
+      ScalarT t = 0;
+      for (unsigned int qp=0; qp<numBasalQPs; ++qp)
       {
-        // Get the local data of side and cell
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
+        ScalarT sum = stiffening(sideSet_idx,qp)*stiffening(sideSet_idx,qp);
+          for (unsigned int idim=0; idim<numSideDims; ++idim)
+            for (unsigned int jdim=0; jdim<numSideDims; ++jdim)
+              sum += grad_stiffening(sideSet_idx,qp,idim)*metric_basal(sideSet_idx,qp,idim,jdim)*grad_stiffening(sideSet_idx,qp,jdim);
 
-        ScalarT t = 0;
-        ScalarT data = 0;
-        if(scalarRMS)
-          for (unsigned int qp=0; qp<numSurfaceQPs; ++qp)
-          {
-            ScalarT diff2 = std::pow(velocity(cell, side, qp, 0)  - observedVelocity (cell, side, qp, 0),2) 
-                                + std::pow(velocity(cell, side, qp, 1)  - observedVelocity (cell, side, qp, 1),2);
-
-            // We have to add a small number to diff2, otherwise the derivative computations can generate NaNs.
-            diff2 += Teuchos::ScalarTraits<ScalarT>::eps();
-
-            ScalarT weightedDiff = std::sqrt(diff2)/observedVelocityMagnitudeRMS(cell, side, qp);
-            ScalarT weightedDiff2 = std::pow(asinh(weightedDiff/ asinh_scaling)*asinh_scaling,2);
-            t += weightedDiff2 * w_measure_surface(cell, side, qp);
-          }
-        else
-          for (unsigned int qp=0; qp<numSurfaceQPs; ++qp)
-          {
-            ParamScalarT refVel0 = asinh(observedVelocity (cell, side, qp, 0) / observedVelocityRMS(cell, side, qp, 0) / asinh_scaling);
-            ParamScalarT refVel1 = asinh(observedVelocity (cell, side, qp, 1) / observedVelocityRMS(cell, side, qp, 1) / asinh_scaling);
-            ScalarT vel0 = asinh(velocity(cell, side, qp, 0) / observedVelocityRMS(cell, side, qp, 0) / asinh_scaling);
-            ScalarT vel1 = asinh(velocity(cell, side, qp, 1) / observedVelocityRMS(cell, side, qp, 1) / asinh_scaling);
-            ScalarT diff0 = refVel0 - vel0;
-            ScalarT diff1 = refVel1 - vel1;
-            data = diff0 * diff0
-                + diff1 * diff1;
-            //data = diff0 * metric_surface(cell,side,qp,0,0) * diff0
-            //     + diff0 * metric_surface(cell,side,qp,0,1) * diff1
-            //     + diff1 * metric_surface(cell,side,qp,1,0) * diff0;
-            //     + diff1 * metric_surface(cell,side,qp,1,1) * diff1;
-            data *= asinh_scaling * asinh_scaling;
-            t += data * w_measure_surface(cell,side,qp);
-          }
-
-        this->local_response_eval(cell, 0) += t*scaling;
-        this->global_response_eval(0) += t*scaling;
-        p_resp += t*scaling;
+          t += sum * w_measure_basal(sideSet_idx,qp);
       }
-    }
-
-    // --------------- Regularization term on the basal side ----------------- //
-    if (alpha!=0) {
-      for (size_t i=0; i<beta_reg_params.size(); ++i) {
-        Teuchos::RCP<Teuchos::ParameterList> pl = beta_reg_params[i];
-        std::string ssName = pl->get<std::string>("Side Set Name","");
-
-        grad_beta = grad_beta_vec[i];
-        metric = metric_beta_vec[i];
-        w_measure = w_measure_beta_vec[i];
-        if (workset.sideSetViews->find(ssName) != workset.sideSetViews->end()) {
-          sideSet = workset.sideSetViews->at(ssName);
-          for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-          {
-            // Get the local data of side and cell
-            const int cell = sideSet.elem_LID(sideSet_idx);
-            const int side = sideSet.side_local_id(sideSet_idx);
-
-            ScalarT t = 0;
-            for (unsigned int qp=0; qp<numBasalQPs; ++qp)
-            {
-              ScalarT sum=0;
-              for (unsigned int idim=0; idim<numSideDims; ++idim)
-                for (unsigned int jdim=0; jdim<numSideDims; ++jdim)
-                  sum += grad_beta(cell,side,qp,idim)*metric(cell,side,qp,idim,jdim)*grad_beta(cell,side,qp,jdim);
-
-              t += sum * w_measure(cell,side,qp);
-            }
-            this->local_response_eval(cell, 0) += t*scaling*alpha;//*50.0;
-            this->global_response_eval(0) += t*scaling*alpha;//*50.0;
-            p_reg += t*scaling*alpha;
-          }
-        }
-      }
-    }
-
-    if (workset.sideSetViews->find(basalSideName) != workset.sideSetViews->end() && alpha_stiffening!=0)
-    {
-      sideSet = workset.sideSetViews->at(basalSideName);
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the local data of side and cell
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
-
-        ScalarT t = 0;
-        for (unsigned int qp=0; qp<numBasalQPs; ++qp)
-        {
-          ScalarT sum = stiffening(cell,side,qp)*stiffening(cell,side,qp);
-            for (unsigned int idim=0; idim<numSideDims; ++idim)
-              for (unsigned int jdim=0; jdim<numSideDims; ++jdim)
-                sum += grad_stiffening(cell,side,qp,idim)*metric_basal(cell,side,qp,idim,jdim)*grad_stiffening(cell,side,qp,jdim);
-
-            t += sum * w_measure_basal(cell,side,qp);
-        }
-        this->local_response_eval(cell, 0) += t*scaling*alpha_stiffening;//*50.0;
-        this->global_response_eval(0) += t*scaling*alpha_stiffening;//*50.0;
-        p_reg_stiffening += t*scaling*alpha_stiffening;
-      }
+      this->local_response_eval(cell, 0) += t*scaling*alpha_stiffening;//*50.0;
+      this->global_response_eval(0) += t*scaling*alpha_stiffening;//*50.0;
+      p_reg_stiffening += t*scaling*alpha_stiffening;
     }
   }
 

--- a/src/LandIce/evaluators/LandIce_StokesFOBasalResid.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOBasalResid.hpp
@@ -44,14 +44,13 @@ public:
 private:
 
   // Input:
-  // TODO: restore layout template arguments when removing old sideset layout
-  PHX::MDField<const BetaScalarT> beta;       // Side, QuadPoint
-  PHX::MDField<const ScalarT>     u;          // Side, QuadPoint, VecDim
-  PHX::MDField<const RealType>    BF;         // Side, Node, QuadPoint
-  PHX::MDField<const MeshScalarT> w_measure;  // Side, QuadPoint
-  PHX::MDField<const MeshScalarT> normals;   // Side, QuadPoint, Dim
+  PHX::MDField<const BetaScalarT,Side,QuadPoint>     beta;
+  PHX::MDField<const ScalarT,Side,QuadPoint,VecDim>  u;
+  PHX::MDField<const RealType,Side,Node,QuadPoint>   BF;
+  PHX::MDField<const MeshScalarT,Side,QuadPoint>     w_measure;
+  PHX::MDField<const MeshScalarT,Side,QuadPoint,Dim> normals;
+  
   PHX::MDField<const ScalarT,Dim> homotopyParam;
-
   PHX::MDField<const ScalarT,Dim> homotopy;
 
   // Output:

--- a/src/LandIce/evaluators/LandIce_StokesFOBasalResid_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOBasalResid_Def.hpp
@@ -33,11 +33,11 @@ StokesFOBasalResid<EvalT, Traits, BetaScalarT>::StokesFOBasalResid (const Teucho
 
   Teuchos::RCP<Albany::Layouts> dl_basal = dl->side_layouts.at(basalSideName);
 
-  u         = decltype(u)(p.get<std::string> ("Velocity Side QP Variable Name"), dl_basal->qp_vector_sideset);
-  beta      = decltype(beta)(p.get<std::string> ("Basal Friction Coefficient Side QP Variable Name"), dl_basal->qp_scalar_sideset);
-  BF        = decltype(BF)(p.get<std::string> ("BF Side Name"), dl_basal->node_qp_scalar_sideset);
-  w_measure = decltype(w_measure)(p.get<std::string> ("Weighted Measure Name"), dl_basal->qp_scalar_sideset);
-  normals   = decltype(normals)(p.get<std::string> ("Side Normal Name"), dl_basal->qp_vector_spacedim_sideset);
+  u         = decltype(u)(p.get<std::string> ("Velocity Side QP Variable Name"), dl_basal->qp_vector);
+  beta      = decltype(beta)(p.get<std::string> ("Basal Friction Coefficient Side QP Variable Name"), dl_basal->qp_scalar);
+  BF        = decltype(BF)(p.get<std::string> ("BF Side Name"), dl_basal->node_qp_scalar);
+  w_measure = decltype(w_measure)(p.get<std::string> ("Weighted Measure Name"), dl_basal->qp_scalar);
+  normals   = decltype(normals)(p.get<std::string> ("Side Normal Name"), dl_basal->qp_vector_spacedim);
 
   this->addDependentField(u);
   this->addDependentField(beta);
@@ -49,8 +49,8 @@ StokesFOBasalResid<EvalT, Traits, BetaScalarT>::StokesFOBasalResid (const Teucho
 
   std::vector<PHX::DataLayout::size_type> dims;
   dl_basal->node_qp_gradient->dimensions(dims);
-  numSideNodes = dims[2];
-  numSideQPs   = dims[3];
+  numSideNodes = dims[1];
+  numSideQPs   = dims[2];
 
   dl->node_vector->dimensions(dims);
   vecDimFO     = std::min((int)dims[2],2);

--- a/src/LandIce/evaluators/LandIce_StokesFOLateralResid.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOLateralResid.hpp
@@ -51,15 +51,14 @@ private:
   void evaluate_with_computed_immersed_ratio(typename Traits::EvalData d);
 
   // Input:
-  // TODO: restore layout template arguments when removing old sideset layout
   // NOTE: if thickness is ParamST or ScalarT, we are moving the surface,
   //       so use ThicknessScalarT for elevation
-  PHX::MDField<const MeshScalarT>        coords_qp; // Side, Node, Dim
-  PHX::MDField<const ThicknessScalarT>   thickness; // Side, QuadPoint
-  PHX::MDField<const ThicknessScalarT>   elevation; // Side, QuadPoint
-  PHX::MDField<const RealType>           BF;        // Side, Node, QuadPoint
-  PHX::MDField<const MeshScalarT>        normals;   // Side, QuadPoint, Dim
-  PHX::MDField<const MeshScalarT>        w_measure; // Side, QuadPoint
+  PHX::MDField<const MeshScalarT,Side,Node,Dim>       coords_qp;
+  PHX::MDField<const ThicknessScalarT,Side,QuadPoint> thickness;
+  PHX::MDField<const ThicknessScalarT,Side,QuadPoint> elevation;
+  PHX::MDField<const RealType,Side,Node,QuadPoint>    BF;
+  PHX::MDField<const MeshScalarT,Side,QuadPoint,Dim>  normals;
+  PHX::MDField<const MeshScalarT,Side,QuadPoint>      w_measure;
 
   // Output:
   PHX::MDField<OutputScalarT,Cell,Node,VecDim> residual;

--- a/src/LandIce/evaluators/LandIce_StokesFOLateralResid_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOLateralResid_Def.hpp
@@ -27,10 +27,10 @@ StokesFOLateralResid (const Teuchos::ParameterList& p,
   Teuchos::RCP<Albany::Layouts> dl_lateral = dl->side_layouts.at(lateralSideName);
 
   // Create dependent fields
-  thickness  = decltype(thickness)(p.get<std::string> ("Ice Thickness Variable Name"), dl_lateral->qp_scalar_sideset);
-  BF         = decltype(BF)(p.get<std::string> ("BF Side Name"), dl_lateral->node_qp_scalar_sideset);
-  normals    = decltype(normals)(p.get<std::string> ("Side Normal Name"), dl_lateral->qp_vector_spacedim_sideset);
-  w_measure  = decltype(w_measure)(p.get<std::string> ("Weighted Measure Name"), dl_lateral->qp_scalar_sideset);
+  thickness  = decltype(thickness)(p.get<std::string> ("Ice Thickness Variable Name"), dl_lateral->qp_scalar);
+  BF         = decltype(BF)(p.get<std::string> ("BF Side Name"), dl_lateral->node_qp_scalar);
+  normals    = decltype(normals)(p.get<std::string> ("Side Normal Name"), dl_lateral->qp_vector_spacedim);
+  w_measure  = decltype(w_measure)(p.get<std::string> ("Weighted Measure Name"), dl_lateral->qp_scalar);
 
   this->addDependentField(thickness);
   this->addDependentField(BF);
@@ -42,7 +42,7 @@ StokesFOLateralResid (const Teuchos::ParameterList& p,
   if (immerse_ratio_provided) {
     given_immersed_ratio = bc_pl.get<double>("Immersed Ratio");
   } else {
-    elevation = decltype(elevation)(p.get<std::string> ("Ice Surface Elevation Variable Name"), dl_lateral->qp_scalar_sideset);
+    elevation = decltype(elevation)(p.get<std::string> ("Ice Surface Elevation Variable Name"), dl_lateral->qp_scalar);
     this->addDependentField(elevation);
   }
 
@@ -70,7 +70,7 @@ StokesFOLateralResid (const Teuchos::ParameterList& p,
     Y_0 = stereographicMapList->get<double>("Y_0", 0);//-2040);
     R2 = std::pow(R,2);
 
-    coords_qp = decltype(coords_qp)(p.get<std::string>("Coordinate Vector Variable Name"), dl_lateral->qp_coords_sideset);
+    coords_qp = decltype(coords_qp)(p.get<std::string>("Coordinate Vector Variable Name"), dl_lateral->qp_coords);
     this->addDependentField(coords_qp);
   }
 
@@ -83,15 +83,15 @@ StokesFOLateralResid (const Teuchos::ParameterList& p,
   // Get dimensions
   std::vector<PHX::DataLayout::size_type> dims;
   dl_lateral->node_qp_gradient->dimensions(dims);
-  unsigned int numSides = dims[1];
-  numSideNodes = dims[2];
-  numSideQPs   = dims[3];
+  numSideNodes = dims[1];
+  numSideQPs   = dims[2];
   dl->node_vector->dimensions(dims);
   vecDimFO     = std::min((int)dims[2],2);
 
   // Index of the nodes on the sides in the numeration of the cell
   Teuchos::RCP<shards::CellTopology> cellType;
   cellType = p.get<Teuchos::RCP <shards::CellTopology> > ("Cell Type");
+  unsigned int numSides = cellType->getSideCount();
   int sideDim = cellType->getDimension()-1;
   int nodeMax = 0;
   for (unsigned int side=0; side<numSides; ++side) {

--- a/src/LandIce/evaluators/LandIce_StokesFOSynteticTestBC.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOSynteticTestBC.hpp
@@ -54,12 +54,11 @@ private:
   };
 
   // Input:
-  // TODO: restore layout template arguments when removing old sideset layout
-  PHX::MDField<const ScalarT>     u;            // Side, QuadPoint, VecDim
-  PHX::MDField<const MeshScalarT> qp_coords;    // Side, QuadPoint, Dim
-  PHX::MDField<const MeshScalarT> side_normals; // Side, QuadPoint, Dim
-  PHX::MDField<const RealType>    BF;           // Side, Node, QuadPoint
-  PHX::MDField<const MeshScalarT> w_measure;    // Side, QuadPoint
+  PHX::MDField<const ScalarT,Side,QuadPoint,VecDim>  u;
+  PHX::MDField<const MeshScalarT,Side,QuadPoint,Dim> qp_coords;
+  PHX::MDField<const MeshScalarT,Side,QuadPoint,Dim> side_normals;
+  PHX::MDField<const RealType,Side,Node,QuadPoint>   BF;
+  PHX::MDField<const MeshScalarT,Side,QuadPoint>     w_measure;
 
   // Output:
   PHX::MDField<ScalarT,Cell,Node,VecDim> residual;

--- a/src/LandIce/evaluators/LandIce_StokesFOSynteticTestBC_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOSynteticTestBC_Def.hpp
@@ -47,9 +47,9 @@ StokesFOSynteticTestBC<EvalT, Traits, betaScalarT>::StokesFOSynteticTestBC (cons
 
   Teuchos::RCP<Albany::Layouts> dl_side = dl->side_layouts.at(ssName);
 
-  u         = decltype(u)(p.get<std::string> ("Velocity Side QP Variable Name"), dl_side->qp_vector_sideset);
-  BF        = decltype(BF)(p.get<std::string> ("BF Side Name"), dl_side->node_qp_scalar_sideset);
-  w_measure = decltype(w_measure)(p.get<std::string> ("Weighted Measure Name"), dl_side->qp_scalar_sideset);
+  u         = decltype(u)(p.get<std::string> ("Velocity Side QP Variable Name"), dl_side->qp_vector);
+  BF        = decltype(BF)(p.get<std::string> ("BF Side Name"), dl_side->node_qp_scalar);
+  w_measure = decltype(w_measure)(p.get<std::string> ("Weighted Measure Name"), dl_side->qp_scalar);
 
   this->addDependentField(u);
   this->addDependentField(BF);
@@ -59,9 +59,8 @@ StokesFOSynteticTestBC<EvalT, Traits, betaScalarT>::StokesFOSynteticTestBC (cons
 
   std::vector<PHX::DataLayout::size_type> dims;
   dl_side->node_qp_gradient->dimensions(dims);
-  unsigned int numSides = dims[1];
-  numSideNodes = dims[2];
-  numSideQPs   = dims[3];
+  numSideNodes = dims[1];
+  numSideQPs   = dims[2];
 
   dl->node_vector->dimensions(dims);
   vecDimFO     = std::min((int)dims[2],2);
@@ -106,10 +105,10 @@ StokesFOSynteticTestBC<EvalT, Traits, betaScalarT>::StokesFOSynteticTestBC (cons
   beta  = pl.get<double>("beta");
 
   if (bc_type!=BCType::CONSTANT) {
-    qp_coords    = decltype(qp_coords)(p.get<std::string>("Coordinate Vector Name"), dl_side->qp_coords_sideset);
+    qp_coords    = decltype(qp_coords)(p.get<std::string>("Coordinate Vector Name"), dl_side->qp_coords);
     this->addDependentField(qp_coords);
     if (bc_type!=BCType::CONFINED_SHELF) {
-      side_normals = decltype(qp_coords)(p.get<std::string>("Side Normal Name"), dl_side->qp_coords_sideset);
+      side_normals = decltype(qp_coords)(p.get<std::string>("Side Normal Name"), dl_side->qp_coords);
       this->addDependentField(side_normals);
     }
   }
@@ -117,6 +116,7 @@ StokesFOSynteticTestBC<EvalT, Traits, betaScalarT>::StokesFOSynteticTestBC (cons
   // Index of the nodes on the sides in the numeration of the cell
   Teuchos::RCP<shards::CellTopology> cellType;
   cellType = p.get<Teuchos::RCP <shards::CellTopology> > ("Cell Type");
+  unsigned int numSides = cellType->getSideCount();
   sideNodes.resize(numSides);
   sideDim = cellType->getDimension()-1;
   for (unsigned int side=0; side<numSides; ++side)

--- a/src/LandIce/evaluators/LandIce_ThicknessResid_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_ThicknessResid_Def.hpp
@@ -54,7 +54,7 @@ ThicknessResid(const Teuchos::ParameterList& p,
                               "Error! Layout for side set " << sideSetName << " not found.\n");
   Teuchos::RCP<Albany::Layouts> dl_side = dl->side_layouts.at(sideSetName);
 
-  auto av_v_layout = dl_side->node_vector_sideset;
+  auto av_v_layout = dl_side->node_vector;
   V = decltype(V)(p.get<std::string>("Averaged Velocity Variable Name"), av_v_layout);
   this->addDependentField(V);
 

--- a/src/LandIce/evaluators/LandIce_w_Resid_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_w_Resid_Def.hpp
@@ -48,23 +48,20 @@ namespace LandIce
                                 "Error! Basal side data layout not found.\n");
     Teuchos::RCP<Albany::Layouts> dl_side = dl->side_layouts.at(sideName);
 
-    TEUCHOS_TEST_FOR_EXCEPTION (not dl_side->useCollapsedSidesets, std::runtime_error,
-                                "Error! LandIce::w_Resid only implemented for collapsed sidesets.\n");
-
-    sideBF = decltype(sideBF)(p.get<std::string> ("BF Side Name"), dl_side->node_qp_scalar_sideset);
-    side_w_measure = decltype(side_w_measure)(p.get<std::string> ("Weighted Measure Side Name"), dl_side->qp_scalar_sideset);
-    side_w_qp  = decltype(side_w_qp)(p.get<std::string> ("w Side QP Variable Name"), dl_side->qp_scalar_sideset);
-    basalVerticalVelocitySideQP = decltype(basalVerticalVelocitySideQP)(p.get<std::string>("Basal Vertical Velocity Side QP Variable Name"), dl_side->qp_scalar_sideset);
-    normals    = decltype(normals)(p.get<std::string> ("Side Normal Name"), dl_side->qp_vector_spacedim_sideset);
+    sideBF = decltype(sideBF)(p.get<std::string> ("BF Side Name"), dl_side->node_qp_scalar);
+    side_w_measure = decltype(side_w_measure)(p.get<std::string> ("Weighted Measure Side Name"), dl_side->qp_scalar);
+    side_w_qp  = decltype(side_w_qp)(p.get<std::string> ("w Side QP Variable Name"), dl_side->qp_scalar);
+    basalVerticalVelocitySideQP = decltype(basalVerticalVelocitySideQP)(p.get<std::string>("Basal Vertical Velocity Side QP Variable Name"), dl_side->qp_scalar);
+    normals    = decltype(normals)(p.get<std::string> ("Side Normal Name"), dl_side->qp_vector_spacedim);
 
     std::vector<PHX::Device::size_type> dims;
     dl->node_qp_vector->dimensions(dims);
     numNodes = dims[1];
     numQPs   = dims[2];
-    numSideQPs   = dl_side->qp_scalar->extent(2);
-    numSideNodes  = dl_side->node_scalar->extent(2);
+    numSideQPs   = dl_side->qp_scalar->extent(1);
+    numSideNodes  = dl_side->node_scalar->extent(1);
 
-    unsigned int numSides = dl_side->node_scalar->extent(1);
+    unsigned int numSides = cellType->getSideCount();
     unsigned int sideDim  = cellType->getDimension()-1;
 
     unsigned int nodeMax = 0;

--- a/src/LandIce/evaluators/hydrology/LandIce_EffectivePressure_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_EffectivePressure_Def.hpp
@@ -34,9 +34,9 @@ EffectivePressure (const Teuchos::ParameterList& p,
 
   Teuchos::RCP<PHX::DataLayout> layout;
   if (p.isParameter("Nodal") && p.get<bool>("Nodal")) {
-    layout = eval_on_side ? dl->node_scalar_sideset : dl->node_scalar;
+    layout = dl->node_scalar;
   } else {
-    layout = eval_on_side ? dl->qp_scalar_sideset : dl->qp_scalar;
+    layout = dl->qp_scalar;
   }
 
   numPts = layout->extent(1);

--- a/src/LandIce/evaluators/hydrology/LandIce_HydraulicPotential_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydraulicPotential_Def.hpp
@@ -29,9 +29,9 @@ HydraulicPotential (const Teuchos::ParameterList& p,
 
   Teuchos::RCP<PHX::DataLayout> layout;
   if (p.isParameter("Nodal") && p.get<bool>("Nodal")) {
-    layout = eval_on_side ? dl->node_scalar_sideset : dl->node_scalar;
+    layout = dl->node_scalar;
   } else {
-    layout = eval_on_side ? dl->qp_scalar_sideset : dl->qp_scalar;
+    layout = dl->qp_scalar;
   }
 
   numPts = layout->extent(1);

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyBasalGravitationalWaterPotential_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyBasalGravitationalWaterPotential_Def.hpp
@@ -28,9 +28,9 @@ BasalGravitationalWaterPotential (const Teuchos::ParameterList& p,
 
   Teuchos::RCP<PHX::DataLayout> layout;
   if (p.isParameter("Nodal") && p.get<bool>("Nodal")) {
-    layout = eval_on_side ? dl->node_scalar_sideset : dl->node_scalar;
+    layout = dl->node_scalar;
   } else {
-    layout = eval_on_side ? dl->qp_scalar_sideset : dl->qp_scalar;
+    layout = dl->qp_scalar;
   }
 
   numPts = layout->extent(1);

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyMeltingRate_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyMeltingRate_Def.hpp
@@ -22,8 +22,8 @@ HydrologyMeltingRate (const Teuchos::ParameterList& p,
   if (IsStokes) {
     TEUCHOS_TEST_FOR_EXCEPTION (!dl->isSideLayouts, Teuchos::Exceptions::InvalidParameter,
                                 "Error! The layout structure does not appear to be that of a side set.\n");
-    numQPs   = dl->qp_scalar_sideset->extent(1);
-    numNodes = dl->node_scalar_sideset->extent(1);
+    numQPs   = dl->qp_scalar->extent(1);
+    numNodes = dl->node_scalar->extent(1);
     sideSetName = p.get<std::string>("Side Set Name");
   } else {
     TEUCHOS_TEST_FOR_EXCEPTION (dl->isSideLayouts, Teuchos::Exceptions::InvalidParameter,
@@ -66,9 +66,9 @@ HydrologyMeltingRate (const Teuchos::ParameterList& p,
   nodal = p.isParameter("Nodal") ? p.get<bool>("Nodal") : false;
   Teuchos::RCP<PHX::DataLayout> layout;
   if (nodal) {
-    layout = IsStokes ? dl->node_scalar_sideset : dl->node_scalar;
+    layout = dl->node_scalar;
   } else {
-    layout = IsStokes ? dl->qp_scalar_sideset : dl->qp_scalar;
+    layout = dl->qp_scalar;
   }
 
   m = PHX::MDField<ScalarT>(p.get<std::string> ("Melting Rate Variable Name"),layout);

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyResidualCavitiesEqn_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyResidualCavitiesEqn_Def.hpp
@@ -35,8 +35,8 @@ HydrologyResidualCavitiesEqn (const Teuchos::ParameterList& p,
     TEUCHOS_TEST_FOR_EXCEPTION (!dl->isSideLayouts, Teuchos::Exceptions::InvalidParameter,
                                 "Error! The layout structure does not appear to be that of a side set.\n");
 
-    numNodes = dl->node_scalar_sideset->extent(1);
-    numQPs   = dl->qp_scalar_sideset->extent(1);
+    numNodes = dl->node_scalar->extent(1);
+    numQPs   = dl->qp_scalar->extent(1);
 
     sideSetName = p.get<std::string>("Side Set Name");
   } else {
@@ -113,12 +113,12 @@ HydrologyResidualCavitiesEqn (const Teuchos::ParameterList& p,
   nodal_equation = cav_eqn_params.isParameter("Nodal") ? cav_eqn_params.get<bool>("Nodal") : false;
   Teuchos::RCP<PHX::DataLayout> layout;
   if (nodal_equation) {
-    layout = IsStokes ? dl->node_scalar_sideset : dl->node_scalar;
+    layout = dl->node_scalar;
   } else {
-    layout = IsStokes ? dl->qp_scalar_sideset : dl->qp_scalar;
+    layout = dl->qp_scalar;
 
-    BF        = PHX::MDField<const RealType>(p.get<std::string> ("BF Name"), IsStokes ? dl->node_qp_scalar_sideset : dl->node_qp_scalar);
-    w_measure = PHX::MDField<const MeshScalarT>(p.get<std::string> ("Weighted Measure Name"), IsStokes ? dl->qp_scalar_sideset : dl->qp_scalar);
+    BF        = PHX::MDField<const RealType>(p.get<std::string> ("BF Name"), dl->node_qp_scalar);
+    w_measure = PHX::MDField<const MeshScalarT>(p.get<std::string> ("Weighted Measure Name"), dl->qp_scalar);
 
     this->addDependentField(BF);
     this->addDependentField(w_measure);
@@ -127,7 +127,7 @@ HydrologyResidualCavitiesEqn (const Teuchos::ParameterList& p,
   h            = PHX::MDField<const ScalarT>(p.get<std::string> ("Water Thickness Variable Name"),     layout);
   N            = PHX::MDField<const ScalarT>(p.get<std::string> ("Effective Pressure Variable Name"),  layout);
   u_b          = PHX::MDField<const IceScalarT>(p.get<std::string> ("Sliding Velocity Variable Name"), layout);
-  ice_softness = PHX::MDField<const TempScalarT>(p.get<std::string>("Ice Softness Variable Name"), IsStokes ? dl->cell_scalar2_sideset : dl->cell_scalar2);
+  ice_softness = PHX::MDField<const TempScalarT>(p.get<std::string>("Ice Softness Variable Name"), dl->cell_scalar2);
   this->addDependentField(h);
   this->addDependentField(N);
   if (use_melting) {

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyResidualTillStorageEqn_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyResidualTillStorageEqn_Def.hpp
@@ -16,11 +16,11 @@ template<typename EvalT, typename Traits>
 HydrologyResidualTillStorageEqn<EvalT, Traits>::
 HydrologyResidualTillStorageEqn (const Teuchos::ParameterList& p,
                           const Teuchos::RCP<Albany::Layouts>& dl) :
-  BF         (p.get<std::string> ("BF Name"), p.isParameter("Side Set Name") ? dl->node_qp_scalar_sideset : dl->node_qp_scalar),
-  w_measure  (p.get<std::string> ("Weighted Measure Name"), p.isParameter("Side Set Name") ? dl->qp_scalar_sideset : dl->qp_scalar),
-  omega      (p.get<std::string> ("Surface Water Input Variable Name"), p.isParameter("Side Set Name") ? dl->qp_scalar_sideset : dl->qp_scalar),
-  h_till_dot (p.get<std::string> ("Till Water Storage Dot Variable Name"), p.isParameter("Side Set Name") ? dl->qp_scalar_sideset : dl->qp_scalar),
-  residual   (p.get<std::string> ("Till Water Storage Eqn Residual Name"), p.isParameter("Side Set Name") ? dl->node_scalar_sideset : dl->node_scalar)
+  BF         (p.get<std::string> ("BF Name"), dl->node_qp_scalar),
+  w_measure  (p.get<std::string> ("Weighted Measure Name"), dl->qp_scalar),
+  omega      (p.get<std::string> ("Surface Water Input Variable Name"), dl->qp_scalar),
+  h_till_dot (p.get<std::string> ("Till Water Storage Dot Variable Name"), dl->qp_scalar),
+  residual   (p.get<std::string> ("Till Water Storage Eqn Residual Name"), dl->node_scalar)
 {
   // Check if it is a sideset evaluation
   eval_on_side = false;
@@ -31,8 +31,8 @@ HydrologyResidualTillStorageEqn (const Teuchos::ParameterList& p,
   TEUCHOS_TEST_FOR_EXCEPTION (eval_on_side!=dl->isSideLayouts, std::logic_error,
       "Error! Input Layouts structure not compatible with requested field layout.\n");
 
-  numNodes = eval_on_side ? dl->node_scalar->extent(2) : dl->node_scalar->extent(1);
-  numQPs   = eval_on_side ? dl->qp_scalar->extent(2)   : dl->qp_scalar->extent(1);
+  numNodes = dl->node_scalar->extent(1);
+  numQPs   = dl->qp_scalar->extent(1);
 
   this->addEvaluatedField(residual);
 
@@ -54,9 +54,9 @@ HydrologyResidualTillStorageEqn (const Teuchos::ParameterList& p,
 
   Teuchos::RCP<PHX::DataLayout> layout;
   if (mass_lumping) {
-    layout = eval_on_side ? dl->node_scalar_sideset : dl->node_scalar;
+    layout = dl->node_scalar;
   } else {
-    layout = eval_on_side ? dl->qp_scalar_sideset : dl->qp_scalar;
+    layout = dl->qp_scalar;
   }
 
   if (use_melting) {

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologySurfaceWaterInput_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologySurfaceWaterInput_Def.hpp
@@ -26,10 +26,10 @@ HydrologySurfaceWaterInput (const Teuchos::ParameterList& p,
   type = util::upper_case(type);
   if (type=="APPROXIMATE FROM SMB") {
     // Set omega=min(-smb,0);
-    smb = decltype(smb)(p.get<std::string> ("Surface Mass Balance Variable Name"), eval_on_side ? dl->node_scalar_sideset : dl->node_scalar);
+    smb = decltype(smb)(p.get<std::string> ("Surface Mass Balance Variable Name"), dl->node_scalar);
     this->addDependentField(smb);
 
-    omega = decltype(omega)(p.get<std::string> ("Surface Water Input Variable Name"), eval_on_side ? dl->node_scalar_sideset: dl->node_scalar);
+    omega = decltype(omega)(p.get<std::string> ("Surface Water Input Variable Name"), dl->node_scalar);
     this->addEvaluatedField(omega);
 
     input_type = InputType::SMB_APPROX;
@@ -44,7 +44,7 @@ HydrologySurfaceWaterInput (const Teuchos::ParameterList& p,
   // Get Dimensions
   if (eval_on_side) {
     sideSetName = p.get<std::string>("Side Set Name");
-    numNodes = dl->node_scalar->extent(2);
+    numNodes = dl->node_scalar->extent(1);
   } else {
     numNodes = dl->node_scalar->extent(1);
   }

--- a/src/LandIce/problems/LandIce_Enthalpy.cpp
+++ b/src/LandIce/problems/LandIce_Enthalpy.cpp
@@ -135,7 +135,7 @@ buildProblem(Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpecsStruct> >  meshSpec
 	           << ", SideNodes= " << numBasalSideNodes
 	           << ", SideQuadPts= " << numBasalSideQPs << std::endl;
 
-	      dl_basal = rcp(new Albany::Layouts(worksetSize,numBasalSideVertices,numBasalSideNodes,numBasalSideQPs,numDim-1,numDim,numCellSides,vecDim,true,basalMeshSpecs.singleWorksetSizeAllocation,basalMeshSpecs.worksetSize));
+	      dl_basal = rcp(new Albany::Layouts(worksetSize,numBasalSideVertices,numBasalSideNodes,numBasalSideQPs,numDim-1,numDim,numCellSides,vecDim,basalMeshSpecs.singleWorksetSizeAllocation,basalMeshSpecs.worksetSize));
 
 	      dl->side_layouts[basalSideName] = dl_basal;
 	  }

--- a/src/LandIce/problems/LandIce_Enthalpy.hpp
+++ b/src/LandIce/problems/LandIce_Enthalpy.hpp
@@ -230,7 +230,7 @@ LandIce::Enthalpy::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
     ev = Teuchos::rcp(new PHAL::LoadStateField<EvalT,PHAL::AlbanyTraits>(*p));
     fm0.template registerEvaluator<EvalT>(ev);
 
-    p = stateMgr.registerSideSetStateVariable(basalSideName, stateName, stateName, dl_basal->node_scalar_sideset, basalEBName, true, &entity, "", true);
+    p = stateMgr.registerSideSetStateVariable(basalSideName, stateName, stateName, dl_basal->node_scalar, basalEBName, true, &entity);
     ev = Teuchos::rcp(new PHAL::LoadSideSetStateField<EvalT,PHAL::AlbanyTraits>(*p));
     fm0.template registerEvaluator<EvalT>(ev);
   }
@@ -243,7 +243,7 @@ LandIce::Enthalpy::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
     ev = Teuchos::rcp(new PHAL::LoadStateField<EvalT,PHAL::AlbanyTraits>(*p));
     fm0.template registerEvaluator<EvalT>(ev);
 
-    p = stateMgr.registerSideSetStateVariable(basalSideName, stateName, stateName, dl_basal->node_scalar_sideset, basalEBName, true, &entity, "", true);
+    p = stateMgr.registerSideSetStateVariable(basalSideName, stateName, stateName, dl_basal->node_scalar, basalEBName, true, &entity);
     ev = Teuchos::rcp(new PHAL::LoadSideSetStateField<EvalT,PHAL::AlbanyTraits>(*p));
     fm0.template registerEvaluator<EvalT>(ev);
   }
@@ -269,7 +269,7 @@ LandIce::Enthalpy::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
     ev = Teuchos::rcp(new PHAL::LoadStateFieldMST<EvalT,PHAL::AlbanyTraits>(*p));
     fm0.template registerEvaluator<EvalT>(ev);
 
-    p = stateMgr.registerSideSetStateVariable(basalSideName, stateName, stateName, dl_basal->node_scalar_sideset, basalEBName, true, &entity, "", true);
+    p = stateMgr.registerSideSetStateVariable(basalSideName, stateName, stateName, dl_basal->node_scalar, basalEBName, true, &entity);
     ev = Teuchos::rcp(new PHAL::LoadSideSetStateFieldMST<EvalT,PHAL::AlbanyTraits>(*p));
     fm0.template registerEvaluator<EvalT>(ev);
   }
@@ -294,7 +294,7 @@ LandIce::Enthalpy::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
     fm0.template registerEvaluator<EvalT> (evalUtils.constructDOFGradInterpolationEvaluator(dof_names[0], offset));
 
     // --- Restrict enthalpy from cell-based to cell-side-based
-    fm0.template registerEvaluator<EvalT> (evalUtils.constructDOFCellToSideEvaluator(dof_names[0],basalSideName,"Node Scalar Sideset",cellType));
+    fm0.template registerEvaluator<EvalT> (evalUtils.constructDOFCellToSideEvaluator(dof_names[0],basalSideName,"Node Scalar",cellType));
 
     fm0.template registerEvaluator<EvalT> (evalUtils.constructDOFInterpolationSideEvaluator(dof_names[0], basalSideName));
   }
@@ -330,7 +330,7 @@ LandIce::Enthalpy::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
   // --- Special evaluators for side handling --- //
 
   // --- Restrict vertex coordinates from cell-based to cell-side-based
-  fm0.template registerEvaluator<EvalT> (evalUtils.getMSTUtils().constructDOFCellToSideEvaluator("Coord Vec",basalSideName,"Vertex Vector Sideset",cellType,
+  fm0.template registerEvaluator<EvalT> (evalUtils.getMSTUtils().constructDOFCellToSideEvaluator("Coord Vec",basalSideName,"Vertex Vector",cellType,
                                                                                                  "Coord Vec " + basalSideName));
 
   // --- Compute side basis functions
@@ -340,12 +340,12 @@ LandIce::Enthalpy::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
   fm0.template registerEvaluator<EvalT> (evalUtils.constructMapToPhysicalFrameSideEvaluator(cellType,basalCubature,basalSideName));
 
   // --- Restrict basal velocity from cell-based to cell-side-based
-  fm0.template registerEvaluator<EvalT> (evalUtils.getPSTUtils().constructDOFCellToSideEvaluator("velocity",basalSideName,"Node Vector Sideset",cellType));
+  fm0.template registerEvaluator<EvalT> (evalUtils.getPSTUtils().constructDOFCellToSideEvaluator("velocity",basalSideName,"Node Vector",cellType));
 
   fm0.template registerEvaluator<EvalT> (evalUtils.constructDOFInterpolationSideEvaluator("basal_dTdz", basalSideName));
 
   // --- Restrict enthalpy Hs from cell-based to cell-side-based
-  fm0.template registerEvaluator<EvalT> (evalUtils.getMSTUtils().constructDOFCellToSideEvaluator("melting enthalpy",basalSideName,"Node Scalar Sideset",cellType));
+  fm0.template registerEvaluator<EvalT> (evalUtils.getMSTUtils().constructDOFCellToSideEvaluator("melting enthalpy",basalSideName,"Node Scalar",cellType));
   fm0.template registerEvaluator<EvalT> (evalUtils.getMSTUtils().constructDOFInterpolationSideEvaluator("melting enthalpy", basalSideName));
 
   // --- Interpolate velocity on QP on side
@@ -360,7 +360,7 @@ LandIce::Enthalpy::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
   // --- Utilities for Basal Melt Rate
   //fm0.template registerEvaluator<EvalT> (evalUtils.getPSTUtils().constructDOFCellToSideEvaluator("melting temp",basalSideName,"Node Scalar",cellType));
 
-  fm0.template registerEvaluator<EvalT> (evalUtils.constructDOFCellToSideEvaluator("phi",basalSideName,"Node Scalar Sideset",cellType));
+  fm0.template registerEvaluator<EvalT> (evalUtils.constructDOFCellToSideEvaluator("phi",basalSideName,"Node Scalar",cellType));
   fm0.template registerEvaluator<EvalT> (evalUtils.constructDOFInterpolationSideEvaluator("phi",basalSideName));
 
   // --- Utilities for Geothermal flux

--- a/src/LandIce/problems/LandIce_Enthalpy.hpp
+++ b/src/LandIce/problems/LandIce_Enthalpy.hpp
@@ -179,7 +179,7 @@ LandIce::Enthalpy::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
         if(thisFieldList.get<std::string>("Field Name") ==  stateName){
           unsigned int numLayers = thisFieldList.get<int>("Number Of Layers");
           auto sns = dl_basal->node_vector;
-          auto dl_temp = Teuchos::rcp(new PHX::MDALayout<Cell,Side,Node,VecDim, LayerDim>(sns->extent(0),sns->extent(1),sns->extent(2),2, numLayers));
+          auto dl_temp = Teuchos::rcp(new PHX::MDALayout<Side,Node,VecDim, LayerDim>(sns->extent(0),sns->extent(1),2, numLayers));
           stateMgr.registerSideSetStateVariable(basalSideName, stateName, stateName, dl_temp, basalEBName, true, &entity);
         }
       }
@@ -205,7 +205,7 @@ LandIce::Enthalpy::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
         if(thisFieldList.get<std::string>("Field Name") ==  stateName){
           unsigned int numLayers = thisFieldList.get<int>("Number Of Layers");
           auto sns = dl_basal->node_vector;
-          auto dl_temp = Teuchos::rcp(new PHX::MDALayout<Cell,Side,Node,LayerDim>(sns->extent(0),sns->extent(1),sns->extent(2), numLayers));
+          auto dl_temp = Teuchos::rcp(new PHX::MDALayout<Side,Node,LayerDim>(sns->extent(0),sns->extent(1), numLayers));
           stateMgr.registerSideSetStateVariable(basalSideName, stateName, stateName, dl_temp, basalEBName, true, &entity);
         }
       }

--- a/src/LandIce/problems/LandIce_LaplacianSampling.cpp
+++ b/src/LandIce/problems/LandIce_LaplacianSampling.cpp
@@ -84,7 +84,7 @@ void LandIce::LaplacianSampling::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Al
     auto numSideQPs      = sideCubature->getNumPoints();
 
 
-    dl_side = rcp(new Albany::Layouts(worksetSize,numSideVertices,numSideNodes, numSideQPs,numDim-1,numDim,numCellSides,1,true,sideMeshSpecs.singleWorksetSizeAllocation,sideMeshSpecs.worksetSize));
+    dl_side = rcp(new Albany::Layouts(worksetSize,numSideVertices,numSideNodes, numSideQPs,numDim-1,numDim,numCellSides,1,sideMeshSpecs.singleWorksetSizeAllocation,sideMeshSpecs.worksetSize));
     dl->side_layouts[sideName] = dl_side;
   }
 

--- a/src/LandIce/problems/LandIce_LaplacianSampling.hpp
+++ b/src/LandIce/problems/LandIce_LaplacianSampling.hpp
@@ -190,7 +190,7 @@ LandIce::LaplacianSampling::constructEvaluators (PHX::FieldManager<PHAL::AlbanyT
 
   if(sideName != "INVALID") {
     //---- Restrict vertex coordinates from cell-based to cell-side-based
-    ev = evalUtils.getMSTUtils().constructDOFCellToSideEvaluator("Coord Vec",sideName,"Vertex Vector Sideset",cellType,"Coord Vec " + sideName);
+    ev = evalUtils.getMSTUtils().constructDOFCellToSideEvaluator("Coord Vec",sideName,"Vertex Vector",cellType,"Coord Vec " + sideName);
     fm0.template registerEvaluator<EvalT> (ev);
 
     ev = evalUtils.constructComputeBasisFunctionsSideEvaluator(cellType, sideBasis, sideCubature, sideName);

--- a/src/LandIce/problems/LandIce_ProblemUtils.cpp
+++ b/src/LandIce/problems/LandIce_ProblemUtils.cpp
@@ -11,56 +11,8 @@ extrudeSideLayout (const Teuchos::RCP<PHX::DataLayout>& in, const int numLayers)
 
   std::vector<std::string> names;
   in->names(names);
-  TEUCHOS_TEST_FOR_EXCEPTION(names[0]!="Cell" && names[1]!="Side", std::runtime_error,
-    "Error! A side layout must begin with <Cell,Side,...>.\n");
-
-  std::vector<PHX::DataLayout::size_type> dims;
-  in->dimensions(dims);
-  const int rank = in->rank();
-  switch (rank) {
-    case 2:
-      out = Teuchos::rcp(new PHX::MDALayout<Cell,Side,LayerDim>(dims[0],dims[1],numLayers));
-        break;
-    case 3:
-      if (names[2]=="Node") {
-        out = Teuchos::rcp(new PHX::MDALayout<Cell,Side,Node,LayerDim>(dims[0],dims[1],dims[2],numLayers));
-      } else if (names[2]=="Dim") {
-        out = Teuchos::rcp(new PHX::MDALayout<Cell,Side,Dim,LayerDim>(dims[0],dims[1],dims[2],numLayers));
-      } else if (names[2]=="VecDim") {
-        out = Teuchos::rcp(new PHX::MDALayout<Cell,Side,VecDim,LayerDim>(dims[0],dims[1],dims[2],numLayers));
-      } else {
-        TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
-          "Error! Unexpected value for names[2]: " + names[2] + ".\n");
-      }
-      break;
-    case 4:
-      if (names[2]=="Node" && names[3]=="VecDim") {
-          out = Teuchos::rcp(new PHX::MDALayout<Cell,Side,Node,VecDim,LayerDim>(dims[0],dims[1],dims[2],dims[3],numLayers));
-      } else if (names[2]=="Node" && names[3]=="Dim") {
-          out = Teuchos::rcp(new PHX::MDALayout<Cell,Side,Node,Dim,LayerDim>(dims[0],dims[1],dims[2],dims[3],numLayers));
-      } else if (names[2]=="Dim" && names[3]=="Dim") {
-        out = Teuchos::rcp(new PHX::MDALayout<Cell,Side,Dim,Dim,LayerDim>(dims[0],dims[1],dims[2],dims[3],numLayers));
-      } else {
-        TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
-          "Error! Unexpected value for names[2],names[3]: " + names[2] + ", " + names[3] + ".\n");
-      }
-      break;
-    default:
-      TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
-        "Error! Unexpected rank for input layout (" + std::to_string(rank) + ").\n");
-  }
-
-  return out;
-}
-
-Teuchos::RCP<PHX::DataLayout>
-extrudeCollapsedSideLayout (const Teuchos::RCP<PHX::DataLayout>& in, const int numLayers) {
-  Teuchos::RCP<PHX::DataLayout> out;
-
-  std::vector<std::string> names;
-  in->names(names);
   TEUCHOS_TEST_FOR_EXCEPTION(names[0]!="Side", std::runtime_error,
-    "Error! A collapsed side layout must begin with <Side,...>.\n");
+    "Error! A side layout must begin with <Side,...>.\n");
 
   std::vector<PHX::DataLayout::size_type> dims;
   in->dimensions(dims);

--- a/src/LandIce/problems/LandIce_ProblemUtils.hpp
+++ b/src/LandIce/problems/LandIce_ProblemUtils.hpp
@@ -452,9 +452,6 @@ createEvaluatorWithThreeScalarTypes (Teuchos::RCP<Teuchos::ParameterList> p,
 Teuchos::RCP<PHX::DataLayout>
 extrudeSideLayout (const Teuchos::RCP<PHX::DataLayout>& in, const int numLayers);
 
-Teuchos::RCP<PHX::DataLayout>
-extrudeCollapsedSideLayout (const Teuchos::RCP<PHX::DataLayout>& in, const int numLayers);
-
 } // namespace LandIce
 
 #endif // LANDICE_PROBLEM_UTILS_HPP

--- a/src/LandIce/problems/LandIce_StokesFO.cpp
+++ b/src/LandIce/problems/LandIce_StokesFO.cpp
@@ -26,7 +26,7 @@ StokesFO( const Teuchos::RCP<Teuchos::ParameterList>& params_,
           const Teuchos::RCP<Teuchos::ParameterList>& discParams_,
           const Teuchos::RCP<ParamLib>& paramLib_,
           const int numDim_) :
-  StokesFOBase(params_, discParams_, paramLib_, numDim_, true)
+  StokesFOBase(params_, discParams_, paramLib_, numDim_)
 {
   //Set # of PDEs per node based on the Equation Set.
   //Equation Set is LandIce by default (2 dofs / node -- usual LandIce Stokes FO).

--- a/src/LandIce/problems/LandIce_StokesFOBase.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.cpp
@@ -11,12 +11,10 @@ StokesFOBase::
 StokesFOBase (const Teuchos::RCP<Teuchos::ParameterList>& params_,
                         const Teuchos::RCP<Teuchos::ParameterList>& discParams_,
                         const Teuchos::RCP<ParamLib>& paramLib_,
-                        const int numDim_,
-                        const bool useCollapsedSidesets_)
+                        const int numDim_)
  : Albany::AbstractProblem(params_, paramLib_, numDim_) 
  , discParams (discParams_)
  , numDim(numDim_)
- , useCollapsedSidesets(useCollapsedSidesets_)
  , use_sdbcs_(false)
  , params(params_)
 {
@@ -164,7 +162,7 @@ void StokesFOBase::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpec
 
       dl->side_layouts[ssName] = rcp(new Albany::Layouts(worksetSize,numSideVertices,numSideNodes,
                                                          numSideQPs,sideDim,numDim,numCellSides,vecDimFO,
-                                                         useCollapsedSidesets,sideMeshSpecs.singleWorksetSizeAllocation,
+                                                         sideMeshSpecs.singleWorksetSizeAllocation,
                                                          sideMeshSpecs.worksetSize));
     }
   }
@@ -190,7 +188,7 @@ void StokesFOBase::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpec
 
     dl->side_layouts[surfaceSideName] = rcp(new Albany::Layouts(worksetSize,numSurfaceSideVertices,numSurfaceSideNodes,
                                                                 numSurfaceSideQPs,sideDim,numDim,numCellSides,vecDimFO,
-                                                                useCollapsedSidesets,surfaceMeshSpecs.singleWorksetSizeAllocation,
+                                                                surfaceMeshSpecs.singleWorksetSizeAllocation,
                                                                 surfaceMeshSpecs.worksetSize));
   }
 
@@ -215,7 +213,7 @@ void StokesFOBase::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpec
 
     dl->side_layouts[basalSideName] = rcp(new Albany::Layouts(worksetSize,numbasalSideVertices,numbasalSideNodes,
                                                               numbasalSideQPs,sideDim,numDim,numCellSides,vecDimFO,
-                                                              useCollapsedSidesets,basalMeshSpecs.singleWorksetSizeAllocation,
+                                                              basalMeshSpecs.singleWorksetSizeAllocation,
                                                               basalMeshSpecs.worksetSize));
   }
 

--- a/src/LandIce/problems/LandIce_StokesFOBase.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.hpp
@@ -492,20 +492,20 @@ constructStatesEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
       // Get data layout
       if (rank == FRT::Scalar) {
         state_dl = loc == FL::Node
-                 ? ss_dl->node_scalar)
-                 : ss_dl->cell_scalar2);
+                 ? ss_dl->node_scalar
+                 : ss_dl->cell_scalar2;
       } else if (rank == FRT::Vector) {
         state_dl = loc == FL::Node
-                 ? ss_dl->node_vector)
-                 : ss_dl->cell_vector);
+                 ? ss_dl->node_vector
+                 : ss_dl->cell_vector;
       } else if (rank == FRT::Gradient) {
         state_dl = loc == FL::Node
-                 ? ss_dl->node_gradient)
-                 : ss_dl->cell_gradient);
+                 ? ss_dl->node_gradient
+                 : ss_dl->cell_gradient;
       } else if (rank == FRT::Tensor) {
         state_dl = loc == FL::Node
-                 ? ss_dl->node_tensor)
-                 : ss_dl->cell_tensor);
+                 ? ss_dl->node_tensor
+                 : ss_dl->cell_tensor;
       }
 
       // If layered, extend the layout

--- a/src/LandIce/problems/LandIce_StokesFOBase.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.hpp
@@ -94,8 +94,7 @@ protected:
   StokesFOBase (const Teuchos::RCP<Teuchos::ParameterList>& params_,
                 const Teuchos::RCP<Teuchos::ParameterList>& discParams_,
                 const Teuchos::RCP<ParamLib>& paramLib_,
-                const int numDim_,
-                const bool useCollapsedSidesets_ = false);
+                const int numDim_);
 
   template <typename EvalT>
   void constructStokesFOBaseEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
@@ -215,9 +214,6 @@ protected:
 
   unsigned int numDim;
   unsigned int vecDimFO;
-
-  /// Temporary boolean so that sideset refactor doesn't break coupled problems
-  bool useCollapsedSidesets;
 
   /// Boolean marking whether SDBCs are used
   bool use_sdbcs_;
@@ -496,28 +492,26 @@ constructStatesEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
       // Get data layout
       if (rank == FRT::Scalar) {
         state_dl = loc == FL::Node
-                 ? (useCollapsedSidesets ? ss_dl->node_scalar_sideset : ss_dl->node_scalar)
-                 : (useCollapsedSidesets ? ss_dl->cell_scalar2_sideset : ss_dl->cell_scalar2);
+                 ? ss_dl->node_scalar)
+                 : ss_dl->cell_scalar2);
       } else if (rank == FRT::Vector) {
         state_dl = loc == FL::Node
-                 ? (useCollapsedSidesets ? ss_dl->node_vector_sideset : ss_dl->node_vector)
-                 : (useCollapsedSidesets ? ss_dl->cell_vector_sideset : ss_dl->cell_vector);
+                 ? ss_dl->node_vector)
+                 : ss_dl->cell_vector);
       } else if (rank == FRT::Gradient) {
         state_dl = loc == FL::Node
-                 ? (useCollapsedSidesets ? ss_dl->node_gradient_sideset : ss_dl->node_gradient)
-                 : (useCollapsedSidesets ? ss_dl->cell_gradient_sideset : ss_dl->cell_gradient);
+                 ? ss_dl->node_gradient)
+                 : ss_dl->cell_gradient);
       } else if (rank == FRT::Tensor) {
         state_dl = loc == FL::Node
-                 ? (useCollapsedSidesets ? ss_dl->node_tensor_sideset : ss_dl->node_tensor)
-                 : (useCollapsedSidesets ? ss_dl->cell_tensor_sideset : ss_dl->cell_tensor);
+                 ? ss_dl->node_tensor)
+                 : ss_dl->cell_tensor);
       }
 
       // If layered, extend the layout
       if(fieldType.find("Layered")!=std::string::npos) {
         numLayers = thisFieldList.get<int>("Number Of Layers");
-        state_dl = useCollapsedSidesets
-                 ? extrudeCollapsedSideLayout(state_dl,numLayers)
-                 : extrudeSideLayout(state_dl,numLayers);
+        state_dl = extrudeSideLayout(state_dl,numLayers);
       }
 
       // Set entity for state struct
@@ -532,7 +526,7 @@ constructStatesEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
       }
 
       // Register the state
-      p = stateMgr.registerSideSetStateVariable(ss_name, stateName, fieldName, state_dl, sideEBName, true, &entity, meshPart, useCollapsedSidesets);
+      p = stateMgr.registerSideSetStateVariable(ss_name, stateName, fieldName, state_dl, sideEBName, true, &entity, meshPart);
 
       // Create load/save evaluator(s)
       // Note:
@@ -767,19 +761,19 @@ constructInterpolationEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0)
       if ( needs[IReq::CELL_TO_SIDE] ) {
         if (!is_available_2d(FL::Node) && is_available_3d(FL::Node)) {
           // Project from cell to side
-          const std::string layout = e2str(FL::Node) + " " + e2str(rank) + " Sideset";
+          const std::string layout = e2str(FL::Node) + " " + e2str(rank);
           ev = utils.constructDOFCellToSideEvaluator(fname, ss_name, layout, cellType, fname_side);
           fm0.template registerEvaluator<EvalT> (ev);
         }
         // For loc==Cell, if the cell field was computed via CellAverage, the st should be st_mst
         if (!is_available_2d(FL::Cell) && is_available_3d(FL::Cell)) {
           // Project from cell to side
-          const std::string layout = e2str(FL::Cell) + " " + e2str(rank) + " Sideset";
+          const std::string layout = e2str(FL::Cell) + " " + e2str(rank);
           ev = utils.constructDOFCellToSideEvaluator(fname, ss_name, layout, cellType, fname_side);
           fm0.template registerEvaluator<EvalT> (ev);
         } else if (!is_available_2d_mst(FL::Cell) && is_available_3d_mst(FL::Cell)) {
           // Project from cell to side
-          const std::string layout = e2str(FL::Cell) + " " + e2str(rank) + " Sideset";
+          const std::string layout = e2str(FL::Cell) + " " + e2str(rank);
           ev = utils_mst.constructDOFCellToSideEvaluator(fname, ss_name, layout, cellType, fname_side);
           fm0.template registerEvaluator<EvalT> (ev);
         }
@@ -863,11 +857,7 @@ constructSideUtilityFields (PHX::FieldManager<PHAL::AlbanyTraits>& fm0)
 
     // If any of the above was true, we need coordinates of vertices on the side
     if (it.second[UtilityRequest::BFS] || it.second[UtilityRequest::QP_COORDS] || it.second[UtilityRequest::NORMALS]) {
-      if (useCollapsedSidesets) {
-        ev = evalUtils.getMSTUtils().constructDOFCellToSideEvaluator(Albany::coord_vec_name,ss_name,"Vertex Vector Sideset",cellType,Albany::coord_vec_name +" " + ss_name);
-      } else {
-        ev = evalUtils.getMSTUtils().constructDOFCellToSideEvaluator(Albany::coord_vec_name,ss_name,"Vertex Vector",cellType,Albany::coord_vec_name +" " + ss_name);
-      }
+      ev = evalUtils.getMSTUtils().constructDOFCellToSideEvaluator(Albany::coord_vec_name,ss_name,"Vertex Vector",cellType,Albany::coord_vec_name +" " + ss_name);
       fm0.template registerEvaluator<EvalT> (ev);
     }
   }
@@ -1655,39 +1645,21 @@ is_available (const PHX::FieldManager<PHAL::AlbanyTraits>& fm,
   // Helper map
   std::map<FRT,std::map<FL,lt_ptr>> map;
 
-  if (layouts->isSideLayouts && layouts->useCollapsedSidesets) {
-    map[FRT::Scalar][FL::Node]      = layouts->node_scalar_sideset;
-    map[FRT::Scalar][FL::Cell]      = layouts->cell_scalar2_sideset;
-    map[FRT::Scalar][FL::QuadPoint] = layouts->qp_scalar_sideset;
+  map[FRT::Scalar][FL::Node]      = layouts->node_scalar;
+  map[FRT::Scalar][FL::Cell]      = layouts->cell_scalar2;
+  map[FRT::Scalar][FL::QuadPoint] = layouts->qp_scalar;
 
-    map[FRT::Vector][FL::Node]      = layouts->node_vector_sideset;
-    map[FRT::Vector][FL::Cell]      = layouts->cell_vector_sideset;
-    map[FRT::Vector][FL::QuadPoint] = layouts->qp_vector_sideset;
+  map[FRT::Vector][FL::Node]      = layouts->node_vector;
+  map[FRT::Vector][FL::Cell]      = layouts->cell_vector;
+  map[FRT::Vector][FL::QuadPoint] = layouts->qp_vector;
 
-    map[FRT::Gradient][FL::Node]      = layouts->node_gradient_sideset;
-    map[FRT::Gradient][FL::Cell]      = layouts->cell_gradient_sideset;
-    map[FRT::Gradient][FL::QuadPoint] = layouts->qp_gradient_sideset;
+  map[FRT::Gradient][FL::Node]      = layouts->node_gradient;
+  map[FRT::Gradient][FL::Cell]      = layouts->cell_gradient;
+  map[FRT::Gradient][FL::QuadPoint] = layouts->qp_gradient;
 
-    map[FRT::Tensor][FL::Node]      = layouts->node_tensor_sideset;
-    map[FRT::Tensor][FL::Cell]      = layouts->cell_tensor_sideset;
-    map[FRT::Tensor][FL::QuadPoint] = layouts->qp_tensor_sideset;
-  } else {
-    map[FRT::Scalar][FL::Node]      = layouts->node_scalar;
-    map[FRT::Scalar][FL::Cell]      = layouts->cell_scalar2;
-    map[FRT::Scalar][FL::QuadPoint] = layouts->qp_scalar;
-
-    map[FRT::Vector][FL::Node]      = layouts->node_vector;
-    map[FRT::Vector][FL::Cell]      = layouts->cell_vector;
-    map[FRT::Vector][FL::QuadPoint] = layouts->qp_vector;
-
-    map[FRT::Gradient][FL::Node]      = layouts->node_gradient;
-    map[FRT::Gradient][FL::Cell]      = layouts->cell_gradient;
-    map[FRT::Gradient][FL::QuadPoint] = layouts->qp_gradient;
-
-    map[FRT::Tensor][FL::Node]      = layouts->node_tensor;
-    map[FRT::Tensor][FL::Cell]      = layouts->cell_tensor;
-    map[FRT::Tensor][FL::QuadPoint] = layouts->qp_tensor;
-  }
+  map[FRT::Tensor][FL::Node]      = layouts->node_tensor;
+  map[FRT::Tensor][FL::Cell]      = layouts->cell_tensor;
+  map[FRT::Tensor][FL::QuadPoint] = layouts->qp_tensor;
 
   auto lt = map.at(rank).at(loc);
 

--- a/src/LandIce/problems/LandIce_StokesFOThermoCoupled.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOThermoCoupled.cpp
@@ -24,7 +24,7 @@ StokesFOThermoCoupled( const Teuchos::RCP<Teuchos::ParameterList>& params_,
                        const Teuchos::RCP<Teuchos::ParameterList>& discParams_,
                        const Teuchos::RCP<ParamLib>& paramLib_,
                        const int numDim_) :
-  StokesFOBase(params_, discParams_, paramLib_, numDim_, true)
+  StokesFOBase(params_, discParams_, paramLib_, numDim_)
 {
   fluxDivIsPartOfSolution = params->isSublist("LandIce Flux Divergence") &&
       params->sublist("LandIce Flux Divergence").get<bool>("Flux Divergence Is Part Of Solution");

--- a/src/LandIce/problems/LandIce_StokesFOThickness.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOThickness.cpp
@@ -22,7 +22,7 @@ StokesFOThickness::StokesFOThickness(
             const Teuchos::RCP<Teuchos::ParameterList>& discParams_,
             const Teuchos::RCP<ParamLib>& paramLib_,
             const int numDim_) :
-  StokesFOBase(params_, discParams_, paramLib_, numDim_, true)
+  StokesFOBase(params_, discParams_, paramLib_, numDim_)
 {
   //Set # of PDEs per node.
   std::string eqnSet = params_->sublist("Equation Set").get<std::string>("Type", "LandIce");

--- a/src/evaluators/gather/PHAL_GatherSolutionSide_Def.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolutionSide_Def.hpp
@@ -36,13 +36,13 @@ GatherSolutionSide(const Teuchos::ParameterList& p,
 
     if (!names.is_null()) {
       if (is_dof_vec) {
-          valvec = PHX::MDField<ScalarT,Side,Node,VecDim> (names[0],dl->node_scalar_sideset);
+          valvec = PHX::MDField<ScalarT,Side,Node,VecDim> (names[0],dl->node_scalar);
           this->addEvaluatedField(valvec);
       } else {
         numFields = names.size();
         val.resize(numFields);
         for (int eq=0; eq<numFields; ++eq) {
-          val[eq] = PHX::MDField<ScalarT,Side,Node> (names[eq],dl->node_scalar_sideset);
+          val[eq] = PHX::MDField<ScalarT,Side,Node> (names[eq],dl->node_scalar);
           this->addEvaluatedField(val[eq]);
         }
       }
@@ -63,13 +63,13 @@ GatherSolutionSide(const Teuchos::ParameterList& p,
 
     if (!names_dot.is_null()) {
       if (is_dof_dot_vec) {
-          valvec_dot = PHX::MDField<ScalarT,Side,Node,VecDim> (names_dot[0],dl->node_scalar_sideset);
+          valvec_dot = PHX::MDField<ScalarT,Side,Node,VecDim> (names_dot[0],dl->node_scalar);
           this->addEvaluatedField(valvec_dot);
       } else {
         numFields = names_dot.size();
         val_dot.resize(numFields);
         for (int eq=0; eq<numFields; ++eq) {
-          val_dot[eq] = PHX::MDField<ScalarT,Side,Node> (names_dot[eq],dl->node_scalar_sideset);
+          val_dot[eq] = PHX::MDField<ScalarT,Side,Node> (names_dot[eq],dl->node_scalar);
           this->addEvaluatedField(val_dot[eq]);
         }
       }
@@ -90,13 +90,13 @@ GatherSolutionSide(const Teuchos::ParameterList& p,
 
     if (!names_dotdot.is_null()) {
       if (is_dof_dotdot_vec) {
-          valvec_dotdot = PHX::MDField<ScalarT,Side,Node,VecDim> (names_dotdot[0],dl->node_scalar_sideset);
+          valvec_dotdot = PHX::MDField<ScalarT,Side,Node,VecDim> (names_dotdot[0],dl->node_scalar);
           this->addEvaluatedField(valvec_dotdot);
       } else {
         numFields = names_dotdot.size();
         val_dot.resize(numFields);
         for (int eq=0; eq<numFields; ++eq) {
-          val_dot[eq] = PHX::MDField<ScalarT,Side,Node> (names_dotdot[eq],dl->node_scalar_sideset);
+          val_dot[eq] = PHX::MDField<ScalarT,Side,Node> (names_dotdot[eq],dl->node_scalar);
           this->addEvaluatedField(val_dot[eq]);
         }
       }

--- a/src/evaluators/interpolation/PHAL_DOFCellToSide.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFCellToSide.hpp
@@ -54,20 +54,15 @@ private:
   //! Values on side
   PHX::MDField<ScalarT> val_side;
 
-  // TODO: Need to update collapsed layouts and add kernels for remaining layout types when removing non-collapsed layouts
   enum LayoutType
   {
     CELL_SCALAR = 1,
-    CELL_SCALAR_SIDESET,
     CELL_VECTOR,
     CELL_TENSOR,
     NODE_SCALAR,
-    NODE_SCALAR_SIDESET,
     NODE_VECTOR,
-    NODE_VECTOR_SIDESET,
     NODE_TENSOR,
-    VERTEX_VECTOR,
-    VERTEX_VECTOR_SIDESET
+    VERTEX_VECTOR
   };
 
   LayoutType layout;
@@ -79,24 +74,12 @@ private:
 public:
 
   typedef Kokkos::View<int***, PHX::Device>::execution_space ExecutionSpace;
-  struct CellScalarSideset_Tag{};
-  struct NodeScalarSideset_Tag{};
-  struct NodeVectorSideset_Tag{};
-  struct VertexVectorSideset_Tag{};
+  struct CellToSide_Tag{};
 
-  typedef Kokkos::RangePolicy<ExecutionSpace, CellScalarSideset_Tag> CellScalarSideset_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace, NodeScalarSideset_Tag> NodeScalarSideset_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace, NodeVectorSideset_Tag> NodeVectorSideset_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace, VertexVectorSideset_Tag> VertexVectorSideset_Policy;
+  typedef Kokkos::RangePolicy<ExecutionSpace, CellToSide_Tag> CellToSide_Policy;
 
   KOKKOS_INLINE_FUNCTION
-  void operator() (const CellScalarSideset_Tag& tag, const int& sideSet_idx) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const NodeScalarSideset_Tag& tag, const int& sideSet_idx) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const NodeVectorSideset_Tag& tag, const int& sideSet_idx) const;
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const VertexVectorSideset_Tag& tag, const int& sideSet_idx) const;
+  void operator() (const CellToSide_Tag& tag, const int& sideSet_idx) const;
 
 };
 

--- a/src/evaluators/interpolation/PHAL_DOFCellToSide_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFCellToSide_Def.hpp
@@ -135,38 +135,30 @@ KOKKOS_INLINE_FUNCTION
 void DOFCellToSideBase<EvalT, Traits, ScalarT>::
 operator() (const CellToSide_Tag&, const int& sideSet_idx) const {
 
+  // Get the local data of side and cell
+  const int cell = sideSet.elem_LID(sideSet_idx);
+  const int side = sideSet.side_local_id(sideSet_idx);
+
   switch (layout)
   {
     case CELL_SCALAR:
-      // Get the local data of cell
-      const int cell = sideSet.elem_LID(sideSet_idx);
       val_side(sideSet_idx) = val_cell(cell);
       break;
-    case CELL_VECTOR:
-      // Get the local data of cell
-      const int cell = sideSet.elem_LID(sideSet_idx);      
+    case CELL_VECTOR:    
       for (int i=0; i<dimsArray[1]; ++i)
         val_side(sideSet_idx,i) = val_cell(cell,i);
       break;
     case CELL_TENSOR:
-      // Get the local data of cell
-      const int cell = sideSet.elem_LID(sideSet_idx);
       for (int i=0; i<dimsArray[1]; ++i)
         for (int j=0; j<dimsArray[2]; ++j)
           val_side(sideSet_idx,i,j) = val_cell(cell,i,j);
       break;
     case NODE_SCALAR:
-      // Get the local data of side and cell
-      const int cell = sideSet.elem_LID(sideSet_idx);
-      const int side = sideSet.side_local_id(sideSet_idx);
       for (int node=0; node<dimsArray[1]; ++node) {
         val_side(sideSet_idx,node) = val_cell(cell,sideNodes(side,node));
       }
       break;
     case NODE_VECTOR:
-      // Get the local data of side and cell
-      const int cell = sideSet.elem_LID(sideSet_idx);
-      const int side = sideSet.side_local_id(sideSet_idx);
       for (int node=0; node<dimsArray[1]; ++node) {
         for (int i=0; i<dimsArray[2]; ++i) {
           val_side(sideSet_idx,node,i) = val_cell(cell,sideNodes(side,node),i);
@@ -174,18 +166,12 @@ operator() (const CellToSide_Tag&, const int& sideSet_idx) const {
       }
       break;
     case NODE_TENSOR:
-      // Get the local data of side and cell
-      const int cell = sideSet.elem_LID(sideSet_idx);
-      const int side = sideSet.side_local_id(sideSet_idx);
       for (int node=0; node<dimsArray[1]; ++node)
         for (int i=0; i<dimsArray[2]; ++i)
           for (int j=0; j<dimsArray[3]; ++j)
             val_side(sideSet_idx,node,i,j) = val_cell(cell,sideNodes(side,node),i,j);
       break;
     case VERTEX_VECTOR:
-      // Get the local data of side and cell
-      const int cell = sideSet.elem_LID(sideSet_idx);
-      const int side = sideSet.side_local_id(sideSet_idx);
       for (int node=0; node<dimsArray[1]; ++node) {
         for (int i=0; i<dimsArray[2]; ++i) {
           val_side(sideSet_idx,node,i) = val_cell(cell,sideNodes(side,node),i);

--- a/src/evaluators/interpolation/PHAL_DOFCellToSide_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFCellToSide_Def.hpp
@@ -33,13 +33,6 @@ DOFCellToSideBase(const Teuchos::ParameterList& p,
 
     layout = CELL_SCALAR;
   }
-  else if (layout_str =="Cell Scalar Sideset")
-  {
-    val_cell = decltype(val_cell)(cell_field_name, dl->cell_scalar2);
-    val_side = decltype(val_side)(side_field_name, dl_side->cell_scalar2_sideset);
-
-    layout = CELL_SCALAR_SIDESET;
-  }
   else if (layout_str=="Cell Vector")
   {
     val_cell = decltype(val_cell)(cell_field_name, dl->cell_vector);
@@ -61,26 +54,12 @@ DOFCellToSideBase(const Teuchos::ParameterList& p,
 
     layout = NODE_SCALAR;
   }
-  else if (layout_str=="Node Scalar Sideset")
-  {
-    val_cell = decltype(val_cell)(cell_field_name, dl->node_scalar);
-    val_side = decltype(val_side)(side_field_name, dl_side->node_scalar_sideset);
-
-    layout = NODE_SCALAR_SIDESET;
-  }
   else if (layout_str=="Node Vector")
   {
     val_cell = decltype(val_cell)(cell_field_name, dl->node_vector);
     val_side = decltype(val_side)(side_field_name, dl_side->node_vector);
 
     layout = NODE_VECTOR;
-  }
-  else if (layout_str=="Node Vector Sideset")
-  {
-    val_cell = decltype(val_cell)(cell_field_name, dl->node_vector);
-    val_side = decltype(val_side)(side_field_name, dl_side->node_vector_sideset);
-
-    layout = NODE_VECTOR_SIDESET;
   }
   else if (layout_str=="Node Tensor")
   {
@@ -96,13 +75,6 @@ DOFCellToSideBase(const Teuchos::ParameterList& p,
 
     layout = VERTEX_VECTOR;
   }
-  else if (layout_str=="Vertex Vector Sideset")
-  {
-    val_cell = decltype(val_cell)(cell_field_name, dl->vertices_vector);
-    val_side = decltype(val_side)(side_field_name, dl_side->vertices_vector_sideset);
-
-    layout = VERTEX_VECTOR_SIDESET;
-  }
   else
   {
     TEUCHOS_TEST_FOR_EXCEPTION (true, Teuchos::Exceptions::InvalidParameter, "Error! Invalid field layout. (" + layout_str + ")\n");
@@ -113,7 +85,7 @@ DOFCellToSideBase(const Teuchos::ParameterList& p,
 
   this->setName("DOFCellToSide(" + cell_field_name + " -> " + side_field_name + ")[" + layout_str + "]" + PHX::print<EvalT>());
 
-  if (layout==NODE_SCALAR || layout==NODE_SCALAR_SIDESET || layout==NODE_VECTOR || layout==NODE_VECTOR_SIDESET || layout==NODE_TENSOR || layout==VERTEX_VECTOR || layout==VERTEX_VECTOR_SIDESET)
+  if (layout==NODE_SCALAR || layout==NODE_VECTOR || layout==NODE_TENSOR || layout==VERTEX_VECTOR)
   {
     Teuchos::RCP<shards::CellTopology> cellType;
     cellType = p.get<Teuchos::RCP <shards::CellTopology> > ("Cell Type");
@@ -161,60 +133,67 @@ postRegistrationSetup(typename Traits::SetupData d,
 template<typename EvalT, typename Traits, typename ScalarT>
 KOKKOS_INLINE_FUNCTION
 void DOFCellToSideBase<EvalT, Traits, ScalarT>::
-operator() (const CellScalarSideset_Tag&, const int& sideSet_idx) const {
-  
-  // Get the local data of side and cell
-  const int cell = sideSet.elem_LID(sideSet_idx);
+operator() (const CellToSide_Tag&, const int& sideSet_idx) const {
 
-  val_side(sideSet_idx) = val_cell(cell);
-
-}
-
-template<typename EvalT, typename Traits, typename ScalarT>
-KOKKOS_INLINE_FUNCTION
-void DOFCellToSideBase<EvalT, Traits, ScalarT>::
-operator() (const NodeScalarSideset_Tag&, const int& sideSet_idx) const {
-
-  // Get the local data of side and cell
-  const int cell = sideSet.elem_LID(sideSet_idx);
-  const int side = sideSet.side_local_id(sideSet_idx);
-
-  for (int node=0; node<dimsArray[1]; ++node) {
-    val_side(sideSet_idx,node) = val_cell(cell,sideNodes(side,node));
-  }
-
-}
-
-template<typename EvalT, typename Traits, typename ScalarT>
-KOKKOS_INLINE_FUNCTION
-void DOFCellToSideBase<EvalT, Traits, ScalarT>::
-operator() (const NodeVectorSideset_Tag&, const int& sideSet_idx) const {
-
-  // Get the local data of side and cell
-  const int cell = sideSet.elem_LID(sideSet_idx);
-  const int side = sideSet.side_local_id(sideSet_idx);
-
-  for (int node=0; node<dimsArray[1]; ++node) {
-    for (int i=0; i<dimsArray[2]; ++i) {
-      val_side(sideSet_idx,node,i) = val_cell(cell,sideNodes(side,node),i);
-    }
-  }
-
-}
-
-template<typename EvalT, typename Traits, typename ScalarT>
-KOKKOS_INLINE_FUNCTION
-void DOFCellToSideBase<EvalT, Traits, ScalarT>::
-operator() (const VertexVectorSideset_Tag&, const int& sideSet_idx) const {
-
-  // Get the local data of side and cell
-  const int cell = sideSet.elem_LID(sideSet_idx);
-  const int side = sideSet.side_local_id(sideSet_idx);
-
-  for (int node=0; node<dimsArray[1]; ++node) {
-    for (int i=0; i<dimsArray[2]; ++i) {
-      val_side(sideSet_idx,node,i) = val_cell(cell,sideNodes(side,node),i);
-    }
+  switch (layout)
+  {
+    case CELL_SCALAR:
+      // Get the local data of cell
+      const int cell = sideSet.elem_LID(sideSet_idx);
+      val_side(sideSet_idx) = val_cell(cell);
+      break;
+    case CELL_VECTOR:
+      // Get the local data of cell
+      const int cell = sideSet.elem_LID(sideSet_idx);      
+      for (int i=0; i<dimsArray[1]; ++i)
+        val_side(sideSet_idx,i) = val_cell(cell,i);
+      break;
+    case CELL_TENSOR:
+      // Get the local data of cell
+      const int cell = sideSet.elem_LID(sideSet_idx);
+      for (int i=0; i<dimsArray[1]; ++i)
+        for (int j=0; j<dimsArray[2]; ++j)
+          val_side(sideSet_idx,i,j) = val_cell(cell,i,j);
+      break;
+    case NODE_SCALAR:
+      // Get the local data of side and cell
+      const int cell = sideSet.elem_LID(sideSet_idx);
+      const int side = sideSet.side_local_id(sideSet_idx);
+      for (int node=0; node<dimsArray[1]; ++node) {
+        val_side(sideSet_idx,node) = val_cell(cell,sideNodes(side,node));
+      }
+      break;
+    case NODE_VECTOR:
+      // Get the local data of side and cell
+      const int cell = sideSet.elem_LID(sideSet_idx);
+      const int side = sideSet.side_local_id(sideSet_idx);
+      for (int node=0; node<dimsArray[1]; ++node) {
+        for (int i=0; i<dimsArray[2]; ++i) {
+          val_side(sideSet_idx,node,i) = val_cell(cell,sideNodes(side,node),i);
+        }
+      }
+      break;
+    case NODE_TENSOR:
+      // Get the local data of side and cell
+      const int cell = sideSet.elem_LID(sideSet_idx);
+      const int side = sideSet.side_local_id(sideSet_idx);
+      for (int node=0; node<dimsArray[1]; ++node)
+        for (int i=0; i<dimsArray[2]; ++i)
+          for (int j=0; j<dimsArray[3]; ++j)
+            val_side(sideSet_idx,node,i,j) = val_cell(cell,sideNodes(side,node),i,j);
+      break;
+    case VERTEX_VECTOR:
+      // Get the local data of side and cell
+      const int cell = sideSet.elem_LID(sideSet_idx);
+      const int side = sideSet.side_local_id(sideSet_idx);
+      for (int node=0; node<dimsArray[1]; ++node) {
+        for (int i=0; i<dimsArray[2]; ++i) {
+          val_side(sideSet_idx,node,i) = val_cell(cell,sideNodes(side,node),i);
+        }
+      }
+      break;
+    default:
+      TEUCHOS_TEST_FOR_EXCEPTION (true, std::logic_error, "Error! Invalid layout (this error should have happened earlier though).\n");
   }
 
 }
@@ -229,104 +208,7 @@ evaluateFields(typename Traits::EvalData workset)
 
   sideSet = workset.sideSetViews->at(sideSetName);
 
-  switch (layout)
-  {
-    case CELL_SCALAR:
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the local data of side and cell
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
-
-        val_side(cell,side) = val_cell(cell);
-      }
-      break;
-    case CELL_SCALAR_SIDESET:
-      Kokkos::parallel_for(CellScalarSideset_Policy(0, sideSet.size), *this);
-      break;
-    case CELL_VECTOR:
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the local data of side and cell
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
-        
-        for (int i=0; i<dims[2]; ++i)
-          val_side(cell,side,i) = val_cell(cell,i);
-      }
-      break;
-    case CELL_TENSOR:
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the local data of side and cell
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
-        
-        for (int i=0; i<dims[2]; ++i)
-          for (int j=0; j<dims[3]; ++j)
-            val_side(cell,side,i,j) = val_cell(cell,i,j);
-      }
-      break;
-    case NODE_SCALAR:
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the local data of side and cell
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
-        
-        for (int node=0; node<dims[2]; ++node)
-          val_side(cell,side,node) = val_cell(cell,sideNodes(side,node));
-      }
-      break;
-    case NODE_SCALAR_SIDESET:
-      Kokkos::parallel_for(NodeScalarSideset_Policy(0, sideSet.size), *this);
-      break;
-    case NODE_VECTOR:
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the local data of side and cell
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
-        
-        for (int node=0; node<dims[2]; ++node)
-          for (int i=0; i<dims[3]; ++i)
-            val_side(cell,side,node,i) = val_cell(cell,sideNodes(side,node),i);
-      }
-      break;
-    case NODE_VECTOR_SIDESET:
-      Kokkos::parallel_for(NodeVectorSideset_Policy(0, sideSet.size), *this);
-      break;
-    case NODE_TENSOR:
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the local data of side and cell
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
-        
-        for (int node=0; node<dims[2]; ++node)
-          for (int i=0; i<dims[3]; ++i)
-            for (int j=0; j<dims[4]; ++j)
-              val_side(cell,side,node,i,j) = val_cell(cell,sideNodes(side,node),i,j);
-      }
-      break;
-    case VERTEX_VECTOR:
-      for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-      {
-        // Get the local data of side and cell
-        const int cell = sideSet.elem_LID(sideSet_idx);
-        const int side = sideSet.side_local_id(sideSet_idx);
-        
-        for (int node=0; node<dims[2]; ++node)
-          for (int i=0; i<dims[3]; ++i)
-            val_side(cell,side,node,i) = val_cell(cell,sideNodes(side,node),i);
-      }
-      break;
-    case VERTEX_VECTOR_SIDESET:
-      Kokkos::parallel_for(VertexVectorSideset_Policy(0, sideSet.size), *this);
-      break;
-    default:
-      TEUCHOS_TEST_FOR_EXCEPTION (true, std::logic_error, "Error! Invalid layout (this error should have happened earlier though).\n");
-  }
+  Kokkos::parallel_for(CellToSide_Policy(0, sideSet.size), *this);
 
 }
 

--- a/src/evaluators/interpolation/PHAL_DOFGradInterpolationSide.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFGradInterpolationSide.hpp
@@ -47,10 +47,9 @@ private:
 
   // Input:
   //! Values at nodes
-  // TODO: restore layout template arguments when removing old sideset layout
-  PHX::MDField<const ScalarT> val_node;   // Side, Node
+  PHX::MDField<const ScalarT,Side,Node> val_node;
   //! Basis Functions
-  PHX::MDField<const MeshScalarT> gradBF; // Side, Node, QuadPoint, Dim
+  PHX::MDField<const MeshScalarT,Side,Node,QuadPoint,Dim> gradBF;
 
   // Output:
   //! Values at quadrature points

--- a/src/evaluators/interpolation/PHAL_DOFGradInterpolationSide_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFGradInterpolationSide_Def.hpp
@@ -20,9 +20,9 @@ DOFGradInterpolationSideBase<EvalT, Traits, ScalarT>::
 DOFGradInterpolationSideBase(const Teuchos::ParameterList& p,
                          const Teuchos::RCP<Albany::Layouts>& dl_side) :
   sideSetName (p.get<std::string> ("Side Set Name")),
-  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_scalar_sideset),
-  gradBF      (p.get<std::string> ("Gradient BF Name"), dl_side->node_qp_gradient_sideset),
-  grad_qp      (p.get<std::string> ("Gradient Variable Name"), dl_side->qp_gradient_sideset)
+  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_scalar),
+  gradBF      (p.get<std::string> ("Gradient BF Name"), dl_side->node_qp_gradient),
+  grad_qp      (p.get<std::string> ("Gradient Variable Name"), dl_side->qp_gradient)
 {
   TEUCHOS_TEST_FOR_EXCEPTION (!dl_side->isSideLayouts, Teuchos::Exceptions::InvalidParameter,
                               "Error! The layouts structure does not appear to be that of a side set.\n");
@@ -33,9 +33,9 @@ DOFGradInterpolationSideBase(const Teuchos::ParameterList& p,
 
   this->setName("DOFGradInterpolationSide("+p.get<std::string>("Variable Name") + ")"+PHX::print<EvalT>());
 
-  numSideNodes = dl_side->node_qp_gradient->extent(2);
-  numSideQPs   = dl_side->node_qp_gradient->extent(3);
-  numDims      = dl_side->node_qp_gradient->extent(4);
+  numSideNodes = dl_side->node_qp_gradient->extent(1);
+  numSideQPs   = dl_side->node_qp_gradient->extent(2);
+  numDims      = dl_side->node_qp_gradient->extent(3);
 }
 
 //**********************************************************************

--- a/src/evaluators/interpolation/PHAL_DOFInterpolationSide_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFInterpolationSide_Def.hpp
@@ -16,9 +16,9 @@ DOFInterpolationSideBase<EvalT, Traits, ScalarT>::
 DOFInterpolationSideBase (const Teuchos::ParameterList& p,
                           const Teuchos::RCP<Albany::Layouts>& dl_side) :
   sideSetName (p.get<std::string> ("Side Set Name")),
-  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_scalar_sideset),
-  BF          (p.get<std::string> ("BF Name"), dl_side->node_qp_scalar_sideset),
-  val_qp      (p.get<std::string> ("Variable Name"), dl_side->qp_scalar_sideset)
+  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_scalar),
+  BF          (p.get<std::string> ("BF Name"), dl_side->node_qp_scalar),
+  val_qp      (p.get<std::string> ("Variable Name"), dl_side->qp_scalar)
 {
   TEUCHOS_TEST_FOR_EXCEPTION (!dl_side->isSideLayouts, Teuchos::Exceptions::InvalidParameter,
                               "Error! The layouts structure does not appear to be that of a side set.\n");
@@ -29,8 +29,8 @@ DOFInterpolationSideBase (const Teuchos::ParameterList& p,
 
   this->setName("DOFInterpolationSide"+PHX::print<EvalT>());
 
-  numSideNodes = dl_side->node_qp_scalar->extent(2);
-  numSideQPs   = dl_side->node_qp_scalar->extent(3);
+  numSideNodes = dl_side->node_qp_scalar->extent(1);
+  numSideQPs   = dl_side->node_qp_scalar->extent(2);
 }
 
 //**********************************************************************

--- a/src/evaluators/interpolation/PHAL_DOFVecGradInterpolationSide.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFVecGradInterpolationSide.hpp
@@ -44,11 +44,10 @@ private:
   std::string sideSetName;
 
   // Input:
-  // TODO: restore layout template arguments when removing old sideset layout
   //! Values at nodes
-  PHX::MDField<const ScalarT> val_node;    // Side, Node, VecDim
+  PHX::MDField<const ScalarT,Side,Node,VecDim> val_node;
   //! Basis Functions
-  PHX::MDField<const MeshScalarT> gradBF;  // Side, Node, QuadPoint, Dim
+  PHX::MDField<const MeshScalarT,Side,Node,QuadPoint,Dim> gradBF; 
 
   // Output:
   //! Values at quadrature points

--- a/src/evaluators/interpolation/PHAL_DOFVecGradInterpolationSide_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFVecGradInterpolationSide_Def.hpp
@@ -16,9 +16,9 @@ DOFVecGradInterpolationSideBase<EvalT, Traits, ScalarT>::
 DOFVecGradInterpolationSideBase(const Teuchos::ParameterList& p,
                             const Teuchos::RCP<Albany::Layouts>& dl_side) :
   sideSetName (p.get<std::string> ("Side Set Name")),
-  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_vector_sideset),
-  gradBF      (p.get<std::string> ("Gradient BF Name"), dl_side->node_qp_gradient_sideset),
-  grad_qp     (p.get<std::string> ("Gradient Variable Name"), dl_side->qp_vecgradient_sideset)
+  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_vector),
+  gradBF      (p.get<std::string> ("Gradient BF Name"), dl_side->node_qp_gradient),
+  grad_qp     (p.get<std::string> ("Gradient Variable Name"), dl_side->qp_vecgradient)
 {
   TEUCHOS_TEST_FOR_EXCEPTION (!dl_side->isSideLayouts, Teuchos::Exceptions::InvalidParameter,
                               "Error! The layouts structure does not appear to be that of a side set.\n");
@@ -29,10 +29,10 @@ DOFVecGradInterpolationSideBase(const Teuchos::ParameterList& p,
 
   this->setName("DOFVecGradInterpolationSideBase" );
 
-  numSideNodes = dl_side->node_qp_gradient->extent(2);
-  numSideQPs   = dl_side->node_qp_gradient->extent(3);
-  numDims      = dl_side->node_qp_gradient->extent(4);
-  vecDim       = dl_side->node_vector->extent(3);
+  numSideNodes = dl_side->node_qp_gradient->extent(1);
+  numSideQPs   = dl_side->node_qp_gradient->extent(2);
+  numDims      = dl_side->node_qp_gradient->extent(3);
+  vecDim       = dl_side->node_vector->extent(2);
 }
 
 //**********************************************************************

--- a/src/evaluators/interpolation/PHAL_DOFVecInterpolationSide_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFVecInterpolationSide_Def.hpp
@@ -17,9 +17,9 @@ DOFVecInterpolationSideBase<EvalT, Traits, Type>::
 DOFVecInterpolationSideBase(const Teuchos::ParameterList& p,
                             const Teuchos::RCP<Albany::Layouts>& dl_side) :
   sideSetName (p.get<std::string> ("Side Set Name")),
-  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_vector_sideset),
-  BF          (p.get<std::string> ("BF Name"), dl_side->node_qp_scalar_sideset),
-  val_qp      (p.get<std::string> ("Variable Name"), dl_side->qp_vector_sideset)
+  val_node    (p.get<std::string> ("Variable Name"), dl_side->node_vector),
+  BF          (p.get<std::string> ("BF Name"), dl_side->node_qp_scalar),
+  val_qp      (p.get<std::string> ("Variable Name"), dl_side->qp_vector)
 {
   TEUCHOS_TEST_FOR_EXCEPTION (!dl_side->isSideLayouts, Teuchos::Exceptions::InvalidParameter,
                               "Error! The layouts structure does not appear to be that of a side set.\n");
@@ -30,9 +30,9 @@ DOFVecInterpolationSideBase(const Teuchos::ParameterList& p,
 
   this->setName("DOFVecInterpolationSide"+PHX::print<EvalT>());
 
-  numSideNodes = dl_side->node_qp_scalar->extent(2);
-  numSideQPs   = dl_side->node_qp_scalar->extent(3);
-  vecDim       = dl_side->qp_vector->extent(3);
+  numSideNodes = dl_side->node_qp_scalar->extent(1);
+  numSideQPs   = dl_side->node_qp_scalar->extent(2);
+  vecDim       = dl_side->qp_vector->extent(2);
 }
 
 //**********************************************************************

--- a/src/evaluators/interpolation/PHAL_P0Interpolation.hpp
+++ b/src/evaluators/interpolation/PHAL_P0Interpolation.hpp
@@ -55,7 +55,6 @@ private:
   };
 
   bool eval_on_side;  // Whether the interpolation is on a volume or side field.
-  bool collapsed;     // if eval_on_side==true, whether we use collapsed sidesets layouts
 
   int numQPs; 
   int numNodes;

--- a/src/evaluators/pde/PHAL_SideLaplacianResidual_Def.hpp
+++ b/src/evaluators/pde/PHAL_SideLaplacianResidual_Def.hpp
@@ -31,22 +31,22 @@ SideLaplacianResidual<EvalT, Traits>::SideLaplacianResidual (const Teuchos::Para
 
     auto dl_side = dl->side_layouts.at(sideSetName);
 
-    u          = PHX::MDField<ScalarT>(p.get<std::string> ("Solution QP Variable Name"), dl_side->qp_scalar_sideset);
-    grad_u     = PHX::MDField<ScalarT>(p.get<std::string> ("Solution Gradient QP Variable Name"), dl_side->qp_gradient_sideset);
-    BF         = PHX::MDField<RealType>(p.get<std::string> ("BF Variable Name"), dl_side->node_qp_scalar_sideset);
-    GradBF     = PHX::MDField<MeshScalarT>(p.get<std::string> ("Gradient BF Variable Name"), dl_side->node_qp_gradient_sideset);
-    w_measure  = PHX::MDField<MeshScalarT>(p.get<std::string> ("Weighted Measure Variable Name"), dl_side->qp_scalar_sideset);
-    metric     = PHX::MDField<MeshScalarT>(p.get<std::string> ("Metric Name"), dl_side->qp_tensor_sideset);
+    u          = PHX::MDField<ScalarT>(p.get<std::string> ("Solution QP Variable Name"), dl_side->qp_scalar);
+    grad_u     = PHX::MDField<ScalarT>(p.get<std::string> ("Solution Gradient QP Variable Name"), dl_side->qp_gradient);
+    BF         = PHX::MDField<RealType>(p.get<std::string> ("BF Variable Name"), dl_side->node_qp_scalar);
+    GradBF     = PHX::MDField<MeshScalarT>(p.get<std::string> ("Gradient BF Variable Name"), dl_side->node_qp_gradient);
+    w_measure  = PHX::MDField<MeshScalarT>(p.get<std::string> ("Weighted Measure Variable Name"), dl_side->qp_scalar);
+    metric     = PHX::MDField<MeshScalarT>(p.get<std::string> ("Metric Name"), dl_side->qp_tensor);
     this->addDependentField(metric.fieldTag());
 
-    unsigned int numSides = dl_side->cell_gradient->extent(1);
-    numNodes     = dl_side->node_scalar->extent(2);
-    numQPs       = dl_side->qp_scalar->extent(2);
-    int sideDim  = dl_side->cell_gradient->extent(2);
+    numNodes     = dl_side->node_scalar->extent(1);
+    numQPs       = dl_side->qp_scalar->extent(1);
 
     // Index of the nodes on the sides in the numeration of the cell
     Teuchos::RCP<shards::CellTopology> cellType;
     cellType = p.get<Teuchos::RCP <shards::CellTopology> > ("Cell Type");
+    unsigned int sideDim = cellType->getDimension()-1;
+    unsigned int numSides = cellType->getSideCount();
     unsigned int nodeMax = 0;
     for (unsigned int side=0; side<numSides; ++side) {
       unsigned int thisSideNodes = cellType->getNodeCount(sideDim,side);

--- a/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide.hpp
+++ b/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide.hpp
@@ -52,9 +52,8 @@ private:
   PHX::MDField<const SourceScalarT> sourceField;
   PHX::MDField<const TargetScalarT> targetField;
 
-  // TODO: restore layout template arguments when removing old sideset layout
-  PHX::MDField<const MeshScalarT>   metric;      // Side, QuadPoint, Dim, Dim
-  PHX::MDField<const MeshScalarT>   w_measure;   // Side, QuadPoint
+  PHX::MDField<const MeshScalarT,Side,QuadPoint,Dim,Dim>   metric;
+  PHX::MDField<const MeshScalarT,Side,QuadPoint>   w_measure;
 
   size_t diffDims;
   Kokkos::View<ScalarT*,  PHX::Device> diff_1;

--- a/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide.hpp
+++ b/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide.hpp
@@ -38,7 +38,6 @@ private:
   int getLayout (const Teuchos::RCP<Albany::Layouts>& dl, const std::string& rank, Teuchos::RCP<PHX::DataLayout>& layout);
 
   std::string sideSetName;
-  bool useCollapsedSidesets;
   Albany::LocalSideSetInfo sideSet;
   
   int sideDim;

--- a/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide_Def.hpp
+++ b/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide_Def.hpp
@@ -23,11 +23,9 @@ ResponseSquaredL2DifferenceSideBase(Teuchos::ParameterList& p, const Teuchos::RC
 
   Teuchos::RCP<Albany::Layouts> dl_side = dl->side_layouts.at(sideSetName);
 
-  useCollapsedSidesets = dl_side->useCollapsedSidesets;
-
   // Gathering dimensions
-  sideDim = dl_side->cell_gradient->extent(2);
-  numQPs  = dl_side->qp_scalar->extent(2);
+  sideDim = dl_side->cell_gradient->extent(1);
+  numQPs  = dl_side->qp_scalar->extent(1);
 
   Teuchos::RCP<PHX::DataLayout> layout;
   std::string rank,fname;
@@ -41,12 +39,12 @@ ResponseSquaredL2DifferenceSideBase(Teuchos::ParameterList& p, const Teuchos::RC
 
   if (fieldDim>0)
   {
-    metric = decltype(metric)("Metric " + sideSetName, useCollapsedSidesets ? dl_side->qp_tensor_sideset : dl_side->qp_tensor);
+    metric = decltype(metric)("Metric " + sideSetName, dl_side->qp_tensor);
     this->addDependentField(metric);
   }
 
   sourceField = decltype(sourceField)(fname,layout);
-  w_measure   = decltype(w_measure)("Weighted Measure " + sideSetName, useCollapsedSidesets ? dl_side->qp_scalar_sideset : dl_side->qp_scalar);
+  w_measure   = decltype(w_measure)("Weighted Measure " + sideSetName, dl_side->qp_scalar);
   scaling     = plist->get("Scaling",1.0);
 
   this->addDependentField(sourceField);
@@ -122,10 +120,10 @@ evaluateFields(typename Traits::EvalData workset)
   PHAL::set(this->local_response_eval, 0.0);
 
   if (fieldDim == 1) {
-    diffDims = useCollapsedSidesets ? dims[2] : dims[3];
+    diffDims = dims[2];
     diff_1 = Kokkos::View<ScalarT*,  PHX::Device>("diff_1", diffDims);
   } else if (fieldDim == 2) {
-    diffDims = useCollapsedSidesets ? dims[2] : dims[3];
+    diffDims = dims[2];
     diff_2 = Kokkos::View<ScalarT**, PHX::Device>("diff_2", diffDims, diffDims);
   }
 
@@ -133,161 +131,80 @@ evaluateFields(typename Traits::EvalData workset)
   {
     sideSet = workset.sideSetViews->at(sideSetName);
 
-    if (useCollapsedSidesets) {
-      switch (fieldDim)
-      {
-        case 0:
-          for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+    switch (fieldDim)
+    {
+      case 0:
+        for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+        {
+          // Get the local data of cell
+          const int cell = sideSet.elem_LID(sideSet_idx);
+
+          ScalarT sum = 0;
+          for (int qp=0; qp<numQPs; ++qp)
           {
-            // Get the local data of cell
-            const int cell = sideSet.elem_LID(sideSet_idx);
-
-            ScalarT sum = 0;
-            for (int qp=0; qp<numQPs; ++qp)
-            {
-              ScalarT sq = 0;
-              // Computing squared difference at qp
-              sq += std::pow(sourceField(sideSet_idx,qp)-(target_value ? target_value_val : targetField(sideSet_idx,qp)),2);
-              sum += sq * w_measure(sideSet_idx,qp);
-            }
-
-            this->local_response_eval(cell, 0) = sum*scaling;
-            this->global_response_eval(0) += sum*scaling;
+            ScalarT sq = 0;
+            // Computing squared difference at qp
+            sq += std::pow(sourceField(sideSet_idx,qp)-(target_value ? target_value_val : targetField(sideSet_idx,qp)),2);
+            sum += sq * w_measure(sideSet_idx,qp);
           }
-          break;
-        case 1:
-          for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+
+          this->local_response_eval(cell, 0) = sum*scaling;
+          this->global_response_eval(0) += sum*scaling;
+        }
+        break;
+      case 1:
+        for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+        {
+          // Get the local data of cell
+          const int cell = sideSet.elem_LID(sideSet_idx);
+
+          ScalarT sum = 0;
+          for (int qp=0; qp<numQPs; ++qp)
           {
-            // Get the local data of cell
-            const int cell = sideSet.elem_LID(sideSet_idx);
+            ScalarT sq = 0;
+            // Computing squared difference at qp
+            // Precompute differentce and access fields only n times (not n^2)
+            for (size_t i=0; i<diffDims; ++i)
+              diff_1(i) = sourceField(sideSet_idx,qp,i) - (target_value ? target_value_val : targetField(sideSet_idx,qp,i));
 
-            ScalarT sum = 0;
-            for (int qp=0; qp<numQPs; ++qp)
-            {
-              ScalarT sq = 0;
-              // Computing squared difference at qp
-              // Precompute differentce and access fields only n times (not n^2)
-              for (size_t i=0; i<diffDims; ++i)
-                diff_1(i) = sourceField(sideSet_idx,qp,i) - (target_value ? target_value_val : targetField(sideSet_idx,qp,i));
-
-              for (size_t i=0; i<diffDims; ++i)
-                for (size_t j=0; j<diffDims; ++j)
-                  sq += diff_1(i)*metric(sideSet_idx,qp,i,j)*diff_1(j);
-              sum += sq * w_measure(sideSet_idx,qp);
-            }
-
-            this->local_response_eval(cell, 0) = sum*scaling;
-            this->global_response_eval(0) += sum*scaling;
+            for (size_t i=0; i<diffDims; ++i)
+              for (size_t j=0; j<diffDims; ++j)
+                sq += diff_1(i)*metric(sideSet_idx,qp,i,j)*diff_1(j);
+            sum += sq * w_measure(sideSet_idx,qp);
           }
-          break;
-        case 2:
-          for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+
+          this->local_response_eval(cell, 0) = sum*scaling;
+          this->global_response_eval(0) += sum*scaling;
+        }
+        break;
+      case 2:
+        for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
+        {
+          // Get the local data of cell
+          const int cell = sideSet.elem_LID(sideSet_idx);
+
+          ScalarT sum = 0;
+          for (int qp=0; qp<numQPs; ++qp)
           {
-            // Get the local data of cell
-            const int cell = sideSet.elem_LID(sideSet_idx);
+            ScalarT sq = 0;
+            // Computing squared difference at qp
+            // Precompute differentce and access fields only n^2 times (not n^4)
+            for (size_t i=0; i<diffDims; ++i)
+              for (size_t j=0; j<diffDims; ++j)
+                diff_2(i,j) = sourceField(sideSet_idx,qp,i,j) - (target_value ? target_value_val : targetField(sideSet_idx,qp,i,j));
 
-            ScalarT sum = 0;
-            for (int qp=0; qp<numQPs; ++qp)
-            {
-              ScalarT sq = 0;
-              // Computing squared difference at qp
-              // Precompute differentce and access fields only n^2 times (not n^4)
-              for (size_t i=0; i<diffDims; ++i)
-                for (size_t j=0; j<diffDims; ++j)
-                  diff_2(i,j) = sourceField(sideSet_idx,qp,i,j) - (target_value ? target_value_val : targetField(sideSet_idx,qp,i,j));
-
-              for (size_t i=0; i<diffDims; ++i)
-                for (size_t j=0; j<diffDims; ++j)
-                  for (size_t k=0; k<diffDims; ++k)
-                    for (size_t l=0; l<diffDims; ++l)
-                      sq += metric(sideSet_idx,qp,k,i)*diff_2(i,j) * metric(sideSet_idx,qp,j,l)*diff_2(l,k);
-              sum += sq * w_measure(sideSet_idx,qp);
-            }
-
-            this->local_response_eval(cell, 0) = sum*scaling;
-            this->global_response_eval(0) += sum*scaling;
+            for (size_t i=0; i<diffDims; ++i)
+              for (size_t j=0; j<diffDims; ++j)
+                for (size_t k=0; k<diffDims; ++k)
+                  for (size_t l=0; l<diffDims; ++l)
+                    sq += metric(sideSet_idx,qp,k,i)*diff_2(i,j) * metric(sideSet_idx,qp,j,l)*diff_2(l,k);
+            sum += sq * w_measure(sideSet_idx,qp);
           }
-          break;
-      }
-    } else {
-      switch (fieldDim)
-      {
-        case 0:
-          for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-          {
-            // Get the local data of side and cell
-            const int cell = sideSet.elem_LID(sideSet_idx);
-            const int side = sideSet.side_local_id(sideSet_idx);
 
-            ScalarT sum = 0;
-            for (int qp=0; qp<numQPs; ++qp)
-            {
-              ScalarT sq = 0;
-              // Computing squared difference at qp
-              sq += std::pow(sourceField(cell,side,qp)-(target_value ? target_value_val : targetField(cell,side,qp)),2);
-              sum += sq * w_measure(cell,side,qp);
-            }
-
-            this->local_response_eval(cell, 0) = sum*scaling;
-            this->global_response_eval(0) += sum*scaling;
-          }
-          break;
-        case 1:
-          for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-          {
-            // Get the local data of side and cell
-            const int cell = sideSet.elem_LID(sideSet_idx);
-            const int side = sideSet.side_local_id(sideSet_idx);
-
-            ScalarT sum = 0;
-            for (int qp=0; qp<numQPs; ++qp)
-            {
-              ScalarT sq = 0;
-              // Computing squared difference at qp
-              // Precompute differentce and access fields only n times (not n^2)
-              for (size_t i=0; i<diffDims; ++i)
-                diff_1(i) = sourceField(cell,side,qp,i) - (target_value ? target_value_val : targetField(cell,side,qp,i));
-
-              for (size_t i=0; i<diffDims; ++i)
-                for (size_t j=0; j<diffDims; ++j)
-                  sq += diff_1(i)*metric(cell,side,qp,i,j)*diff_1(j);
-              sum += sq * w_measure(cell,side,qp);
-            }
-
-            this->local_response_eval(cell, 0) = sum*scaling;
-            this->global_response_eval(0) += sum*scaling;
-          }
-          break;
-        case 2:
-          for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
-          {
-            // Get the local data of side and cell
-            const int cell = sideSet.elem_LID(sideSet_idx);
-            const int side = sideSet.side_local_id(sideSet_idx);
-
-            ScalarT sum = 0;
-            for (int qp=0; qp<numQPs; ++qp)
-            {
-              ScalarT sq = 0;
-              // Computing squared difference at qp
-              // Precompute differentce and access fields only n^2 times (not n^4)
-              for (size_t i=0; i<diffDims; ++i)
-                for (size_t j=0; j<diffDims; ++j)
-                  diff_2(i,j) = sourceField(cell,side,qp,i,j) - (target_value ? target_value_val : targetField(cell,side,qp,i,j));
-
-              for (size_t i=0; i<diffDims; ++i)
-                for (size_t j=0; j<diffDims; ++j)
-                  for (size_t k=0; k<diffDims; ++k)
-                    for (size_t l=0; l<diffDims; ++l)
-                      sq += metric(cell,side,qp,k,i)*diff_2(i,j) * metric(cell,side,qp,j,l)*diff_2(l,k);
-              sum += sq * w_measure(cell,side,qp);
-            }
-
-            this->local_response_eval(cell, 0) = sum*scaling;
-            this->global_response_eval(0) += sum*scaling;
-          }
-          break;
-      }
+          this->local_response_eval(cell, 0) = sum*scaling;
+          this->global_response_eval(0) += sum*scaling;
+        }
+        break;
     }
 
   }
@@ -318,22 +235,22 @@ getLayout (const Teuchos::RCP<Albany::Layouts>& dl, const std::string& rank, Teu
   int dim = -1;
   if (rank=="Scalar")
   {
-    layout = useCollapsedSidesets ? dl->qp_scalar_sideset : dl->qp_scalar;
+    layout = dl->qp_scalar;
     dim = 0;
   }
   else if (rank=="Vector")
   {
-    layout = useCollapsedSidesets ? dl->qp_vector_sideset : dl->qp_vector;
+    layout = dl->qp_vector;
     dim = 1;
   }
   else if (rank=="Gradient")
   {
-    layout = useCollapsedSidesets ? dl->qp_gradient_sideset : dl->qp_gradient;
+    layout = dl->qp_gradient;
     dim = 1;
   }
   else if (rank=="Tensor")
   {
-    layout = useCollapsedSidesets ? dl->qp_tensor_sideset : dl->qp_tensor;
+    layout = dl->qp_tensor;
     dim = 2;
   }
   else

--- a/src/evaluators/scatter/PHAL_ScatterSideEqnResidual_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterSideEqnResidual_Def.hpp
@@ -77,23 +77,20 @@ ScatterSideEqnResidualBase (const Teuchos::ParameterList& p,
     numFields = names.size();
     val.resize(numFields);
     for (int eq = 0; eq < numFields; ++eq) {
-      val[eq] = res_type(names[eq], residualsAreVolumeFields ? res_dl->node_scalar : res_dl->node_scalar_sideset);
+      val[eq] = res_type(names[eq], res_dl->node_scalar);
       this->addDependentField(val[eq]);
     }
   } else if (tensorRank == 1 ) {
     // vector
     valVec = res_type(names[0], res_dl->node_vector);
     this->addDependentField(valVec);
-    numFields = residualsAreVolumeFields ? res_dl->node_vector->extent(2) : res_dl->node_vector->extent(3);
+    numFields = res_dl->node_vector->extent(2);
   } else if (tensorRank == 2 ) {
     // tensor
-    valTensor = res_type (names[0], residualsAreVolumeFields ? res_dl->node_tensor : res_dl->node_tensor_sideset);
+    valTensor = res_type (names[0], res_dl->node_tensor);
     this->addDependentField(valTensor);
-    numDims = residualsAreVolumeFields ?
-                  res_dl->node_tensor->extent(2) : res_dl->node_tensor->extent(3);
-    numFields = residualsAreVolumeFields ?
-                  (res_dl->node_tensor->extent(2))*(res_dl->node_tensor->extent(3)) :
-                  (res_dl->node_tensor->extent(3))*(res_dl->node_tensor->extent(4));
+    numDims = res_dl->node_tensor->extent(2);
+    numFields = (res_dl->node_tensor->extent(2))*(res_dl->node_tensor->extent(3));
   }
 
   if (p.isType<int>("Offset of First DOF")) {

--- a/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide.hpp
+++ b/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide.hpp
@@ -65,7 +65,6 @@ private:
   Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> > intrepidBasis;
 
   // Output:
-  // TODO: restore layout template arguments when removing old sideset layout
   //! Basis Functions and other quantities at quadrature points
   PHX::MDField<MeshScalarT>                               metric_det;
   PHX::MDField<MeshScalarT>                               tangents;
@@ -74,7 +73,7 @@ private:
   PHX::MDField<MeshScalarT>                               inv_metric;
   PHX::MDField<RealType>                                  BF;
   PHX::MDField<MeshScalarT>                               GradBF;
-  PHX::MDField<MeshScalarT>                               normals;    // Side, QuadPoint, Dim
+  PHX::MDField<MeshScalarT,Side,QuadPoint,Dim>            normals;
 
   int currentSide;
 

--- a/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide.hpp
+++ b/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide.hpp
@@ -42,7 +42,7 @@ public:
 private:
 
   typedef typename EvalT::MeshScalarT MeshScalarT;
-  unsigned int numCells, numSides, numSideNodes, numSideQPs, numCellDims, numSideDims, numNodes, effectiveCoordDim;
+  unsigned int numSides, numSideNodes, numSideQPs, numCellDims, numSideDims, numNodes, effectiveCoordDim;
   MDFieldMemoizer<Traits> memoizer;
 
   //! The side set where to compute the Basis Functions

--- a/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide_Def.hpp
+++ b/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide_Def.hpp
@@ -26,14 +26,14 @@ ComputeBasisFunctionsSide (const Teuchos::ParameterList& p,
   Teuchos::RCP<Albany::Layouts> dl_side = dl->side_layouts.at(sideSetName);
 
   // Build output fields
-  sideCoordVec = decltype(sideCoordVec)(p.get<std::string> ("Side Coordinate Vector Name"), dl_side->vertices_vector_sideset);
-  tangents     = decltype(tangents    )(p.get<std::string> ("Tangents Name"), dl_side->qp_tensor_cd_sd_sideset);
-  metric       = decltype(metric      )(p.get<std::string> ("Metric Name"), dl_side->qp_tensor_sideset);
-  w_measure    = decltype(w_measure   )(p.get<std::string> ("Weighted Measure Name"), dl_side->qp_scalar_sideset);
-  inv_metric   = decltype(inv_metric  )(p.get<std::string> ("Inverse Metric Name"), dl_side->qp_tensor_sideset);
-  metric_det   = decltype(metric_det  )(p.get<std::string> ("Metric Determinant Name"), dl_side->qp_scalar_sideset);
-  BF           = decltype(BF          )(p.get<std::string> ("BF Name"), dl_side->node_qp_scalar_sideset);
-  GradBF       = decltype(GradBF      )(p.get<std::string> ("Gradient BF Name"), dl_side->node_qp_gradient_sideset);
+  sideCoordVec = decltype(sideCoordVec)(p.get<std::string> ("Side Coordinate Vector Name"), dl_side->vertices_vector);
+  tangents     = decltype(tangents    )(p.get<std::string> ("Tangents Name"), dl_side->qp_tensor_cd_sd);
+  metric       = decltype(metric      )(p.get<std::string> ("Metric Name"), dl_side->qp_tensor);
+  w_measure    = decltype(w_measure   )(p.get<std::string> ("Weighted Measure Name"), dl_side->qp_scalar);
+  inv_metric   = decltype(inv_metric  )(p.get<std::string> ("Inverse Metric Name"), dl_side->qp_tensor);
+  metric_det   = decltype(metric_det  )(p.get<std::string> ("Metric Determinant Name"), dl_side->qp_scalar);
+  BF           = decltype(BF          )(p.get<std::string> ("BF Name"), dl_side->node_qp_scalar);
+  GradBF       = decltype(GradBF      )(p.get<std::string> ("Gradient BF Name"), dl_side->node_qp_gradient);
 
   this->addDependentField(sideCoordVec);
   this->addEvaluatedField(tangents);
@@ -47,7 +47,7 @@ ComputeBasisFunctionsSide (const Teuchos::ParameterList& p,
   compute_normals = p.isParameter("Side Normal Name");
 
   if(compute_normals) {
-    normals  = decltype(normals)(p.get<std::string> ("Side Normal Name"), dl_side->qp_vector_spacedim_sideset);
+    normals  = decltype(normals)(p.get<std::string> ("Side Normal Name"), dl_side->qp_vector_spacedim);
     coordVec = decltype(coordVec)(p.get<std::string> ("Coordinate Vector Name"), dl->vertices_vector);
     numNodes = dl->node_gradient->extent(1);
     this->addEvaluatedField(normals);
@@ -57,11 +57,10 @@ ComputeBasisFunctionsSide (const Teuchos::ParameterList& p,
   cellType = p.get<Teuchos::RCP <shards::CellTopology> > ("Cell Type");
 
   // Get Dimensions
-  numCells     = dl_side->node_qp_gradient->extent(0);
-  numSides     = dl_side->node_qp_gradient->extent(1);
-  numSideNodes = dl_side->node_qp_gradient->extent(2);
-  numSideQPs   = dl_side->node_qp_gradient->extent(3);
-  numCellDims  = dl_side->vertices_vector->extent(3);    // Vertices vector always has the ambient space dimension
+  numSides     = cellType->getSideCount();
+  numSideNodes = dl_side->node_qp_gradient->extent(1);
+  numSideQPs   = dl_side->node_qp_gradient->extent(2);
+  numCellDims  = dl_side->vertices_vector->extent(2);    // Vertices vector always has the ambient space dimension
   numSideDims  = numCellDims-1;
 
   effectiveCoordDim = p.get<bool>("Side Set Is Planar") ? 2 : numCellDims;
@@ -72,7 +71,6 @@ ComputeBasisFunctionsSide (const Teuchos::ParameterList& p,
 #ifdef OUTPUT_TO_SCREEN
   Teuchos::RCP<Teuchos::FancyOStream> output(Teuchos::VerboseObjectBase::getDefaultOStream());
   *output << "Compute Basis Functions Side has: "
-          << numCells << " cells, "
           << numSides << " sides, "
           << numSideNodes << " side nodes, "
           << numSideQPs << " side QPs, "

--- a/src/evaluators/utility/PHAL_FieldFrobeniusNorm_Def.hpp
+++ b/src/evaluators/utility/PHAL_FieldFrobeniusNorm_Def.hpp
@@ -70,10 +70,10 @@ FieldFrobeniusNormBase (const Teuchos::ParameterList& p,
     TEUCHOS_TEST_FOR_EXCEPTION (!eval_on_side, Teuchos::Exceptions::InvalidParameter,
                                 "Error! The layouts structure does not appear to be that of a side set.\n");
 
-    field      = decltype(field)(fieldName, dl->cell_vector_sideset);
-    field_norm = decltype(field_norm)(fieldNormName, dl->cell_scalar2_sideset);
+    field      = decltype(field)(fieldName, dl->cell_vector);
+    field_norm = decltype(field_norm)(fieldNormName, dl->cell_scalar2);
 
-    dl->cell_vector_sideset->dimensions(dims);
+    dl->cell_vector->dimensions(dims);
   }
   else if (layout=="Cell Side Gradient")
   {
@@ -82,10 +82,10 @@ FieldFrobeniusNormBase (const Teuchos::ParameterList& p,
     TEUCHOS_TEST_FOR_EXCEPTION (!eval_on_side, Teuchos::Exceptions::InvalidParameter,
                                 "Error! The layouts structure does not appear to be that of a side set.\n");
 
-    field      = decltype(field)(fieldName, dl->cell_gradient_sideset);
-    field_norm = decltype(field_norm)(fieldNormName, dl->cell_scalar2_sideset);
+    field      = decltype(field)(fieldName, dl->cell_gradient);
+    field_norm = decltype(field_norm)(fieldNormName, dl->cell_scalar2);
 
-    dl->cell_gradient_sideset->dimensions(dims);
+    dl->cell_gradient->dimensions(dims);
   }
   else if (layout=="Cell Side Node Vector")
   {
@@ -94,10 +94,10 @@ FieldFrobeniusNormBase (const Teuchos::ParameterList& p,
     TEUCHOS_TEST_FOR_EXCEPTION (!eval_on_side, Teuchos::Exceptions::InvalidParameter,
                                 "Error! The layouts structure does not appear to be that of a side set.\n");
 
-    field      = decltype(field)(fieldName, dl->node_vector_sideset);
-    field_norm = decltype(field_norm)(fieldNormName, dl->node_scalar_sideset);
+    field      = decltype(field)(fieldName, dl->node_vector);
+    field_norm = decltype(field_norm)(fieldNormName, dl->node_scalar);
 
-    dl->node_vector_sideset->dimensions(dims);
+    dl->node_vector->dimensions(dims);
   }
   else if (layout=="Cell Side QuadPoint Vector")
   {
@@ -106,10 +106,10 @@ FieldFrobeniusNormBase (const Teuchos::ParameterList& p,
     TEUCHOS_TEST_FOR_EXCEPTION (!eval_on_side, Teuchos::Exceptions::InvalidParameter,
                                 "Error! The layouts structure does not appear to be that of a side set.\n");
 
-    field      = decltype(field)(fieldName, dl->qp_vector_sideset);
-    field_norm = decltype(field_norm)(fieldNormName, dl->qp_scalar_sideset);
+    field      = decltype(field)(fieldName, dl->qp_vector);
+    field_norm = decltype(field_norm)(fieldNormName, dl->qp_scalar);
 
-    dl->qp_vector_sideset->dimensions(dims);
+    dl->qp_vector->dimensions(dims);
   }
   else if (layout=="Cell Side QuadPoint Gradient")
   {
@@ -118,10 +118,10 @@ FieldFrobeniusNormBase (const Teuchos::ParameterList& p,
     TEUCHOS_TEST_FOR_EXCEPTION (!eval_on_side, Teuchos::Exceptions::InvalidParameter,
                                 "Error! The layouts structure does not appear to be that of a side set.\n");
 
-    field      = decltype(field)(fieldName, dl->qp_gradient_sideset);
-    field_norm = decltype(field_norm)(fieldNormName, dl->qp_scalar_sideset);
+    field      = decltype(field)(fieldName, dl->qp_gradient);
+    field_norm = decltype(field_norm)(fieldNormName, dl->qp_scalar);
 
-    dl->qp_gradient_sideset->dimensions(dims);
+    dl->qp_gradient->dimensions(dims);
   }
   else
   {

--- a/src/evaluators/utility/PHAL_MapToPhysicalFrameSide.hpp
+++ b/src/evaluators/utility/PHAL_MapToPhysicalFrameSide.hpp
@@ -59,9 +59,8 @@ private:
   Albany::LocalSideSetInfo sideSet;
 
   // Input:
-  // TODO: restore layout template arguments when removing old sideset layout
   //! Values at vertices
-  PHX::MDField<const MeshScalarT> coords_side_vertices;  // Side, Vertex, Dim
+  PHX::MDField<const MeshScalarT,Side,Vertex,Dim> coords_side_vertices;
 
   // Output:
   //! Values at quadrature points

--- a/src/evaluators/utility/PHAL_MapToPhysicalFrameSide_Def.hpp
+++ b/src/evaluators/utility/PHAL_MapToPhysicalFrameSide_Def.hpp
@@ -54,7 +54,6 @@ MapToPhysicalFrameSide(const Teuchos::ParameterList& p,
   cubature->getCubature(ref_cub_points, ref_weights);
 
   // Index of the vertices on the sides in the numeration of the cell
-  Teuchos::RCP<shards::CellTopology> cellType = p.get<Teuchos::RCP <shards::CellTopology> > ("Cell Type");
   for (int side=0; side<numSides; ++side)
   {
     // Since sides may be different (and we don't know on which local side this side set is), we build one basis per side.

--- a/src/evaluators/utility/PHAL_MapToPhysicalFrameSide_Def.hpp
+++ b/src/evaluators/utility/PHAL_MapToPhysicalFrameSide_Def.hpp
@@ -27,17 +27,20 @@ MapToPhysicalFrameSide(const Teuchos::ParameterList& p,
                               "Error! The layouts structure does not appear to be that of a side set.\n");
 
   coords_side_vertices = decltype(coords_side_vertices)(
-      p.get<std::string>("Coordinate Vector Vertex Name"), dl_side->vertices_vector_sideset);
+      p.get<std::string>("Coordinate Vector Vertex Name"), dl_side->vertices_vector);
   coords_side_qp = decltype(coords_side_qp)(
-      p.get<std::string>("Coordinate Vector QP Name"), dl_side->qp_coords_sideset);
+      p.get<std::string>("Coordinate Vector QP Name"), dl_side->qp_coords);
 
   this->addDependentField(coords_side_vertices.fieldTag());
   this->addEvaluatedField(coords_side_qp);
 
+  Teuchos::RCP<shards::CellTopology> cellType;
+  cellType = p.get<Teuchos::RCP <shards::CellTopology> > ("Cell Type");
+
   // Get Dimensions
-  int numSides = dl_side->qp_coords->extent(1);
-  numSideQPs   = dl_side->qp_coords->extent(2);
-  numDim       = dl_side->qp_coords->extent(3);
+  int numSides = cellType->getSideCount();
+  numSideQPs   = dl_side->qp_coords->extent(1);
+  numDim       = dl_side->qp_coords->extent(2);
   int sideDim  = numDim-1;
 
   TEUCHOS_TEST_FOR_EXCEPTION (numSides > 6, Teuchos::Exceptions::InvalidParameter,

--- a/src/problems/Albany_Layouts.cpp
+++ b/src/problems/Albany_Layouts.cpp
@@ -131,10 +131,10 @@ Albany::Layouts::Layouts (int worksetSize, int numVertices, int numNodes, int nu
   sidesetWorksetSize = singleWorksetSizeAllocation ? sidesetWorksetSize : worksetSize*numSides;
 
   // Solution Fields
-  node_scalar  = rcp(new MDALayout<Side,Node>(worksetSize,numNodes));
-  qp_scalar    = rcp(new MDALayout<Side,QuadPoint>(worksetSize,numQPts));
-  cell_scalar  = rcp(new MDALayout<Side,QuadPoint>(worksetSize,1));
-  cell_scalar2 = rcp(new MDALayout<Side>(worksetSize));
+  node_scalar  = rcp(new MDALayout<Side,Node>(sidesetWorksetSize,numNodes));
+  qp_scalar    = rcp(new MDALayout<Side,QuadPoint>(sidesetWorksetSize,numQPts));
+  cell_scalar  = rcp(new MDALayout<Side,QuadPoint>(sidesetWorksetSize,1));
+  cell_scalar2 = rcp(new MDALayout<Side>(sidesetWorksetSize));
 
   node_vector = rcp(new MDALayout<Side,Node,Dim>(sidesetWorksetSize,numNodes,vecDim));
   qp_vector   = rcp(new MDALayout<Side,QuadPoint,Dim>(sidesetWorksetSize,numQPts,vecDim));
@@ -165,9 +165,9 @@ Albany::Layouts::Layouts (int worksetSize, int numVertices, int numNodes, int nu
   qp_tensor4    = rcp(new MDALayout<Side,QuadPoint,Dim,Dim,Dim,Dim>(sidesetWorksetSize,numQPts,numSideDim,numSideDim,numSideDim,numSideDim));
   cell_tensor4  = rcp(new MDALayout<Side,Dim,Dim,Dim,Dim>(sidesetWorksetSize,numSideDim,numSideDim,numSideDim,numSideDim));
 
-  node_node_scalar = rcp(new MDALayout<Node,Side,Dim>(sidesetWorksetSize,1));
-  node_node_vector = rcp(new MDALayout<Node,Side,Dim>(sidesetWorksetSize,vecDim));
-  node_node_tensor = rcp(new MDALayout<Node,Side,Dim,Dim>(sidesetWorksetSize,numSideDim,numSideDim));
+  node_node_scalar = rcp(new MDALayout<Node,Side,Dim>(worksetSize,numSides,1));
+  node_node_vector = rcp(new MDALayout<Node,Side,Dim>(worksetSize,numSides,vecDim));
+  node_node_tensor = rcp(new MDALayout<Node,Side,Dim,Dim>(worksetSize,numSides,numSideDim,numSideDim));
 
   // Coordinates: 3vector is for shells 2D topology 3 coordinates
   // Note: vertices coordinates always have the dimension of the ambient space. In fact, you need full n-dim coordinates

--- a/src/problems/Albany_Layouts.cpp
+++ b/src/problems/Albany_Layouts.cpp
@@ -105,7 +105,7 @@ Albany::Layouts::Layouts (int worksetSize, int numVertices, int numNodes, int nu
   // have separate node_vector and node_gradient layouts.
 }
 
-Albany::Layouts::Layouts (int worksetSize, int numVertices, int numNodes, int numQPts, int numSideDim, int numSpaceDim, int numSides, int vecDim, bool collapsed_sidesets, bool singleWorksetSizeAllocation, int sidesetWorksetSize)
+Albany::Layouts::Layouts (int worksetSize, int numVertices, int numNodes, int numQPts, int numSideDim, int numSpaceDim, int numSides, int vecDim, bool singleWorksetSizeAllocation, int sidesetWorksetSize)
 // numSideDim is the number of spatial dimensions
 // vecDim is the length of a vector quantity
 // -- For many problems, numSideDim is used for both since there are
@@ -127,58 +127,61 @@ Albany::Layouts::Layouts (int worksetSize, int numVertices, int numNodes, int nu
 
   isSideLayouts = true;
 
+  // Collapsed sideset layouts are now used to ensure contiguous memory access for efficient GPU evaluation
+  sidesetWorksetSize = singleWorksetSizeAllocation ? sidesetWorksetSize : worksetSize*numSides;
+
   // Solution Fields
-  node_scalar  = rcp(new MDALayout<Cell,Side,Node>(worksetSize,numSides,numNodes));
-  qp_scalar    = rcp(new MDALayout<Cell,Side,QuadPoint>(worksetSize,numSides,numQPts));
-  cell_scalar  = rcp(new MDALayout<Cell,Side,QuadPoint>(worksetSize,numSides,1));
-  cell_scalar2 = rcp(new MDALayout<Cell,Side>(worksetSize,numSides));
+  node_scalar  = rcp(new MDALayout<Side,Node>(worksetSize,numNodes));
+  qp_scalar    = rcp(new MDALayout<Side,QuadPoint>(worksetSize,numQPts));
+  cell_scalar  = rcp(new MDALayout<Side,QuadPoint>(worksetSize,1));
+  cell_scalar2 = rcp(new MDALayout<Side>(worksetSize));
 
-  node_vector = rcp(new MDALayout<Cell,Side,Node,Dim>(worksetSize,numSides,numNodes,vecDim));
-  qp_vector   = rcp(new MDALayout<Cell,Side,QuadPoint,Dim>(worksetSize,numSides,numQPts,vecDim));
-  cell_vector = rcp(new MDALayout<Cell,Side,Dim>(worksetSize,numSides,vecDim));
+  node_vector = rcp(new MDALayout<Side,Node,Dim>(sidesetWorksetSize,numNodes,vecDim));
+  qp_vector   = rcp(new MDALayout<Side,QuadPoint,Dim>(sidesetWorksetSize,numQPts,vecDim));
+  cell_vector = rcp(new MDALayout<Side,Dim>(sidesetWorksetSize,vecDim));
 
-  node_gradient = rcp(new MDALayout<Cell,Side,Node,Dim>(worksetSize,numSides,numNodes,numSideDim));
-  qp_gradient   = rcp(new MDALayout<Cell,Side,QuadPoint,Dim>(worksetSize,numSides,numQPts,numSideDim));
-  cell_gradient = rcp(new MDALayout<Cell,Side,Dim>(worksetSize,numSides,numSideDim));
+  node_gradient = rcp(new MDALayout<Side,Node,Dim>(sidesetWorksetSize,numNodes,numSideDim));
+  qp_gradient   = rcp(new MDALayout<Side,QuadPoint,Dim>(sidesetWorksetSize,numQPts,numSideDim));
+  cell_gradient = rcp(new MDALayout<Side,Dim>(sidesetWorksetSize,numSideDim));
 
-  qp_vector_spacedim = rcp(new MDALayout<Cell,Side,QuadPoint,Dim>(worksetSize,numSides,numQPts,numSpaceDim));
+  qp_vector_spacedim = rcp(new MDALayout<Side,QuadPoint,Dim>(sidesetWorksetSize,numQPts,numSpaceDim));
 
-  node_tensor     = rcp(new MDALayout<Cell,Side,Node,Dim,Dim>(worksetSize,numSides,numNodes,numSideDim,numSideDim));
-  qp_tensor       = rcp(new MDALayout<Cell,Side,QuadPoint,Dim,Dim>(worksetSize,numSides,numQPts,numSideDim,numSideDim));
-  cell_tensor     = rcp(new MDALayout<Cell,Side,Dim,Dim>(worksetSize,numSides,numSideDim,numSideDim));
-  qp_tensor_cd_sd = rcp(new MDALayout<Cell,Side,QuadPoint,Dim,Dim>(worksetSize,numSides,numQPts,numSideDim+1,numSideDim));
+  node_tensor     = rcp(new MDALayout<Side,Node,Dim,Dim>(sidesetWorksetSize,numNodes,numSideDim,numSideDim));
+  qp_tensor       = rcp(new MDALayout<Side,QuadPoint,Dim,Dim>(sidesetWorksetSize,numQPts,numSideDim,numSideDim));
+  cell_tensor     = rcp(new MDALayout<Side,Dim,Dim>(sidesetWorksetSize,numSideDim,numSideDim));
+  qp_tensor_cd_sd = rcp(new MDALayout<Side,QuadPoint,Dim,Dim>(sidesetWorksetSize,numQPts,numSideDim+1,numSideDim));
 
-  node_vecgradient = rcp(new MDALayout<Cell,Side,Node,Dim,Dim>(worksetSize,numSides,numNodes,vecDim,numSideDim));
-  qp_vecgradient   = rcp(new MDALayout<Cell,Side,QuadPoint,Dim,Dim>(worksetSize,numSides,numQPts,vecDim,numSideDim));
-  cell_vecgradient = rcp(new MDALayout<Cell,Side,Dim,Dim>(worksetSize,numSides,vecDim,numSideDim));
+  node_vecgradient = rcp(new MDALayout<Side,Node,Dim,Dim>(sidesetWorksetSize,numNodes,vecDim,numSideDim));
+  qp_vecgradient   = rcp(new MDALayout<Side,QuadPoint,Dim,Dim>(sidesetWorksetSize,numQPts,vecDim,numSideDim));
+  cell_vecgradient = rcp(new MDALayout<Side,Dim,Dim>(sidesetWorksetSize,vecDim,numSideDim));
 
-  qp_tensorgradient = rcp(new MDALayout<Cell,Side,QuadPoint,Dim,Dim,Dim>(worksetSize,numSides,numQPts,vecDim,vecDim,numSideDim));
+  qp_tensorgradient = rcp(new MDALayout<Side,QuadPoint,Dim,Dim,Dim>(sidesetWorksetSize,numQPts,vecDim,vecDim,numSideDim));
 
-  node_tensor3  = rcp(new MDALayout<Cell,Side,Node,Dim,Dim,Dim>(worksetSize,numSides,numNodes,numSideDim,numSideDim,numSideDim));
-  qp_tensor3    = rcp(new MDALayout<Cell,Side,QuadPoint,Dim,Dim,Dim>(worksetSize,numSides,numQPts,numSideDim,numSideDim,numSideDim));
-  cell_tensor3  = rcp(new MDALayout<Cell,Side,Dim,Dim,Dim>(worksetSize,numSides,numSideDim,numSideDim,numSideDim));
+  node_tensor3  = rcp(new MDALayout<Side,Node,Dim,Dim,Dim>(sidesetWorksetSize,numNodes,numSideDim,numSideDim,numSideDim));
+  qp_tensor3    = rcp(new MDALayout<Side,QuadPoint,Dim,Dim,Dim>(sidesetWorksetSize,numQPts,numSideDim,numSideDim,numSideDim));
+  cell_tensor3  = rcp(new MDALayout<Side,Dim,Dim,Dim>(sidesetWorksetSize,numSideDim,numSideDim,numSideDim));
 
-  node_tensor4  = rcp(new MDALayout<Cell,Side,Node,Dim,Dim,Dim,Dim>(worksetSize,numSides,numNodes,numSideDim,numSideDim,numSideDim,numSideDim));
-  qp_tensor4    = rcp(new MDALayout<Cell,Side,QuadPoint,Dim,Dim,Dim,Dim>(worksetSize,numSides,numQPts,numSideDim,numSideDim,numSideDim,numSideDim));
-  cell_tensor4  = rcp(new MDALayout<Cell,Side,Dim,Dim,Dim,Dim>(worksetSize,numSides,numSideDim,numSideDim,numSideDim,numSideDim));
+  node_tensor4  = rcp(new MDALayout<Side,Node,Dim,Dim,Dim,Dim>(sidesetWorksetSize,numNodes,numSideDim,numSideDim,numSideDim,numSideDim));
+  qp_tensor4    = rcp(new MDALayout<Side,QuadPoint,Dim,Dim,Dim,Dim>(sidesetWorksetSize,numQPts,numSideDim,numSideDim,numSideDim,numSideDim));
+  cell_tensor4  = rcp(new MDALayout<Side,Dim,Dim,Dim,Dim>(sidesetWorksetSize,numSideDim,numSideDim,numSideDim,numSideDim));
 
-  node_node_scalar = rcp(new MDALayout<Node,Side,Dim>(worksetSize,numSides,1));
-  node_node_vector = rcp(new MDALayout<Node,Side,Dim>(worksetSize,numSides,vecDim));
-  node_node_tensor = rcp(new MDALayout<Node,Side,Dim,Dim>(worksetSize,numSides,numSideDim,numSideDim));
+  node_node_scalar = rcp(new MDALayout<Node,Side,Dim>(sidesetWorksetSize,1));
+  node_node_vector = rcp(new MDALayout<Node,Side,Dim>(sidesetWorksetSize,vecDim));
+  node_node_tensor = rcp(new MDALayout<Node,Side,Dim,Dim>(sidesetWorksetSize,numSideDim,numSideDim));
 
   // Coordinates: 3vector is for shells 2D topology 3 coordinates
   // Note: vertices coordinates always have the dimension of the ambient space. In fact, you need full n-dim coordinates
   //       to build the manifold metric and other structures.
   // WARNING: if you change the above fact, make sure to make the appropriate corrections to the parts of
   //          the library that rely on it!
-  vertices_vector = rcp(new MDALayout<Cell,Side,Vertex,Dim>(worksetSize,numSides,numVertices,numSpaceDim));
-  node_3vector    = rcp(new MDALayout<Cell,Side,Node,Dim>(worksetSize,numSides,numNodes,3));
-  qp_coords       = rcp(new MDALayout<Cell,Side,QuadPoint,Dim>(worksetSize,numSides,numQPts,numSpaceDim));
+  vertices_vector = rcp(new MDALayout<Side,Vertex,Dim>(sidesetWorksetSize,numVertices,numSpaceDim));
+  node_3vector    = rcp(new MDALayout<Side,Node,Dim>(sidesetWorksetSize,numNodes,3));
+  qp_coords       = rcp(new MDALayout<Side,QuadPoint,Dim>(sidesetWorksetSize,numQPts,numSpaceDim));
 
   // Basis Functions
-  node_qp_scalar   = rcp(new MDALayout<Cell,Side,Node,QuadPoint>(worksetSize,numSides,numNodes,numQPts));
-  node_qp_gradient = rcp(new MDALayout<Cell,Side,Node,QuadPoint,Dim>(worksetSize,numSides,numNodes,numQPts,numSideDim));
-  node_qp_vector   = rcp(new MDALayout<Cell,Side,Node,QuadPoint,Dim>(worksetSize,numSides,numNodes,numQPts,vecDim));
+  node_qp_scalar   = rcp(new MDALayout<Side,Node,QuadPoint>(sidesetWorksetSize,numNodes,numQPts));
+  node_qp_gradient = rcp(new MDALayout<Side,Node,QuadPoint,Dim>(sidesetWorksetSize,numNodes,numQPts,numSideDim));
+  node_qp_vector   = rcp(new MDALayout<Side,Node,QuadPoint,Dim>(sidesetWorksetSize,numNodes,numQPts,vecDim));
 
   workset_scalar      = rcp(new MDALayout<Dummy>(1));
   workset_vector      = rcp(new MDALayout<Dim>(vecDim));
@@ -195,31 +198,4 @@ Albany::Layouts::Layouts (int worksetSize, int numVertices, int numNodes, int nu
   // the vector fields are length numSideDim (which tends to be true
   // for displacements and velocities). Could be separated to
   // have separate node_vector and node_gradient layouts.
-
-
-  // This flag lets evaluators know to use the collapsed sideset layouts
-  useCollapsedSidesets = collapsed_sidesets;
-
-  // Collapsed sideset layouts to ensure contiguous memory access for efficient GPU evaluation
-  // TODO: using meshspecs struct to set sideset workset size doesn't work yet for extruded boundaries
-  sidesetWorksetSize = singleWorksetSizeAllocation ? sidesetWorksetSize : worksetSize*numSides;
-  qp_scalar_sideset       = rcp(new MDALayout<Side,QuadPoint>(sidesetWorksetSize,numQPts));
-  node_scalar_sideset     = rcp(new MDALayout<Side,Node>(sidesetWorksetSize,numNodes));
-  node_vector_sideset     = rcp(new MDALayout<Side,Node,Dim>(sidesetWorksetSize,numNodes,vecDim));
-  qp_vector_sideset       = rcp(new MDALayout<Side,QuadPoint,Dim>(sidesetWorksetSize,numQPts,vecDim));
-  qp_vecgradient_sideset   = rcp(new MDALayout<Side,QuadPoint,Dim,Dim>(sidesetWorksetSize,numQPts,vecDim,numSideDim));
-  vertices_vector_sideset = rcp(new MDALayout<Side,Vertex,Dim>(sidesetWorksetSize,numVertices,numSpaceDim));
-  qp_coords_sideset       = rcp(new MDALayout<Side,QuadPoint,Dim>(sidesetWorksetSize,numQPts,numSpaceDim));
-  node_qp_scalar_sideset  = rcp(new MDALayout<Side,Node,QuadPoint>(sidesetWorksetSize,numNodes,numQPts));
-  node_qp_gradient_sideset = rcp(new MDALayout<Side,Node,QuadPoint,Dim>(sidesetWorksetSize,numNodes,numQPts,numSideDim));
-  node_gradient_sideset   = rcp(new MDALayout<Side,Node,Dim>(sidesetWorksetSize,numNodes,numSideDim));
-  qp_gradient_sideset     = rcp(new MDALayout<Side,QuadPoint,Dim>(sidesetWorksetSize,numQPts,numSideDim));
-  cell_gradient_sideset   = rcp(new MDALayout<Side,Dim>(sidesetWorksetSize,numSideDim));
-  node_tensor_sideset     = rcp(new MDALayout<Side,Node,Dim,Dim>(sidesetWorksetSize,numNodes,numSideDim,numSideDim));
-  qp_tensor_sideset       = rcp(new MDALayout<Side,QuadPoint,Dim,Dim>(sidesetWorksetSize,numQPts,numSideDim,numSideDim));
-  qp_tensor_cd_sd_sideset = rcp(new MDALayout<Side,QuadPoint,Dim,Dim>(sidesetWorksetSize,numQPts,numSideDim+1,numSideDim));
-  qp_vector_spacedim_sideset = rcp(new MDALayout<Side,QuadPoint,Dim>(sidesetWorksetSize,numQPts,numSpaceDim));
-  cell_scalar2_sideset = rcp(new MDALayout<Side>(sidesetWorksetSize));
-  cell_vector_sideset  = rcp(new MDALayout<Side,Dim>(sidesetWorksetSize,vecDim));
-  cell_tensor_sideset  = rcp(new MDALayout<Side,Dim,Dim>(sidesetWorksetSize,numSideDim,numSideDim));
 }

--- a/src/problems/Albany_Layouts.hpp
+++ b/src/problems/Albany_Layouts.hpp
@@ -20,7 +20,7 @@ namespace Albany {
   struct Layouts {
 
     Layouts (int worksetSize, int numVertices, int numNodes, int numQPts, int numCellDim, int vecDim=-1, int numFace=0);
-    Layouts (int worksetSize, int numVertices, int numNodes, int numQPts, int numSideDim, int numSpaceDim, int numSides, int vecDim, bool collapsed_sidesets=false, bool singleWorksetSizeAllocation=false, int sidesetWorksetSize=1);
+    Layouts (int worksetSize, int numVertices, int numNodes, int numQPts, int numSideDim, int numSpaceDim, int numSides, int vecDim, bool singleWorksetSizeAllocation=false, int sidesetWorksetSize=1);
 
     //! Data Layout for scalar quantity that lives at nodes
     Teuchos::RCP<PHX::DataLayout> node_scalar;
@@ -86,7 +86,7 @@ namespace Albany {
     Teuchos::RCP<PHX::DataLayout> cell_tensor4;
     //! Data Layout for fourth order tensor quantity that lives on a face
     Teuchos::RCP<PHX::DataLayout> face_tensor4;
-    //! Data Layout for vector quantity that lives at vertices (coordinates) //FIXME: dont oords live at nodes, not vertices?
+    //! Data Layout for vector quantity that lives at vertices (coordinates) //FIXME: dont coords live at nodes, not vertices?
     Teuchos::RCP<PHX::DataLayout> vertices_vector;
     Teuchos::RCP<PHX::DataLayout> qp_coords;
     //! Data Layout for length 3 quantity  that lives at nodes (shell coordinates)
@@ -128,44 +128,6 @@ namespace Albany {
     Teuchos::RCP<PHX::DataLayout> shared_param_vec; // same length as other vectors
     Teuchos::RCP<PHX::DataLayout> dummy;
 
-    //! Data Layout for scalar quantity that lives at nodes that belong to a sideset
-    Teuchos::RCP<PHX::DataLayout> node_scalar_sideset;
-    //! Data Layout for scalar quantity that lives at QPs that belong to a sideset
-    Teuchos::RCP<PHX::DataLayout> qp_scalar_sideset;
-    //! Data Layout for vector quantity that lives at nodes that belong to a sideset
-    Teuchos::RCP<PHX::DataLayout> node_vector_sideset;
-    //! Data Layout for vector quantity that lives at QPs that belong to a sideset
-    Teuchos::RCP<PHX::DataLayout> qp_vector_sideset;
-    //! Data Layout for vector quantity that lives at vertices (coordinates) that belong to a sideset //FIXME: dont oords live at nodes, not vertices?
-    Teuchos::RCP<PHX::DataLayout> vertices_vector_sideset;
-    Teuchos::RCP<PHX::DataLayout> qp_coords_sideset;
-    //! Data Layout for scalar basis functions that belong to a sideset
-    Teuchos::RCP<PHX::DataLayout> node_qp_scalar_sideset;
-    //! Data Layout for gradient basis functions that belong to a sideset
-    Teuchos::RCP<PHX::DataLayout> node_qp_gradient_sideset;
-    //! Data Layout for tensor quantity that lives at nodes that belong to a sideset
-    Teuchos::RCP<PHX::DataLayout> node_tensor_sideset;
-    //! Data Layout for tensor quantity that lives at quad points that belong to a sideset
-    Teuchos::RCP<PHX::DataLayout> qp_tensor_sideset;
-    //! Data Layout for tensor quantity (cellDim x sideDim) that lives at quad points that belong to a sideset
-    Teuchos::RCP<PHX::DataLayout> qp_tensor_cd_sd_sideset;
-    //! Data Layout for vector quantity that lives at quad points, with dimension of the ambient space
-    Teuchos::RCP<PHX::DataLayout> qp_vector_spacedim_sideset;
-    //! Data Layout for scalar quantity that lives on a cell that belongs to a sideset
-    Teuchos::RCP<PHX::DataLayout> cell_scalar2_sideset;
-    //! Data Layout for vector quantity that lives on a cell that belongs to a sideset
-    Teuchos::RCP<PHX::DataLayout> cell_vector_sideset;
-    //! Data Layout for tensor quantity that lives on a cell that belongs to a sideset
-    Teuchos::RCP<PHX::DataLayout> cell_tensor_sideset;
-    //! Data Layout for vector gradient quantity that lives at quad points that belong to a sideset
-    Teuchos::RCP<PHX::DataLayout> qp_vecgradient_sideset;
-    //! Data Layout for gradient quantity that lives at nodes that belong to a sideset
-    Teuchos::RCP<PHX::DataLayout> node_gradient_sideset;
-    //! Data Layout for gradient quantity that lives at quad points that belong to a sideset
-    Teuchos::RCP<PHX::DataLayout> qp_gradient_sideset;
-    //! Data Layout for gradient quantity that lives on a cell that belong to a sideset
-    Teuchos::RCP<PHX::DataLayout> cell_gradient_sideset;
-
     // For backward compatibility, and simplicitiy, we want to check if
     // the vector length is the same as the spatial dimension. This
     // assumption is hardwired in mechanics problems and we want to
@@ -174,9 +136,6 @@ namespace Albany {
 
     // A flag to check whether this layouts structure belongs to a sideset
     bool isSideLayouts;
-    
-    // A flag to check whether this layouts structure is using collapsed sideset layouts
-    bool useCollapsedSidesets;
 
     std::map<std::string,Teuchos::RCP<Layouts>> side_layouts;
   };
@@ -232,73 +191,37 @@ get_field_layout (const FieldRankType rank,
   using FL  = FieldLocation;
 
   Teuchos::RCP<PHX::DataLayout> fl;
-  if (layouts->isSideLayouts && layouts->useCollapsedSidesets) {
-    if (rank==FRT::Scalar) {
-      if (loc==FL::Cell) {
-        fl = layouts->cell_scalar2_sideset;
-      } else if (loc==FL::Node) {
-        fl = layouts->node_scalar_sideset;
-      } else {
-        fl = layouts->qp_scalar_sideset;
-      }
-    } else if (rank==FRT::Vector) {
-      if (loc==FL::Cell) {
-        fl = layouts->cell_vector_sideset;
-      } else if (loc==FL::Node) {
-        fl = layouts->node_vector_sideset;
-      } else {
-        fl = layouts->qp_vector_sideset;
-      }
-    } else if (rank==FRT::Gradient) {
-      if (loc==FL::Cell) {
-        fl = layouts->cell_gradient_sideset;
-      } else if (loc==FL::Node) {
-        fl = layouts->node_gradient_sideset;
-      } else {
-        fl = layouts->qp_gradient_sideset;
-      }
-    } else if (rank==FRT::Tensor) {
-      if (loc==FL::Cell) {
-        fl = layouts->cell_tensor_sideset;
-      } else if (loc==FL::Node) {
-        fl = layouts->node_tensor_sideset;
-      } else {
-        fl = layouts->qp_tensor_sideset;
-      }
+  if (rank==FRT::Scalar) {
+    if (loc==FL::Cell) {
+      fl = layouts->cell_scalar2;
+    } else if (loc==FL::Node) {
+      fl = layouts->node_scalar;
+    } else {
+      fl = layouts->qp_scalar;
     }
-  } else {
-    if (rank==FRT::Scalar) {
-      if (loc==FL::Cell) {
-        fl = layouts->cell_scalar2;
-      } else if (loc==FL::Node) {
-        fl = layouts->node_scalar;
-      } else {
-        fl = layouts->qp_scalar;
-      }
-    } else if (rank==FRT::Vector) {
-      if (loc==FL::Cell) {
-        fl = layouts->cell_vector;
-      } else if (loc==FL::Node) {
-        fl = layouts->node_vector;
-      } else {
-        fl = layouts->qp_vector;
-      }
-    } else if (rank==FRT::Gradient) {
-      if (loc==FL::Cell) {
-        fl = layouts->cell_gradient;
-      } else if (loc==FL::Node) {
-        fl = layouts->node_gradient;
-      } else {
-        fl = layouts->qp_gradient;
-      }
-    } else if (rank==FRT::Tensor) {
-      if (loc==FL::Cell) {
-        fl = layouts->cell_tensor;
-      } else if (loc==FL::Node) {
-        fl = layouts->node_tensor;
-      } else {
-        fl = layouts->qp_tensor;
-      }
+  } else if (rank==FRT::Vector) {
+    if (loc==FL::Cell) {
+      fl = layouts->cell_vector;
+    } else if (loc==FL::Node) {
+      fl = layouts->node_vector;
+    } else {
+      fl = layouts->qp_vector;
+    }
+  } else if (rank==FRT::Gradient) {
+    if (loc==FL::Cell) {
+      fl = layouts->cell_gradient;
+    } else if (loc==FL::Node) {
+      fl = layouts->node_gradient;
+    } else {
+      fl = layouts->qp_gradient;
+    }
+  } else if (rank==FRT::Tensor) {
+    if (loc==FL::Cell) {
+      fl = layouts->cell_tensor;
+    } else if (loc==FL::Node) {
+      fl = layouts->node_tensor;
+    } else {
+      fl = layouts->qp_tensor;
     }
   }
 

--- a/src/problems/Albany_PopulateMesh.cpp
+++ b/src/problems/Albany_PopulateMesh.cpp
@@ -76,7 +76,9 @@ void PopulateMesh::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<MeshSpecsStruct>
       const int numSideVecDim   = -1;
 
       dl->side_layouts[ss_name] = Teuchos::rcp(new Layouts(worksetSize,numSideVertices,numSideNodes,numSideQPs,
-                                                           numSideDim,numCellDim,numCellSides,numSideVecDim));
+                                                           numSideDim,numCellDim,numCellSides,numSideVecDim,
+                                                           ssMeshSpecs.singleWorksetSizeAllocation,
+                                                           ssMeshSpecs.worksetSize));
     }
   }
 
@@ -171,8 +173,8 @@ void PopulateMesh::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<MeshSpecsStruct>
         if (is_vector)
         {
           int vec_dim = thisFieldList.get<int>("Vector Dim");
-          layout = is_nodal ? PHAL::ExtendLayout<Dim,Cell,Side,Node>::apply(layout,vec_dim)
-                            : PHAL::ExtendLayout<Dim,Cell,Side>::apply(layout,vec_dim);
+          layout = is_nodal ? PHAL::ExtendLayout<Dim,Side,Node>::apply(layout,vec_dim)
+                            : PHAL::ExtendLayout<Dim,Side>::apply(layout,vec_dim);
         }
 
         // Layered fields
@@ -180,10 +182,10 @@ void PopulateMesh::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<MeshSpecsStruct>
         {
           int num_layers = thisFieldList.get<int>("Number Of Layers");
           layout = is_vector
-                      ? (is_nodal ? PHAL::ExtendLayout<LayerDim,Cell,Side,Node,Dim>::apply(layout,num_layers)
-                                  : PHAL::ExtendLayout<LayerDim,Cell,Side,Dim>::apply(layout,num_layers))
-                      : (is_nodal ? PHAL::ExtendLayout<LayerDim,Cell,Side,Node>::apply(layout,num_layers)
-                                  : PHAL::ExtendLayout<LayerDim,Cell,Side>::apply(layout,num_layers));
+                      ? (is_nodal ? PHAL::ExtendLayout<LayerDim,Side,Node,Dim>::apply(layout,num_layers)
+                                  : PHAL::ExtendLayout<LayerDim,Side,Dim>::apply(layout,num_layers))
+                      : (is_nodal ? PHAL::ExtendLayout<LayerDim,Side,Node>::apply(layout,num_layers)
+                                  : PHAL::ExtendLayout<LayerDim,Side>::apply(layout,num_layers));
         }
 
         // Finally, register the state

--- a/src/problems/Albany_SideLaplacianProblem.cpp
+++ b/src/problems/Albany_SideLaplacianProblem.cpp
@@ -91,7 +91,7 @@ void SideLaplacian::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpe
     numSideQPs      = sideCubature->getNumPoints();
 
     dl_side = Teuchos::rcp(new Albany::Layouts(worksetSize,numSideVertices,numSideNodes,
-                                               numSideQPs,numDim-1,numDim,numCellSides,2,true,
+                                               numSideQPs,numDim-1,numDim,numCellSides,2,
                                                sideMeshSpecs.singleWorksetSizeAllocation,sideMeshSpecs.worksetSize));
     dl->side_layouts[sideSetName] = dl_side;
   }

--- a/src/problems/Albany_SideLaplacianProblem.hpp
+++ b/src/problems/Albany_SideLaplacianProblem.hpp
@@ -272,11 +272,11 @@ SideLaplacian::constructEvaluators3D (PHX::FieldManager<PHAL::AlbanyTraits>& fm0
   fm0.template registerEvaluator<EvalT> (ev);
 
   // -------- Restriction of Solution to Side Field -------- /
-  ev = evalUtils.constructDOFCellToSideEvaluator(dof_names[0],sideSetName,"Node Scalar Sideset",cellType);
+  ev = evalUtils.constructDOFCellToSideEvaluator(dof_names[0],sideSetName,"Node Scalar",cellType);
   fm0.template registerEvaluator<EvalT>(ev);
 
   //---- Restrict vertex coordinates from cell-based to cell-side-based
-  ev = evalUtils.getMSTUtils().constructDOFCellToSideEvaluator("Coord Vec",sideSetName,"Vertex Vector Sideset",cellType,"Coord Vec " + sideSetName);
+  ev = evalUtils.getMSTUtils().constructDOFCellToSideEvaluator("Coord Vec",sideSetName,"Vertex Vector",cellType,"Coord Vec " + sideSetName);
   fm0.template registerEvaluator<EvalT> (ev);
 
   // ------- Side Laplacian Residual -------- //


### PR DESCRIPTION
This PR completely removes the old sideset layouts and replaces them with the collapsed sideset layouts. The layouts previously had the `_sideset` temporary suffix to indicate it was a collapsed layout, but now these suffixes have been removed and evaluators have been updated accordingly.

Additionally, all temporary code from problem files has been removed since we can now assume that the collapsed layout is the only layout.

I think the PR that Luca is working on has some sideset related changes so before this PR can go in, we're going to need to coordinate to figure out if the changes are orthogonal to each other and, if not, come up with a plan for consolidating the changes.

Also, I apologize about how big this PR is but I didn't really see any way of breaking it up into smaller chunks. I hope it isn't too much of a bother.