### PR TITLE
Add checks not to run BlockDiscretization_Jacobian_Unit_Test

### DIFF
--- a/tests/unit/disc/CMakeLists.txt
+++ b/tests/unit/disc/CMakeLists.txt
@@ -41,25 +41,9 @@ set_target_properties(disc_unit_tester PROPERTIES
 
 TARGET_LINK_LIBRARIES(disc_unit_tester albanyLib ${ALB_TRILINOS_LIBS} ${Trilinos_EXTRA_LD_FLAGS})
 
-SET(SOURCES
-          ./UnitTest_BlockedJacobian.cpp
-          ../Albany_UnitTestMain.cpp
-)
+set(PYTHON_TEST TRUE)
 
-ADD_EXECUTABLE(
-  blockJacobian_unit_tester
-  ${HEADERS} ${SOURCES}
-)
-
-set_target_properties(blockJacobian_unit_tester PROPERTIES
-  PUBLIC_HEADER "${HEADERS}")
-
-TARGET_LINK_LIBRARIES(blockJacobian_unit_tester albanyLib ${ALB_TRILINOS_LIBS} ${Trilinos_EXTRA_LD_FLAGS})
-
-set(TESTFILES matrices_comparison.py)
-
-file(COPY ${TESTFILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/.)
-
+# If not python executable is set, find the one in the path (if any):
 IF(NOT DEFINED PYTHON_EXECUTABLE)
   find_program(PYTHON_EXECUTABLE
       NAMES python3 python
@@ -67,7 +51,63 @@ IF(NOT DEFINED PYTHON_EXECUTABLE)
   MESSAGE("  -- CMake has set: PYTHON_EXECUTABLE = ${PYTHON_EXECUTABLE}")
 ENDIF()
 
-ADD_TEST(BlockDiscretization_Jacobian_Unit_Test "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/matrices_comparison.py")
+# Get the python version
+EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c
+                        "import sys; print(sys.version[:3])"
+  OUTPUT_VARIABLE PYTHON_VERSION
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+IF(${PYTHON_VERSION} VERSION_LESS 2.7)
+  set(PYTHON_TEST FALSE)
+  MESSAGE("The PYTHON_EXECUTABLE = ${PYTHON_EXECUTABLE} is older than 2.7.0, the test BlockDiscretization_Jacobian_Unit_Test will NOT be run.")
+ELSE()
+  # Verify that numpy and scipy are available:
+  EXECUTE_PROCESS(COMMAND
+    ${PYTHON_EXECUTABLE} -c "import numpy; print(numpy.__version__)"
+    OUTPUT_VARIABLE NUMPY_VERSION
+    ERROR_VARIABLE  NUMPY_VERSION_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  EXECUTE_PROCESS(COMMAND
+    ${PYTHON_EXECUTABLE} -c "import scipy; print(scipy.__version__)"
+    OUTPUT_VARIABLE SCIPY_VERSION
+    ERROR_VARIABLE  SCIPY_VERSION_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  IF(NUMPY_VERSION_ERROR OR SCIPY_VERSION_ERROR)
+    set(PYTHON_TEST FALSE)
+    MESSAGE("The PYTHON_EXECUTABLE = ${PYTHON_EXECUTABLE} does not support numpy or scipy, the test BlockDiscretization_Jacobian_Unit_Test will NOT be run.")
+  ELSE()
+    IF(${SCIPY_VERSION} VERSION_LESS 1.2.1 OR ${NUMPY_VERSION} VERSION_LESS 1.15.1)
+      set(PYTHON_TEST FALSE)
+      MESSAGE("The PYTHON_EXECUTABLE = ${PYTHON_EXECUTABLE} supports numpy and scipy but one of them is too old, the test BlockDiscretization_Jacobian_Unit_Test will NOT be run.")
+    ELSE()
+      MESSAGE("The PYTHON_EXECUTABLE = ${PYTHON_EXECUTABLE} supports numpy and scipy, the test BlockDiscretization_Jacobian_Unit_Test will be run.")
+    ENDIF()
+  ENDIF()
+ENDIF()
+
+IF(${PYTHON_TEST})
+  SET(SOURCES
+            ./UnitTest_BlockedJacobian.cpp
+            ../Albany_UnitTestMain.cpp
+  )
+
+  ADD_EXECUTABLE(
+    blockJacobian_unit_tester
+    ${HEADERS} ${SOURCES}
+  )
+
+  set_target_properties(blockJacobian_unit_tester PROPERTIES
+    PUBLIC_HEADER "${HEADERS}")
+
+  TARGET_LINK_LIBRARIES(blockJacobian_unit_tester albanyLib ${ALB_TRILINOS_LIBS} ${Trilinos_EXTRA_LD_FLAGS})
+
+  set(TESTFILES matrices_comparison.py)
+
+  file(COPY ${TESTFILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/.)
+  ADD_TEST(BlockDiscretization_Jacobian_Unit_Test "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/matrices_comparison.py")
+ENDIF()
 
 # We should always run the unit tests in both serial and parallel if possible (they should run quickly)
 IF (ALBANY_MPI)


### PR DESCRIPTION
 If the PYTHON_EXECUTABLE is not sufficiently new or does not support sufficiently new numpy or scipy, these CMAKE modifications prevent from running the test BlockDiscretization_Jacobian_Unit_Test.

This is related to issue #703.

EDIT: I should specify that the versions of python, scipy, and numpy listed are the oldest ones with which I tried the test. The test can work with older versions but it has not been tested. If needed, those can be changed.