### PR TITLE
Removing 'is_adjoint' options

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -714,8 +714,6 @@ Application::finalSetUp(
 
   perturbBetaForDirichlets = problemParams->get("Perturb Dirichlet", 0.0);
 
-  is_adjoint = problemParams->get("Solve Adjoint", false);
-
   // For backward compatibility, use any value at the old location of the
   // "Compute Sensitivity" flag as a default value for the new flag location
   // when the latter has been left undefined
@@ -3111,7 +3109,6 @@ Application::loadWorksetJacobianInfo(
   workset.n_coeff         = omega;
   workset.j_coeff         = beta;
   workset.ignore_residual = ignore_residual_in_jacobian;
-  workset.is_adjoint      = is_adjoint;
 }
 
 void

--- a/src/Albany_Application.hpp
+++ b/src/Albany_Application.hpp
@@ -1021,8 +1021,6 @@ void
     return params_;
   }
 
-  bool is_adjoint;
-
  private:
   //! Utility function to set up ShapeParameters through Sacado
   void

--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -1174,23 +1174,7 @@ evalModelImpl(const Thyra_InArgs&  inArgs,
   }
 
   // f
-  if (app->is_adjoint) {
-    const Thyra_Derivative f_deriv(outArgs.get_f(), Thyra_ModelEvaluator::DERIV_MV_GRADIENT_FORM);
-
-    const Thyra_Derivative dummy_deriv;
-
-    const int response_index = 0;  // need to add capability for sending this in
-    app->evaluateResponseDerivative(
-        response_index, curr_time,
-        x, x_dot, x_dotdot,
-        sacado_param_vec,
-        NULL,
-        Teuchos::null,
-        f_deriv,
-        dummy_deriv,
-        dummy_deriv,
-        dummy_deriv);
-  } else if (Teuchos::nonnull(f_out) && !f_already_computed) {
+  if (Teuchos::nonnull(f_out) && !f_already_computed) {
     app->computeGlobalResidual(
         curr_time,
         x, x_dot, x_dotdot,

--- a/src/LandIce/evaluators/LandIce_ScatterResidual2D_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_ScatterResidual2D_Def.hpp
@@ -250,21 +250,11 @@ evaluateFields(typename Traits::EvalData workset)
           }
           // Check derivative array is nonzero
           if (valptr.hasFastAccess()) {
-            if (workset.is_adjoint) {
-              // Sum Jacobian transposed
-              for (unsigned int lunk = 0; lunk < nunk; lunk++) {
-                Albany::addToLocalRowValues(Jac,lcols[lunk],
-                                                Teuchos::arrayView(&lrow,1),
-                                                Teuchos::arrayView(&(valptr.fastAccessDx(index[lunk])), 1));
-              }
-
-            } else {
-              // Sum Jacobian entries all at once
-              for (unsigned int lunk = 0; lunk < nunk; lunk++) {
-                Albany::addToLocalRowValues(Jac,lrow,
-                                                Teuchos::arrayView(&lcols[lunk],1),
-                                                Teuchos::arrayView(&(valptr.fastAccessDx(index[lunk])), 1));
-              }
+            // Sum Jacobian entries all at once
+            for (unsigned int lunk = 0; lunk < nunk; lunk++) {
+              Albany::addToLocalRowValues(Jac,lrow,
+                                          Teuchos::arrayView(&lcols[lunk],1),
+                                          Teuchos::arrayView(&(valptr.fastAccessDx(index[lunk])), 1));
             }
           } // has fast access
         }

--- a/src/PHAL_Workset.hpp
+++ b/src/PHAL_Workset.hpp
@@ -175,11 +175,6 @@ struct Workset
   // significantly reduce Jacobian calculation cost.
   bool ignore_residual;
 
-  // Flag indicated whether we are solving the adjoint operator or the
-  // forward operator.  This is used in the Albany application when
-  // either the Jacobian or the transpose of the Jacobian is scattered.
-  bool is_adjoint;
-
   // New field manager response stuff
   Teuchos::RCP<const Teuchos::Comm<int>> comm;
 

--- a/src/evaluators/bc/PHAL_Neumann.hpp
+++ b/src/evaluators/bc/PHAL_Neumann.hpp
@@ -212,7 +212,6 @@ private:
 //  typedef typename Tpetra_CrsMatrix::local_matrix_type  LocalMatrixType;
 //  LocalMatrixType jacobian;
 //  Kokkos::View<int***, PHX::Device> Index;
-//  bool is_adjoint;
 
 //  typedef Kokkos::View<int***, PHX::Device>::execution_space ExecutionSpace;
 

--- a/src/evaluators/bc/PHAL_Neumann_Def.hpp
+++ b/src/evaluators/bc/PHAL_Neumann_Def.hpp
@@ -808,14 +808,8 @@ Neumann(Teuchos::ParameterList& p)
 //             // Global column
 //             colT[0] =  Index(cell, node_col, eq_col);
 //             value[0] = this->neumann(cell, node, dim).fastAccessDx(lcol);
-//             if (is_adjoint) {
-//               // Sum Jacobian transposed
-//               jacobian.sumIntoValues(colT[0], &rowT,1, &value[0], false, true);
-//             }
-//             else {
-//               // Sum Jacobian
+               // Sum Jacobian
 //               jacobian.sumIntoValues(rowT, colT, nunk,value, false, true);
-//             }
 //           } // column equations
 //         } // column nodes
 //       } // has fast access
@@ -879,13 +873,8 @@ evaluateFields(typename Traits::EvalData workset)
             // Global column
             col[0] =  nodeID(cell,node_col,eq_col);
             value[0] = this->neumann(cell, node, dim).fastAccessDx(lcol);
-            if (workset.is_adjoint) {
-              // Sum Jacobian transposed
-              Albany::addToLocalRowValues(jac,col[0],row(),value());
-            } else {
-              // Sum Jacobian
-              Albany::addToLocalRowValues(jac,row[0],col(),value());
-            }
+            // Sum Jacobian
+            Albany::addToLocalRowValues(jac,row[0],col(),value());
           } // column equations
         } // column nodes
       } // has fast access

--- a/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
@@ -535,26 +535,16 @@ evaluateFieldsDevice(typename Traits::EvalData workset)
       cudaCheckError();
     }
 
-    if (workset.is_adjoint) {
-      Kokkos::parallel_for(PHAL_ScatterJacRank0_Adjoint_Policy(0,workset.numCells),*this);  
-      cudaCheckError();
-    } else {
-      Kokkos::parallel_for(PHAL_ScatterJacRank0_Policy(0,workset.numCells),*this);
-      cudaCheckError();
-    }
+    Kokkos::parallel_for(PHAL_ScatterJacRank0_Policy(0,workset.numCells),*this);
+    cudaCheckError();
   } else  if (this->tensorRank == 1) {
     if (loadResid) {
       Kokkos::parallel_for(PHAL_ScatterResRank1_Policy(0,workset.numCells),*this);
       cudaCheckError();
     }
 
-    if (workset.is_adjoint) {
-      Kokkos::parallel_for(PHAL_ScatterJacRank1_Adjoint_Policy(0,workset.numCells),*this);
-      cudaCheckError();
-    } else {
-      Kokkos::parallel_for(PHAL_ScatterJacRank1_Policy(0,workset.numCells),*this);
-      cudaCheckError();
-    }
+    Kokkos::parallel_for(PHAL_ScatterJacRank1_Policy(0,workset.numCells),*this);
+    cudaCheckError();
   } else if (this->tensorRank == 2) {
     numDims = this->valTensor.extent(2);
 
@@ -563,13 +553,8 @@ evaluateFieldsDevice(typename Traits::EvalData workset)
       cudaCheckError();
     }
 
-    if (workset.is_adjoint) {
-      Kokkos::parallel_for(PHAL_ScatterJacRank2_Adjoint_Policy(0,workset.numCells),*this);
-    }
-    else {
-      Kokkos::parallel_for(PHAL_ScatterJacRank2_Policy(0,workset.numCells),*this);
-      cudaCheckError();
-    }
+    Kokkos::parallel_for(PHAL_ScatterJacRank2_Policy(0,workset.numCells),*this);
+    cudaCheckError();
   }
 
 #ifdef ALBANY_TIMER
@@ -622,17 +607,9 @@ evaluateFieldsHost(typename Traits::EvalData workset)
         }
         // Check derivative array is nonzero
         if (valptr.hasFastAccess()) {
-          if (workset.is_adjoint) {
-            // Sum Jacobian transposed
-            for (int lunk = 0; lunk < nunk; lunk++)
-              Albany::addToLocalRowValues(Jac,
-                col[lunk], Teuchos::arrayView(&row, 1),
-                Teuchos::arrayView(&(valptr.fastAccessDx(lunk)), 1));
-          } else {
-            // Sum Jacobian entries all at once
-            Albany::addToLocalRowValues(Jac,
-              row, col, Teuchos::arrayView(&(valptr.fastAccessDx(0)), nunk));
-          }
+          // Sum Jacobian entries all at once
+          Albany::addToLocalRowValues(Jac,
+            row, col, Teuchos::arrayView(&(valptr.fastAccessDx(0)), nunk));
         } // has fast access
       }
     }

--- a/src/evaluators/scatter/PHAL_ScatterSideEqnResidual_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterSideEqnResidual_Def.hpp
@@ -367,17 +367,9 @@ doEvaluateFieldsCell(typename Traits::EvalData workset, int cell, int side)
 
       // Check derivative array is nonzero
       if (valptr.hasFastAccess()) {
-        if (workset.is_adjoint) {
-          // Sum Jacobian transposed
-          for (int lunk = 0; lunk < nunk; lunk++)
-            Albany::addToLocalRowValues(Jac,
-              cols[lunk], Teuchos::arrayView(&row, 1),
-              Teuchos::arrayView(&(valptr.fastAccessDx(lunk)), 1));
-        } else {
-          // Sum Jacobian entries all at once
-          Albany::addToLocalRowValues(Jac,
-            row, cols, Teuchos::arrayView(&(valptr.fastAccessDx(0)), nunk));
-        }
+        // Sum Jacobian entries all at once
+        Albany::addToLocalRowValues(Jac,
+          row, cols, Teuchos::arrayView(&(valptr.fastAccessDx(0)), nunk));
       } // has fast access
     }
   }
@@ -418,17 +410,9 @@ doEvaluateFieldsSide(typename Traits::EvalData workset, int cell, int side, int 
 
       // Check derivative array is nonzero
       if (valptr.hasFastAccess()) {
-        if (workset.is_adjoint) {
-          // Sum Jacobian transposed
-          for (int lunk = 0; lunk < nunk; lunk++)
-            Albany::addToLocalRowValues(Jac,
-              cols[lunk], Teuchos::arrayView(&row, 1),
-              Teuchos::arrayView(&(valptr.fastAccessDx(lunk)), 1));
-        } else {
-          // Sum Jacobian entries all at once
-          Albany::addToLocalRowValues(Jac,
-            row, cols, Teuchos::arrayView(&(valptr.fastAccessDx(0)), nunk));
-        }
+        // Sum Jacobian entries all at once
+        Albany::addToLocalRowValues(Jac,
+          row, cols, Teuchos::arrayView(&(valptr.fastAccessDx(0)), nunk));
       } // has fast access
     }
   }

--- a/src/problems/Albany_AbstractProblem.cpp
+++ b/src/problems/Albany_AbstractProblem.cpp
@@ -136,7 +136,6 @@ Albany::AbstractProblem::getGenericProblemParams(std::string listname) const
   validPL->sublist("Dirichlet BCs", false, "");
   validPL->sublist("Neumann BCs", false, "");
   validPL->sublist("Adaptation", false, "");
-  validPL->set<bool>("Solve Adjoint", false, "");
   validPL->set<bool>("Overwrite Nominal Values With Final Point",false,
                      "Whether 'reportFinalPoint' should be allowed to overwrite nominal values");
   validPL->set<int>("Number Of Time Derivatives", 1, "Number of time derivatives in use in the problem");


### PR DESCRIPTION
Per discussion with @mperego , removing "is_adjoint" options, as these are obsolete / not used, and just cause confusion.  @mperego , can you please approve?