### PR TITLE
Add tests for the graph of the blocked Jacobian

### DIFF
--- a/src/utility/Albany_ThyraCrsMatrixFactory.cpp
+++ b/src/utility/Albany_ThyraCrsMatrixFactory.cpp
@@ -64,8 +64,10 @@ ThyraCrsMatrixFactory (const Teuchos::RCP<const Thyra_VectorSpace> domain_vs,
   TEUCHOS_TEST_FOR_EXCEPTION (bt==BuildType::None, std::logic_error, "Error! No build type set for albany.\n");
 
   if (sameAs(m_range_vs,m_ov_range_vs)) {
-    TEUCHOS_TEST_FOR_EXCEPTION (!sameAs(m_domain_vs,m_ov_domain_vs), std::runtime_error,
-                                "Error! Rnage and overlapped range vs coincide, but domain and overlapped domain vs do not.\n");
+    // Restrict this test for square matrices:
+    if(sameAs(m_range_vs,m_domain_vs))
+      TEUCHOS_TEST_FOR_EXCEPTION (!sameAs(m_domain_vs,m_ov_domain_vs), std::runtime_error,
+                                  "Error! Range and overlapped range vs coincide, but domain and overlapped domain vs do not.\n");
     m_fe_crs = false;
   } else {
     // When building a FECrs matrix, we REQUIRE the overlapped domain vs.

--- a/tests/unit/disc/CMakeLists.txt
+++ b/tests/unit/disc/CMakeLists.txt
@@ -61,11 +61,10 @@ IF (ALBANY_MPI)
 #  Throw test that evaluated to true: !isOneToOne(m_domain_vs)
 #  
 #  [ThyraCrsMatrixFactory] Error! When providing an overlapped domain vs, the domain vs must be one-to-one.
-#  
-
-#  ADD_TEST(
-#    Discretization_Parallel_Unit_Test ${PARALLEL_CALL} ${CMAKE_CURRENT_BINARY_DIR}/disc_unit_tester
-##  )
+#
+  ADD_TEST(
+    Discretization_Parallel_Unit_Test ${PARALLEL_CALL} ${CMAKE_CURRENT_BINARY_DIR}/disc_unit_tester
+  )
 ELSE(ALBANY_MPI)
   ADD_TEST(
     Discretization_Unit_Test ${CMAKE_CURRENT_BINARY_DIR}/disc_unit_tester

--- a/tests/unit/disc/CMakeLists.txt
+++ b/tests/unit/disc/CMakeLists.txt
@@ -41,6 +41,34 @@ set_target_properties(disc_unit_tester PROPERTIES
 
 TARGET_LINK_LIBRARIES(disc_unit_tester albanyLib ${ALB_TRILINOS_LIBS} ${Trilinos_EXTRA_LD_FLAGS})
 
+SET(SOURCES
+          ./UnitTest_BlockedJacobian.cpp
+          ../Albany_UnitTestMain.cpp
+)
+
+ADD_EXECUTABLE(
+  blockJacobian_unit_tester
+  ${HEADERS} ${SOURCES}
+)
+
+set_target_properties(blockJacobian_unit_tester PROPERTIES
+  PUBLIC_HEADER "${HEADERS}")
+
+TARGET_LINK_LIBRARIES(blockJacobian_unit_tester albanyLib ${ALB_TRILINOS_LIBS} ${Trilinos_EXTRA_LD_FLAGS})
+
+file(GLOB TESTFILES *.py)
+
+file(COPY ${TESTFILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/.)
+
+IF(NOT DEFINED PYTHON_EXECUTABLE)
+  find_program(PYTHON_EXECUTABLE
+      NAMES python3 python
+      )
+  MESSAGE("  -- CMake has set: PYTHON_EXECUTABLE = ${PYTHON_EXECUTABLE}")
+ENDIF()
+
+ADD_TEST(BlockDiscretization_Jacobian_Unit_Test "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/matrices_comparison.py")
+
 # We should always run the unit tests in both serial and parallel if possible (they should run quickly)
 IF (ALBANY_MPI)
   ADD_TEST(

--- a/tests/unit/disc/CMakeLists.txt
+++ b/tests/unit/disc/CMakeLists.txt
@@ -56,7 +56,7 @@ set_target_properties(blockJacobian_unit_tester PROPERTIES
 
 TARGET_LINK_LIBRARIES(blockJacobian_unit_tester albanyLib ${ALB_TRILINOS_LIBS} ${Trilinos_EXTRA_LD_FLAGS})
 
-file(GLOB TESTFILES *.py)
+set(TESTFILES matrices_comparison.py)
 
 file(COPY ${TESTFILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/.)
 

--- a/tests/unit/disc/UnitTest_BlockedDOFManager.cpp
+++ b/tests/unit/disc/UnitTest_BlockedDOFManager.cpp
@@ -103,7 +103,7 @@ tests are a beginning, "work in progress."
          const std::map<std::string, Teuchos::RCP<Albany::StateInfoStruct>> side_set_sis;
          const std::map<std::string, AbstractFieldContainer::FieldContainerRequirements> side_set_req;
 
-         ms->setFieldAndBulkData(comm, discParams, req, sis, meshStruct->getMeshSpecs()[0]->worksetSize,
+         ms->setFieldAndBulkData(comm, req, sis, meshStruct->getMeshSpecs()[0]->worksetSize,
                                  side_set_sis, side_set_req);
 
          // Null for this test
@@ -417,9 +417,11 @@ tests are a beginning, "work in progress."
                   << std::endl;
             if (verbose)
             {
-               *out1 << "Before describe jacobian " << i << " " << j << std::endl;
-               Albany::describe(jacobian.getConst(), *out1, Teuchos::VERB_EXTREME);
-               *out1 << "After describe jacobian " << i << " " << j << std::endl;
+               std::ofstream myfile;
+               RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(Teuchos::rcpFromRef(myfile));
+               myfile.open("b_jac_" + std::to_string(i) + "_" + std::to_string(j) + ".txt");
+               Albany::describe(jacobian.getConst(), *fancy, Teuchos::VERB_EXTREME);
+               myfile.close();
             }
          }
 

--- a/tests/unit/disc/UnitTest_BlockedDOFManager.cpp
+++ b/tests/unit/disc/UnitTest_BlockedDOFManager.cpp
@@ -44,11 +44,11 @@ namespace Albany
 {
 
    template <typename Intrepid2Type>
-   Teuchos::RCP<const panzer::FieldPattern> buildFieldPattern()
+   RCP<const panzer::FieldPattern> buildFieldPattern()
    {
       // build a geometric pattern from a single basis
-      Teuchos::RCP<Intrepid2::Basis<PHX::exec_space, double, double>> basis = rcp(new Intrepid2Type);
-      Teuchos::RCP<const panzer::FieldPattern> pattern = rcp(new panzer::Intrepid2FieldPattern(basis));
+      RCP<Intrepid2::Basis<PHX::exec_space, double, double>> basis = rcp(new Intrepid2Type);
+      RCP<const panzer::FieldPattern> pattern = rcp(new panzer::Intrepid2FieldPattern(basis));
       return pattern;
    }
 
@@ -69,21 +69,16 @@ tests are a beginning, "work in progress."
       // Set the static variable that denotes this as a Tpetra run
       static_cast<void>(Albany::build_type(Albany::BuildType::Tpetra));
 
-      Teuchos::RCP<const Teuchos_Comm> comm = Albany::getDefaultComm();
+      RCP<const Teuchos_Comm> comm = Albany::getDefaultComm();
       int numProcs = comm->getSize();
       int myRank = comm->getRank();
 
       if(numProcs==1) {
          // panzer::pauseToAttach();
-
-         using Teuchos::RCP;
-         using Teuchos::rcp;
-         using Teuchos::rcp_dynamic_cast;
-
          // Build an STK Discretization object that holds the test mesh "2D_Blk_Test.e"
 
          // 2D, quad, 3 block mesh built in Cubit.
-         Teuchos::RCP<Teuchos::ParameterList> discParams = rcp(new Teuchos::ParameterList);
+         RCP<Teuchos::ParameterList> discParams = rcp(new Teuchos::ParameterList);
          discParams->set<std::string>("Exodus Input File Name", "2D_Blk_Test.e");
          discParams->set<std::string>("Method", "Exodus");
          discParams->set<int>("Interleaved Ordering", 2);
@@ -93,25 +88,25 @@ tests are a beginning, "work in progress."
 
          // Need to test various meshes, with various element types and block structures.
 
-         Teuchos::RCP<Albany::AbstractMeshStruct> meshStruct;
+         RCP<Albany::AbstractMeshStruct> meshStruct;
          meshStruct = DiscretizationFactory::createMeshStruct(discParams, comm, 0);
-         auto ms = Teuchos::rcp_dynamic_cast<AbstractSTKMeshStruct>(meshStruct);
-         auto gms = Teuchos::rcp_dynamic_cast<GenericSTKMeshStruct>(meshStruct);
+         auto ms = rcp_dynamic_cast<AbstractSTKMeshStruct>(meshStruct);
+         auto gms = rcp_dynamic_cast<GenericSTKMeshStruct>(meshStruct);
 
          const AbstractFieldContainer::FieldContainerRequirements req;
-         const Teuchos::RCP<StateInfoStruct> sis = Teuchos::rcp(new StateInfoStruct());
-         const std::map<std::string, Teuchos::RCP<Albany::StateInfoStruct>> side_set_sis;
+         const RCP<StateInfoStruct> sis = rcp(new StateInfoStruct());
+         const std::map<std::string, RCP<Albany::StateInfoStruct>> side_set_sis;
          const std::map<std::string, AbstractFieldContainer::FieldContainerRequirements> side_set_req;
 
          ms->setFieldAndBulkData(comm, req, sis, meshStruct->getMeshSpecs()[0]->worksetSize,
                                  side_set_sis, side_set_req);
 
          // Null for this test
-         const Teuchos::RCP<Albany::RigidBodyModes> rigidBodyModes;
+         const RCP<Albany::RigidBodyModes> rigidBodyModes;
          const std::map<int, std::vector<std::string>> sideSetEquations;
 
          // Use the Albany STK interface as it is used elsewhere in the code
-         auto stkDisc = Teuchos::rcp(new STKDiscretization(discParams, 3, ms, comm, rigidBodyModes, sideSetEquations));
+         auto stkDisc = rcp(new STKDiscretization(discParams, 3, ms, comm, rigidBodyModes, sideSetEquations));
          stkDisc->updateMesh();
 
          // Connection manager is the interface between Albany's historical STK interface and the Panzer DOF manager (and the
@@ -277,18 +272,14 @@ tests are a beginning, "work in progress."
       // Set the static variable that denotes this as a Tpetra run
       static_cast<void>(Albany::build_type(Albany::BuildType::Tpetra));
 
-      Teuchos::RCP<const Teuchos_Comm> comm = Albany::getDefaultComm();
+      RCP<const Teuchos_Comm> comm = Albany::getDefaultComm();
 
       // panzer::pauseToAttach();
-
-      using Teuchos::RCP;
-      using Teuchos::rcp;
-      using Teuchos::rcp_dynamic_cast;
 
       bool useExodus = false;
       bool verbose = false;
 
-      Teuchos::RCP<Teuchos::ParameterList> discParams = rcp(new Teuchos::ParameterList);
+      RCP<Teuchos::ParameterList> discParams = rcp(new Teuchos::ParameterList);
 
       std::string sideName;
 
@@ -318,29 +309,29 @@ tests are a beginning, "work in progress."
 
       if (!useExodus)
       {
-         Teuchos::RCP<Teuchos::ParameterList> ssDiscParams = Teuchos::sublist(discParams, "Side Set Discretizations", false);
+         RCP<Teuchos::ParameterList> ssDiscParams = Teuchos::sublist(discParams, "Side Set Discretizations", false);
          Teuchos::Array<std::string> sideset(1);
          sideset[0] = sideName;
          ssDiscParams->set<Teuchos::Array<std::string>>("Side Sets", sideset);
-         Teuchos::RCP<Teuchos::ParameterList> params_ss = Teuchos::sublist(ssDiscParams, sideset[0], false);
+         RCP<Teuchos::ParameterList> params_ss = Teuchos::sublist(ssDiscParams, sideset[0], false);
          params_ss->set<std::string>("Method", "SideSetSTK");
       }
 
-      Teuchos::RCP<Albany::AbstractMeshStruct> meshStruct = DiscretizationFactory::createMeshStruct(discParams, comm, 0);
+      RCP<Albany::AbstractMeshStruct> meshStruct = DiscretizationFactory::createMeshStruct(discParams, comm, 0);
 
-      Teuchos::RCP<Teuchos::ParameterList> blockedDiscParams = rcp(new Teuchos::ParameterList);
-      Teuchos::RCP<Teuchos::ParameterList> mParams = Teuchos::sublist(blockedDiscParams, "Mesh", false);
+      RCP<Teuchos::ParameterList> blockedDiscParams = rcp(new Teuchos::ParameterList);
+      RCP<Teuchos::ParameterList> mParams = Teuchos::sublist(blockedDiscParams, "Mesh", false);
       mParams->set<std::string>("Name", "Body 1");
       mParams->set<std::string>("Type", "Extruded");
-      Teuchos::RCP<Teuchos::ParameterList> smParams = Teuchos::sublist(mParams, "Side Meshes", false);
+      RCP<Teuchos::ParameterList> smParams = Teuchos::sublist(mParams, "Side Meshes", false);
       smParams->set<std::string>("Sidesets", "[Bottom,Top]");
 
-      Teuchos::RCP<Teuchos::ParameterList> dParams = Teuchos::sublist(blockedDiscParams, "Discretization", false);
+      RCP<Teuchos::ParameterList> dParams = Teuchos::sublist(blockedDiscParams, "Discretization", false);
       dParams->set<int>("Num Blocks", 3);
 
-      Teuchos::RCP<Teuchos::ParameterList> db0Params = Teuchos::sublist(dParams, "Block 0", false);
-      Teuchos::RCP<Teuchos::ParameterList> db1Params = Teuchos::sublist(dParams, "Block 1", false);
-      Teuchos::RCP<Teuchos::ParameterList> db2Params = Teuchos::sublist(dParams, "Block 2", false);
+      RCP<Teuchos::ParameterList> db0Params = Teuchos::sublist(dParams, "Block 0", false);
+      RCP<Teuchos::ParameterList> db1Params = Teuchos::sublist(dParams, "Block 1", false);
+      RCP<Teuchos::ParameterList> db2Params = Teuchos::sublist(dParams, "Block 2", false);
 
       if (useExodus)
       {
@@ -374,21 +365,21 @@ tests are a beginning, "work in progress."
          dParams->set<std::string>("Side Name", sideName);
       }
 
-      Teuchos::RCP<Teuchos::ParameterList> sParams = Teuchos::sublist(blockedDiscParams, "Solution", false);
+      RCP<Teuchos::ParameterList> sParams = Teuchos::sublist(blockedDiscParams, "Solution", false);
       sParams->set<std::string>("blocks names", "[ [Ux, Uy, Uz], N, h]");
       sParams->set<std::string>("blocks discretizations", "[ [vol_C1, vol_C1, vol_C1], basal_C1, basal_C0 ]");
 
-      Teuchos::RCP<AbstractSTKMeshStruct> ms = Teuchos::rcp_dynamic_cast<AbstractSTKMeshStruct>(meshStruct);
+      RCP<AbstractSTKMeshStruct> ms = rcp_dynamic_cast<AbstractSTKMeshStruct>(meshStruct);
 
       const AbstractFieldContainer::FieldContainerRequirements req;
-      const Teuchos::RCP<StateInfoStruct> sis = Teuchos::rcp(new StateInfoStruct());
-      const std::map<std::string, Teuchos::RCP<Albany::StateInfoStruct>> side_set_sis;
+      const RCP<StateInfoStruct> sis = rcp(new StateInfoStruct());
+      const std::map<std::string, RCP<Albany::StateInfoStruct>> side_set_sis;
       const std::map<std::string, AbstractFieldContainer::FieldContainerRequirements> side_set_req;
 
       ms->setFieldAndBulkData(comm, req, sis, meshStruct->getMeshSpecs()[0]->worksetSize);
 
       // Use the Albany STK interface as it is used elsewhere in the code
-      auto stkDisc = Teuchos::rcp(new BlockedSTKDiscretization(blockedDiscParams, ms, comm));
+      auto stkDisc = rcp(new BlockedSTKDiscretization(blockedDiscParams, ms, comm));
       stkDisc->updateMesh();
 
       auto nvs = stkDisc->getOverlapProductVectorSpace();
@@ -401,19 +392,19 @@ tests are a beginning, "work in progress."
 
       TEST_EQUALITY(nvs->dim(), total_size);
 
-      Teuchos::RCP<Thyra_BlockedLinearOp> bJacobianOp = stkDisc->createBlockedJacobianOp();
+      RCP<Thyra_BlockedLinearOp> bJacobianOp = stkDisc->createBlockedJacobianOp();
 
-      Teuchos::RCP<Teuchos::FancyOStream> out1 = Teuchos::VerboseObjectBase::getDefaultOStream();
+      RCP<Teuchos::FancyOStream> out1 = Teuchos::VerboseObjectBase::getDefaultOStream();
 
       for (int i = 0; i < stkDisc->getNumFieldBlocks(); ++i)
          for (int j = 0; j < stkDisc->getNumFieldBlocks(); ++j)
          {
-            Teuchos::RCP<const Thyra_LinearOp> jacobian = bJacobianOp->getBlock(i, j);
+            RCP<const Thyra_LinearOp> jacobian = bJacobianOp->getBlock(i, j);
 
             auto top = Albany::getConstTpetraOperator(jacobian, false);
 
             *out1 << "Number of entries in the block (" << i << "," << j << ") = "
-                  << Teuchos::rcp_dynamic_cast<const Tpetra_CrsMatrix>(top)->getGlobalNumEntries()
+                  << rcp_dynamic_cast<const Tpetra_CrsMatrix>(top)->getGlobalNumEntries()
                   << std::endl;
             if (verbose)
             {

--- a/tests/unit/disc/UnitTest_BlockedJacobian.cpp
+++ b/tests/unit/disc/UnitTest_BlockedJacobian.cpp
@@ -45,11 +45,11 @@ namespace Albany
 {
 
    template <typename Intrepid2Type>
-   Teuchos::RCP<const panzer::FieldPattern> buildFieldPattern()
+   RCP<const panzer::FieldPattern> buildFieldPattern()
    {
       // build a geometric pattern from a single basis
-      Teuchos::RCP<Intrepid2::Basis<PHX::exec_space, double, double>> basis = rcp(new Intrepid2Type);
-      Teuchos::RCP<const panzer::FieldPattern> pattern = rcp(new panzer::Intrepid2FieldPattern(basis));
+      RCP<Intrepid2::Basis<PHX::exec_space, double, double>> basis = rcp(new Intrepid2Type);
+      RCP<const panzer::FieldPattern> pattern = rcp(new panzer::Intrepid2FieldPattern(basis));
       return pattern;
    }
 
@@ -59,15 +59,11 @@ namespace Albany
       // Set the static variable that denotes this as a Tpetra run
       static_cast<void>(Albany::build_type(Albany::BuildType::Tpetra));
 
-      Teuchos::RCP<const Teuchos_Comm> comm = Albany::getDefaultComm();
+      RCP<const Teuchos_Comm> comm = Albany::getDefaultComm();
 
       // panzer::pauseToAttach();
 
-      using Teuchos::RCP;
-      using Teuchos::rcp;
-      using Teuchos::rcp_dynamic_cast;
-
-      Teuchos::RCP<Teuchos::ParameterList> discParams = rcp(new Teuchos::ParameterList);
+      RCP<Teuchos::ParameterList> discParams = rcp(new Teuchos::ParameterList);
 
       std::string sideName;
 
@@ -81,62 +77,62 @@ namespace Albany
       discParams->set<int>("Number Of Time Derivatives", 0);
       discParams->set<bool>("Use Serial Mesh", 1);
 
-      Teuchos::RCP<Teuchos::ParameterList> ssDiscParams = Teuchos::sublist(discParams, "Side Set Discretizations", false);
+      RCP<Teuchos::ParameterList> ssDiscParams = Teuchos::sublist(discParams, "Side Set Discretizations", false);
       Teuchos::Array<std::string> sideset(1);
       sideset[0] = sideName;
       ssDiscParams->set<Teuchos::Array<std::string>>("Side Sets", sideset);
-      Teuchos::RCP<Teuchos::ParameterList> params_ss = Teuchos::sublist(ssDiscParams, sideset[0], false);
+      RCP<Teuchos::ParameterList> params_ss = Teuchos::sublist(ssDiscParams, sideset[0], false);
       params_ss->set<std::string>("Method", "SideSetSTK");
 
-      Teuchos::RCP<Albany::AbstractMeshStruct> meshStruct = DiscretizationFactory::createMeshStruct(discParams, comm, 0);
+      RCP<Albany::AbstractMeshStruct> meshStruct = DiscretizationFactory::createMeshStruct(discParams, comm, 0);
 
       // Blocked discretization:
       {
-         Teuchos::RCP<Teuchos::ParameterList> blockedDiscParams = rcp(new Teuchos::ParameterList);
-         Teuchos::RCP<Teuchos::ParameterList> mParams = Teuchos::sublist(blockedDiscParams, "Mesh", false);
+         RCP<Teuchos::ParameterList> blockedDiscParams = rcp(new Teuchos::ParameterList);
+         RCP<Teuchos::ParameterList> mParams = Teuchos::sublist(blockedDiscParams, "Mesh", false);
          mParams->set<std::string>("Name", "Body 1");
          mParams->set<std::string>("Type", "Extruded");
-         Teuchos::RCP<Teuchos::ParameterList> smParams = Teuchos::sublist(mParams, "Side Meshes", false);
+         RCP<Teuchos::ParameterList> smParams = Teuchos::sublist(mParams, "Side Meshes", false);
          smParams->set<std::string>("Sidesets", "[Bottom,Top]");
 
-         Teuchos::RCP<Teuchos::ParameterList> dParams = Teuchos::sublist(blockedDiscParams, "Discretization", false);
+         RCP<Teuchos::ParameterList> dParams = Teuchos::sublist(blockedDiscParams, "Discretization", false);
          dParams->set<int>("Num Blocks", 3);
 
-         Teuchos::RCP<Teuchos::ParameterList> db0Params = Teuchos::sublist(dParams, "Block 0", false);
-         Teuchos::RCP<Teuchos::ParameterList> db1Params = Teuchos::sublist(dParams, "Block 1", false);
-         Teuchos::RCP<Teuchos::ParameterList> db2Params = Teuchos::sublist(dParams, "Block 2", false);
+         RCP<Teuchos::ParameterList> db0Params = Teuchos::sublist(dParams, "Block 0", false);
+         RCP<Teuchos::ParameterList> db1Params = Teuchos::sublist(dParams, "Block 1", false);
+         RCP<Teuchos::ParameterList> db2Params = Teuchos::sublist(dParams, "Block 2", false);
 
          db0Params->set<std::string>("Name", "vol_C1");
          db0Params->set<std::string>("Mesh", "ElementBlock_Body_1");
          db0Params->set<std::string>("FE Type", "HGRAD_C1");
          db0Params->set<std::string>("Domain", "Volume");
 
-         Teuchos::RCP<Teuchos::ParameterList> sParams = Teuchos::sublist(blockedDiscParams, "Solution", false);
+         RCP<Teuchos::ParameterList> sParams = Teuchos::sublist(blockedDiscParams, "Solution", false);
          sParams->set<std::string>("blocks names", "[ [Ux], [Uy], [Uz], [N], [h] ]");
          sParams->set<std::string>("blocks discretizations", "[ [vol_C1], [vol_C1], [vol_C1], [vol_C1], [vol_C1] ]");
 
-         Teuchos::RCP<AbstractSTKMeshStruct> ms = Teuchos::rcp_dynamic_cast<AbstractSTKMeshStruct>(meshStruct);
+         RCP<AbstractSTKMeshStruct> ms = rcp_dynamic_cast<AbstractSTKMeshStruct>(meshStruct);
 
          const AbstractFieldContainer::FieldContainerRequirements req;
-         const Teuchos::RCP<StateInfoStruct> sis = Teuchos::rcp(new StateInfoStruct());
-         const std::map<std::string, Teuchos::RCP<Albany::StateInfoStruct>> side_set_sis;
+         const RCP<StateInfoStruct> sis = rcp(new StateInfoStruct());
+         const std::map<std::string, RCP<Albany::StateInfoStruct>> side_set_sis;
          const std::map<std::string, AbstractFieldContainer::FieldContainerRequirements> side_set_req;
 
          ms->setFieldAndBulkData(comm, req, sis, meshStruct->getMeshSpecs()[0]->worksetSize);
 
          // Use the Albany STK interface as it is used elsewhere in the code
-         auto stkDisc = Teuchos::rcp(new BlockedSTKDiscretization(blockedDiscParams, ms, comm));
+         auto stkDisc = rcp(new BlockedSTKDiscretization(blockedDiscParams, ms, comm));
          stkDisc->updateMesh();
 
-         Teuchos::RCP<Thyra_BlockedLinearOp> bJacobianOp = stkDisc->createBlockedJacobianOp();
+         RCP<Thyra_BlockedLinearOp> bJacobianOp = stkDisc->createBlockedJacobianOp();
 
          for (int i = 0; i < stkDisc->getNumFieldBlocks(); ++i)
             for (int j = 0; j < stkDisc->getNumFieldBlocks(); ++j)
             {
-               Teuchos::RCP<const Thyra_LinearOp> jacobian = bJacobianOp->getBlock(i, j);
+               RCP<const Thyra_LinearOp> jacobian = bJacobianOp->getBlock(i, j);
 
                std::ofstream myfile;
-               RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(Teuchos::rcpFromRef(myfile));
+               RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(rcpFromRef(myfile));
                myfile.open("b_jac_" + std::to_string(i) + "_" + std::to_string(j) + ".txt");
                Albany::describe(jacobian.getConst(), *fancy, Teuchos::VERB_EXTREME);
                myfile.close();
@@ -145,31 +141,31 @@ namespace Albany
 
       //Non-block discretization:
       {
-         Teuchos::RCP<Teuchos::ParameterList> dDiscParams = rcp(new Teuchos::ParameterList);
-         Teuchos::RCP<Teuchos::ParameterList> mParams = Teuchos::sublist(dDiscParams, "Mesh", false);
+         RCP<Teuchos::ParameterList> dDiscParams = rcp(new Teuchos::ParameterList);
+         RCP<Teuchos::ParameterList> mParams = Teuchos::sublist(dDiscParams, "Mesh", false);
          mParams->set<std::string>("Name", "Body 1");
          mParams->set<std::string>("Type", "Extruded");
 
          int neq = 5;
 
-         Teuchos::RCP<Albany::AbstractMeshStruct> meshStruct = DiscretizationFactory::createMeshStruct(discParams, comm, 0);
-         Teuchos::RCP<AbstractSTKMeshStruct> ms = Teuchos::rcp_dynamic_cast<AbstractSTKMeshStruct>(meshStruct);
+         RCP<Albany::AbstractMeshStruct> meshStruct = DiscretizationFactory::createMeshStruct(discParams, comm, 0);
+         RCP<AbstractSTKMeshStruct> ms = rcp_dynamic_cast<AbstractSTKMeshStruct>(meshStruct);
 
          const AbstractFieldContainer::FieldContainerRequirements req;
-         const Teuchos::RCP<StateInfoStruct> sis = Teuchos::rcp(new StateInfoStruct());
-         const std::map<std::string, Teuchos::RCP<Albany::StateInfoStruct>> side_set_sis;
+         const RCP<StateInfoStruct> sis = rcp(new StateInfoStruct());
+         const std::map<std::string, RCP<Albany::StateInfoStruct>> side_set_sis;
          const std::map<std::string, AbstractFieldContainer::FieldContainerRequirements> side_set_req;
 
          ms->setFieldAndBulkData(comm, req, sis, meshStruct->getMeshSpecs()[0]->worksetSize);
 
          // Use the Albany STK interface as it is used elsewhere in the code
-         auto stkDisc = Teuchos::rcp(new STKDiscretization(dDiscParams, neq, ms, comm));
+         auto stkDisc = rcp(new STKDiscretization(dDiscParams, neq, ms, comm));
          stkDisc->updateMesh();
 
-         Teuchos::RCP<Thyra_LinearOp> jacobian = stkDisc->createJacobianOp();
+         RCP<Thyra_LinearOp> jacobian = stkDisc->createJacobianOp();
 
          std::ofstream myfile;
-         RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(Teuchos::rcpFromRef(myfile));
+         RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(rcpFromRef(myfile));
          myfile.open("jac.txt");
          Albany::describe(jacobian.getConst(), *fancy, Teuchos::VERB_EXTREME);
          myfile.close();

--- a/tests/unit/disc/UnitTest_BlockedJacobian.cpp
+++ b/tests/unit/disc/UnitTest_BlockedJacobian.cpp
@@ -1,0 +1,178 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#include <Teuchos_ConfigDefs.hpp>
+#include <Teuchos_UnitTestHarness.hpp>
+#include <Teuchos_RCP.hpp>
+#include <Teuchos_TimeMonitor.hpp>
+
+#include <string>
+#include <iostream>
+#include <vector>
+#include <set>
+
+#include "Panzer_BlockedDOFManager.hpp"
+#include "Panzer_IntrepidFieldPattern.hpp"
+#include "Panzer_PauseToAttach.hpp"
+
+#include "Albany_GenericSTKMeshStruct.hpp"
+#include "Albany_DiscretizationFactory.hpp"
+#include "Albany_STKDiscretization.hpp"
+#include "STKConnManager.hpp"
+#include "Albany_BlockedSTKDiscretization.hpp"
+
+// include some intrepid basis functions
+// 2D basis
+#include "Intrepid2_HGRAD_QUAD_C1_FEM.hpp"
+
+#include "Kokkos_DynRankView.hpp"
+
+#include "Albany_ThyraUtils.hpp"
+
+#include "Albany_IossSTKMeshStruct.hpp"
+
+using Teuchos::rcp;
+using Teuchos::RCP;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::rcpFromRef;
+
+typedef Kokkos::DynRankView<double, PHX::Device> FieldContainer;
+
+namespace Albany
+{
+
+   template <typename Intrepid2Type>
+   Teuchos::RCP<const panzer::FieldPattern> buildFieldPattern()
+   {
+      // build a geometric pattern from a single basis
+      Teuchos::RCP<Intrepid2::Basis<PHX::exec_space, double, double>> basis = rcp(new Intrepid2Type);
+      Teuchos::RCP<const panzer::FieldPattern> pattern = rcp(new panzer::Intrepid2FieldPattern(basis));
+      return pattern;
+   }
+
+   TEUCHOS_UNIT_TEST(AlbanyBlockedDOFManager_BlockedJacobian, assortedTests)
+   {
+
+      // Set the static variable that denotes this as a Tpetra run
+      static_cast<void>(Albany::build_type(Albany::BuildType::Tpetra));
+
+      Teuchos::RCP<const Teuchos_Comm> comm = Albany::getDefaultComm();
+
+      // panzer::pauseToAttach();
+
+      using Teuchos::RCP;
+      using Teuchos::rcp;
+      using Teuchos::rcp_dynamic_cast;
+
+      Teuchos::RCP<Teuchos::ParameterList> discParams = rcp(new Teuchos::ParameterList);
+
+      std::string sideName;
+
+      discParams->set<std::string>("Gmsh Input Mesh File Name", "cube.msh");
+      discParams->set<std::string>("Method", "Gmsh");
+
+      sideName = "BoundarySideSet_Bottom";
+
+      discParams->set<int>("Interleaved Ordering", 2);
+      discParams->set<bool>("Use Composite Tet 10", 0);
+      discParams->set<int>("Number Of Time Derivatives", 0);
+      discParams->set<bool>("Use Serial Mesh", 1);
+
+      Teuchos::RCP<Teuchos::ParameterList> ssDiscParams = Teuchos::sublist(discParams, "Side Set Discretizations", false);
+      Teuchos::Array<std::string> sideset(1);
+      sideset[0] = sideName;
+      ssDiscParams->set<Teuchos::Array<std::string>>("Side Sets", sideset);
+      Teuchos::RCP<Teuchos::ParameterList> params_ss = Teuchos::sublist(ssDiscParams, sideset[0], false);
+      params_ss->set<std::string>("Method", "SideSetSTK");
+
+      Teuchos::RCP<Albany::AbstractMeshStruct> meshStruct = DiscretizationFactory::createMeshStruct(discParams, comm, 0);
+
+      // Blocked discretization:
+      {
+         Teuchos::RCP<Teuchos::ParameterList> blockedDiscParams = rcp(new Teuchos::ParameterList);
+         Teuchos::RCP<Teuchos::ParameterList> mParams = Teuchos::sublist(blockedDiscParams, "Mesh", false);
+         mParams->set<std::string>("Name", "Body 1");
+         mParams->set<std::string>("Type", "Extruded");
+         Teuchos::RCP<Teuchos::ParameterList> smParams = Teuchos::sublist(mParams, "Side Meshes", false);
+         smParams->set<std::string>("Sidesets", "[Bottom,Top]");
+
+         Teuchos::RCP<Teuchos::ParameterList> dParams = Teuchos::sublist(blockedDiscParams, "Discretization", false);
+         dParams->set<int>("Num Blocks", 3);
+
+         Teuchos::RCP<Teuchos::ParameterList> db0Params = Teuchos::sublist(dParams, "Block 0", false);
+         Teuchos::RCP<Teuchos::ParameterList> db1Params = Teuchos::sublist(dParams, "Block 1", false);
+         Teuchos::RCP<Teuchos::ParameterList> db2Params = Teuchos::sublist(dParams, "Block 2", false);
+
+         db0Params->set<std::string>("Name", "vol_C1");
+         db0Params->set<std::string>("Mesh", "ElementBlock_Body_1");
+         db0Params->set<std::string>("FE Type", "HGRAD_C1");
+         db0Params->set<std::string>("Domain", "Volume");
+
+         Teuchos::RCP<Teuchos::ParameterList> sParams = Teuchos::sublist(blockedDiscParams, "Solution", false);
+         sParams->set<std::string>("blocks names", "[ [Ux], [Uy], [Uz], [N], [h] ]");
+         sParams->set<std::string>("blocks discretizations", "[ [vol_C1], [vol_C1], [vol_C1], [vol_C1], [vol_C1] ]");
+
+         Teuchos::RCP<AbstractSTKMeshStruct> ms = Teuchos::rcp_dynamic_cast<AbstractSTKMeshStruct>(meshStruct);
+
+         const AbstractFieldContainer::FieldContainerRequirements req;
+         const Teuchos::RCP<StateInfoStruct> sis = Teuchos::rcp(new StateInfoStruct());
+         const std::map<std::string, Teuchos::RCP<Albany::StateInfoStruct>> side_set_sis;
+         const std::map<std::string, AbstractFieldContainer::FieldContainerRequirements> side_set_req;
+
+         ms->setFieldAndBulkData(comm, req, sis, meshStruct->getMeshSpecs()[0]->worksetSize);
+
+         // Use the Albany STK interface as it is used elsewhere in the code
+         auto stkDisc = Teuchos::rcp(new BlockedSTKDiscretization(blockedDiscParams, ms, comm));
+         stkDisc->updateMesh();
+
+         Teuchos::RCP<Thyra_BlockedLinearOp> bJacobianOp = stkDisc->createBlockedJacobianOp();
+
+         for (int i = 0; i < stkDisc->getNumFieldBlocks(); ++i)
+            for (int j = 0; j < stkDisc->getNumFieldBlocks(); ++j)
+            {
+               Teuchos::RCP<const Thyra_LinearOp> jacobian = bJacobianOp->getBlock(i, j);
+
+               std::ofstream myfile;
+               RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(Teuchos::rcpFromRef(myfile));
+               myfile.open("b_jac_" + std::to_string(i) + "_" + std::to_string(j) + ".txt");
+               Albany::describe(jacobian.getConst(), *fancy, Teuchos::VERB_EXTREME);
+               myfile.close();
+            }
+      }
+
+      //Non-block discretization:
+      {
+         Teuchos::RCP<Teuchos::ParameterList> dDiscParams = rcp(new Teuchos::ParameterList);
+         Teuchos::RCP<Teuchos::ParameterList> mParams = Teuchos::sublist(dDiscParams, "Mesh", false);
+         mParams->set<std::string>("Name", "Body 1");
+         mParams->set<std::string>("Type", "Extruded");
+
+         int neq = 5;
+
+         Teuchos::RCP<Albany::AbstractMeshStruct> meshStruct = DiscretizationFactory::createMeshStruct(discParams, comm, 0);
+         Teuchos::RCP<AbstractSTKMeshStruct> ms = Teuchos::rcp_dynamic_cast<AbstractSTKMeshStruct>(meshStruct);
+
+         const AbstractFieldContainer::FieldContainerRequirements req;
+         const Teuchos::RCP<StateInfoStruct> sis = Teuchos::rcp(new StateInfoStruct());
+         const std::map<std::string, Teuchos::RCP<Albany::StateInfoStruct>> side_set_sis;
+         const std::map<std::string, AbstractFieldContainer::FieldContainerRequirements> side_set_req;
+
+         ms->setFieldAndBulkData(comm, req, sis, meshStruct->getMeshSpecs()[0]->worksetSize);
+
+         // Use the Albany STK interface as it is used elsewhere in the code
+         auto stkDisc = Teuchos::rcp(new STKDiscretization(dDiscParams, neq, ms, comm));
+         stkDisc->updateMesh();
+
+         Teuchos::RCP<Thyra_LinearOp> jacobian = stkDisc->createJacobianOp();
+
+         std::ofstream myfile;
+         RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(Teuchos::rcpFromRef(myfile));
+         myfile.open("jac.txt");
+         Albany::describe(jacobian.getConst(), *fancy, Teuchos::VERB_EXTREME);
+         myfile.close();
+      }
+   }
+}

--- a/tests/unit/disc/matrices_comparison.py
+++ b/tests/unit/disc/matrices_comparison.py
@@ -1,0 +1,151 @@
+import numpy as np
+import re
+from scipy.sparse import csr_matrix
+import unittest
+import subprocess
+import os.path
+
+
+def remove_all_non_num(line):
+    return re.sub('[^0-9.]', ' ', line)
+
+
+def read_matrix(name):
+    read_data = False
+
+    row_ptr = np.zeros((1,), dtype=int)
+    row_indices = np.zeros((1,), dtype=int)
+    col_indices = np.zeros((1,), dtype=int)
+    values = np.zeros((1,), dtype=float)
+
+    tmp_col_indices = np.zeros((1,), dtype=int)
+    tmp_values = np.zeros((1,), dtype=float)
+
+    nrows_read = False
+    nnz_read = False
+    max_nnz_read = False
+    tmp_resize = False
+
+    with open(name, 'r') as bfile:
+        lines = bfile.read().splitlines()
+        for l in lines:
+            if read_data:
+                data = np.fromstring(remove_all_non_num(l),
+                                     dtype=float, sep=' ')
+
+                current_row = int(data[1])
+                nnz_current_row = int(data[2])
+
+                row_ptr[current_row+1] = nnz_current_row
+
+                for i in range(0, nnz_current_row):
+                    tmp_col_indices[current_row, i] = int(data[3 + 2*i])
+                    tmp_values[current_row, i] = data[4 + 2*i]
+
+            if 'Entries(Index,Value)' in l:
+                read_data = True
+
+            if 'Global dimensions' in l and not nrows_read:
+                data = np.fromstring(remove_all_non_num(l), dtype=int, sep=' ')
+                nrows = data[0]
+                ncols = data[1]
+                row_ptr = np.resize(row_ptr, (nrows+1,))
+                row_ptr[0] = 0
+                nrows_read = True
+
+            if 'Global number of entries' in l and not nnz_read:
+                data = np.fromstring(remove_all_non_num(l), dtype=int, sep=' ')
+                nnz = data[0]
+                row_indices = np.resize(col_indices, (nnz,))
+                col_indices = np.resize(col_indices, (nnz,))
+                values = np.resize(values, (nnz,))
+                nnz_read = True
+
+            if 'Max number of entries per row' in l and not max_nnz_read:
+                data = np.fromstring(remove_all_non_num(l), dtype=int, sep=' ')
+                max_nnz = data[0]
+                max_nnz_read = True
+
+            if max_nnz_read and nrows_read and not tmp_resize:
+                tmp_col_indices = np.resize(tmp_col_indices, (nrows, max_nnz))
+                tmp_values = np.resize(tmp_values, (nrows, max_nnz))
+                tmp_resize = True
+
+    for current_row in range(0, nrows):
+        nnz_current_row = row_ptr[current_row+1]
+        row_ptr[current_row+1] = row_ptr[current_row] + nnz_current_row
+
+        for i in range(0, nnz_current_row):
+            row_indices[row_ptr[current_row] +
+                        i] = current_row
+            col_indices[row_ptr[current_row] +
+                        i] = tmp_col_indices[current_row, i]
+            values[row_ptr[current_row] + i] = tmp_values[current_row, i]
+
+    return row_indices, col_indices, values, nrows, ncols
+
+
+def read_block(i_block, j_block, base_dir, extension=".txt"):
+    return read_matrix(base_dir+str(i_block)+"_"+str(j_block)+extension)
+
+
+def fuse_blocks(n_blocks, m_blocks, base_dir, extension=".txt"):
+    row_indices = np.array((), dtype=int)
+    col_indices = np.array((), dtype=int)
+    values = np.array((), dtype=float)
+
+    nrows_per_block = np.zeros((n_blocks+1,), dtype=int)
+    ncols_per_block = np.zeros((m_blocks+1,), dtype=int)
+
+    for i_block in range(0, n_blocks):
+        for j_block in range(0, m_blocks):
+            tmp_row_indices, tmp_col_indices, tmp_values, nrows, ncols = read_block(
+                i_block, j_block, base_dir)
+            nrows_per_block[i_block+1] = nrows_per_block[i_block] + nrows
+            ncols_per_block[j_block+1] = ncols_per_block[j_block] + ncols
+            row_indices = np.append(
+                row_indices, nrows_per_block[i_block] + tmp_row_indices)
+            col_indices = np.append(
+                col_indices, ncols_per_block[j_block] + tmp_col_indices)
+            values = np.append(values, tmp_values)
+    total_nrows = nrows_per_block[-1]
+    total_ncols = ncols_per_block[-1]
+    return row_indices, col_indices, values, total_nrows, total_ncols, nrows_per_block, ncols_per_block
+
+
+class TestBlockJacobian(unittest.TestCase):
+    def test_graph(self):
+        n_blocks = 5
+        # Remove previously computed files:
+        if os.path.isfile('jac.txt'):
+            os.remove('jac.txt')
+        for i in range(0, n_blocks):
+            for j in range(0, n_blocks):
+                if os.path.isfile('b_jac_'+str(i)+'_'+str(j)+'.txt'):
+                    os.remove('b_jac_'+str(i)+'_'+str(j)+'.txt')
+
+        subprocess.call('./blockJacobian_unit_tester')
+
+        row_indices, col_indices, values, nrows, ncols, nrows_per_block, ncols_per_block = fuse_blocks(
+            n_blocks, n_blocks, "b_jac_")
+
+        nnz_total = len(col_indices)
+
+        A = csr_matrix(
+            (values+1, (row_indices, col_indices)), shape=(nrows, ncols))
+
+        row_indices, col_indices, values, nrows, ncols = read_matrix("jac.txt")
+
+        jac = csr_matrix(
+            (values+1, (row_indices, col_indices)), shape=(nrows, ncols))
+
+        nnz_jac = len(col_indices)
+
+        tol = 1e-8
+
+        self.assertEqual(nnz_jac, nnz_total)
+        self.assertTrue(np.amax(np.abs(A-jac)) < tol)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This small PR adds a test for the graph of the blocked Jacobian and run the previously developed test with MPI.

This PR modifies 5 files:
* src/utility/Albany_ThyraCrsMatrixFactory.cpp : this file had to be modified as, in the case of a block_(1,0) with MPI we can have that the `m_range_vs` and `m_ov_range_vs` are the same but not `m_domain_vs` and `m_ov_domain_vs`, @bartgol are you fine with this?
* tests/unit/disc/CMakeLists.txt has been modified to run the previous test with MPI and to add the new test,
* tests/unit/disc/UnitTest_BlockedDOFManager.cpp : this file has been modified not to run `AlbanyBlockedDOFManager_SimpleTests ` with MPI (as discussed in the comments by @gahansen , this test does not run with MPI),
* tests/unit/disc/UnitTest_BlockedJacobian.cpp and tests/unit/disc/matrices_comparison.py have been added to test the graph of the block Jacobian. The test behaves as follows:
   1. The python script is run by `ctest` and starts by cleaning previously generated files if any, 
   2. It runs the executable built based on tests/unit/disc/UnitTest_BlockedJacobian.cpp , this creates the graph of the Jacobian using the blocked discretization and the non-block discretization, the graphs of all the blocks and the graph of the full matrix are printed to files,
   3. The python scripts then read the files and create scipy sparse matrices corresponding to the two graphs, it sets all the nonzero values to 1,
   4. Finally, the script verifies that the number of non-zeros are the same and that the difference of the two matrices is zero; if both checks are verified, the ctest test pass.

 The tests passed on Blake and the code is building warning-free.