### PR TITLE
Fix coordinates passed into ML libs and used to compute nullspace

### DIFF
--- a/src/Albany_NullSpaceUtils.cpp
+++ b/src/Albany_NullSpaceUtils.cpp
@@ -33,7 +33,7 @@ void ComputeNullSpace(
   auto data = getLocalData(coordMV.getConst());
 
   // At least component x should be there
-  const int numNodes = data[0].size(); // length of each vector in the multivector
+  const int numNodes = data[0].size(); // local length of each vector
 
   Teuchos::ArrayRCP<const ST> x, y, z;
   x = data[0];
@@ -84,7 +84,7 @@ void ComputeNullSpace(
 void subtractCentroid(const Teuchos::RCP<Thyra_MultiVector> &coordMV)
 {
   auto spmd_vs = getSpmdVectorSpace(coordMV->range());
-  const int nnodes = spmd_vs->localSubDim(); // local length of each vector
+  const int numNodes = spmd_vs->localSubDim(); // local length of each vector
   const int ndim = coordMV->domain()->dim(); // Number of multivectors are the dimension of the problem
 
   auto data = getNonconstLocalData(coordMV);
@@ -94,17 +94,17 @@ void subtractCentroid(const Teuchos::RCP<Thyra_MultiVector> &coordMV)
     for (int i = 0; i < ndim; ++i) {
       Teuchos::ArrayRCP<const ST> x = data[i];
       sum[i] = 0;
-      for (int j = 0; j < nnodes; ++j) sum[i] += x[j];
+      for (int j = 0; j < numNodes; ++j) sum[i] += x[j];
     }
     Teuchos::reduceAll(*createTeuchosCommFromThyraComm(spmd_vs->getComm()), Teuchos::REDUCE_SUM, ndim,
                                 sum, centroid);
-    const int numNodes = spmd_vs->localSubDim(); // length of each vector in the multivector
-    for (int i = 0; i < ndim; ++i) centroid[i] /= numNodes;
+    const int numGlobalNodes = spmd_vs->dim(); // global length of each vector in the multivector
+    for (int i = 0; i < ndim; ++i) centroid[i] /= numGlobalNodes;
   }
 
   for (int i = 0; i < ndim; ++i) {
     Teuchos::ArrayRCP<ST> x = data[i];
-    for (Teuchos::ArrayRCP<ST>::size_type j = 0; j < nnodes; ++j)
+    for (Teuchos::ArrayRCP<ST>::size_type j = 0; j < numNodes; ++j)
       x[j] -= centroid[i];
   }
 }
@@ -342,6 +342,9 @@ setCoordinatesAndComputeNullspace(const Teuchos::RCP<Thyra_MultiVector>& coordMV
       plist->set("null space: add default vectors", false);
 
     } else {  // MueLu and FROSch
+      TEUCHOS_TEST_FOR_EXCEPTION(soln_vs.is_null(), std::logic_error,
+          "nullSpaceDim > 0 and (isMueLuUsed() or isFROSchUsed()): solution vector space must be provided.");
+
       using NullSpaceTraits = TpetraNullSpaceTraits;
       auto& tpetraTraitsArray =
           Teuchos::rcp_dynamic_cast<TraitsImpl<NullSpaceTraits>>(nullSpaceTraits)->array;
@@ -351,14 +354,11 @@ setCoordinatesAndComputeNullspace(const Teuchos::RCP<Thyra_MultiVector>& coordMV
 
       ComputeNullSpace(nullSpace, coordMV, interleavedOrdering, numPDEs, computeConstantModes, physVectorDim, computeRotationModes);
 
-      TEUCHOS_TEST_FOR_EXCEPTION(
-        soln_vs.is_null(), std::logic_error,
-        "numElasticityDim > 0 and (isMueLuUsed() or isFROSchUsed()): soln_map must be provided.");
-        if (isMueLuUsed()) {
-          plist->set("Nullspace", tpetraTraitsArray);
-        } else { // This means that FROSch is used
-          plist->set("Null Space", tpetraTraitsArray);
-        }
+      if (isMueLuUsed()) {
+        plist->set("Nullspace", tpetraTraitsArray);
+      } else { // This means that FROSch is used
+        plist->set("Null Space", tpetraTraitsArray);
+      }
     }
   }
   if(isFROSchUsed()) {

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -137,9 +137,23 @@ STKDiscretization::printCoords() const
 {
   std::cout << "Processor " << bulkData->parallel_rank() << " has "
             << coords.size() << " worksets.\n";
+
+  const int numDim = stkMeshStruct->numDim;
+  double xmin = std::numeric_limits<double>::max(), xmax = std::numeric_limits<double>::lowest(),
+      ymin = xmin, ymax = xmax, zmin = xmin, zmax = xmax;
   for (int ws = 0; ws < coords.size(); ws++) {
     for (int e = 0; e < coords[ws].size(); e++) {
       for (int j = 0; j < coords[ws][e].size(); j++) {
+        xmin = std::min(xmin, coords[ws][e][j][0]);
+        xmax = std::max(xmax, coords[ws][e][j][0]);
+        if (numDim > 1) {
+          ymin = std::min(ymin, coords[ws][e][j][1]);
+          ymax = std::max(ymax, coords[ws][e][j][1]);
+        }
+        if (numDim > 2) {
+          zmin = std::min(zmin, coords[ws][e][j][2]);
+          zmax = std::max(zmax, coords[ws][e][j][2]);
+        }
         std::cout << "Coord for workset: " << ws << " element: " << e
                   << " node: " << j << " x, y, z: " << coords[ws][e][j][0]
                   << ", " << coords[ws][e][j][1] << ", " << coords[ws][e][j][2]
@@ -147,6 +161,15 @@ STKDiscretization::printCoords() const
       }
     }
   }
+
+  std::cout << "Processor " << bulkData->parallel_rank() << " has the following x-range: ["
+      << xmin << ", " << xmax << "]" << std::endl;
+  if (numDim > 1)
+    std::cout << "Processor " << bulkData->parallel_rank() << " has the following y-range: ["
+        << ymin << ", " << ymax << "]" << std::endl;
+  if (numDim > 2)
+    std::cout << "Processor " << bulkData->parallel_rank() << " has the following z-range: ["
+        << zmin << ", " << zmax << "]" << std::endl;
 }
 
 const Teuchos::ArrayRCP<double>&
@@ -538,6 +561,7 @@ STKDiscretization::setupMLCoords()
     }
   }
   rigidBodyModes->setCoordinatesAndComputeNullspace(coordMV, interleavedOrdering, m_vs, m_overlap_vs);
+  writeCoordsToMatrixMarket();
 }
 
 void

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -4,5 +4,41 @@
 ##    in the file "license.txt" in the top-level Albany directory  //
 ##*****************************************************************//
 
+#####################################################################
+# NullSpaceUtils unit tests
+INCLUDE_DIRECTORIES(
+  ${Trilinos_INCLUDE_DIRS}
+  ${Trilinos_TPL_INCLUDE_DIRS}
+  ${CMAKE_BINARY_DIR}/src
+  ${CMAKE_SOURCE_DIR}/src
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+SET(SOURCES
+  ./UnitTest_NullSpaceUtils.cpp
+  ./Albany_UnitTestMain.cpp
+)
+
+#LINK_DIRECTORIES(${Trilinos_LIBRARY_DIRS} ${Trilinos_TPL_LIBRARY_DIRS})
+
+ADD_EXECUTABLE(
+  nullSpaceUtils_unit_tester
+  ${SOURCES}
+)
+
+TARGET_LINK_LIBRARIES(nullSpaceUtils_unit_tester albanyLib ${ALB_TRILINOS_LIBS} ${Trilinos_EXTRA_LD_FLAGS})
+
+ADD_TEST(
+  NullSpaceUtils_Serial_Unit_Test ${SERIAL_CALL} ${CMAKE_CURRENT_BINARY_DIR}/nullSpaceUtils_unit_tester
+)
+IF(ALBANY_MPI)
+  ADD_TEST(
+    NullSpaceUtils_Parallel_Unit_Test ${PARALLEL_CALL} ${CMAKE_CURRENT_BINARY_DIR}/nullSpaceUtils_unit_tester
+  )
+ENDIF(ALBANY_MPI)
+
+#####################################################################
+
 add_subdirectory(evaluators)
 add_subdirectory(disc)
+

--- a/tests/unit/UnitTest_NullSpaceUtils.cpp
+++ b/tests/unit/UnitTest_NullSpaceUtils.cpp
@@ -1,0 +1,250 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#include <Teuchos_UnitTestHarness.hpp>
+#include <numeric>
+#include <stdexcept>
+#include <vector>
+
+#include "Albany_Macros.hpp"
+#include "Albany_NullSpaceUtils.hpp"
+#include "Albany_ThyraUtils.hpp"
+#include "Albany_TpetraTypes.hpp"
+#include "Albany_TpetraThyraUtils.hpp"
+
+namespace {
+
+struct Cube
+{
+  static constexpr int numDims = 3;
+  const int numGNodesPerDir, numGNodes;
+  const double side, dx;
+
+  Teuchos::RCP<const Teuchos::Comm<int>> comm;
+  Tpetra_GO gnodeStart;
+  int numNodes, numDofs;
+  Teuchos::RCP<const Thyra_MultiVector> coordMV;
+  Teuchos::RCP<const Thyra_VectorSpace> solnVS;
+
+  Cube(const int numGNodesPerDir, const double side) :
+      numGNodesPerDir(numGNodesPerDir),
+      numGNodes(numGNodesPerDir * numGNodesPerDir * numGNodesPerDir),
+      side(side),
+      dx(side / (numGNodesPerDir-1))
+  {
+    // Number of local nodes
+    comm = Teuchos::rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
+    const int rank = comm->getRank();
+    const int numRanks = comm->getSize();
+    const int blockSize = (numGNodes + numRanks - 1) / numRanks;
+    gnodeStart = rank * blockSize;
+    numNodes = (rank == (numRanks-1)) ? (numGNodes - gnodeStart) : blockSize;
+
+    // Create coordinate multivector
+    std::vector<Tpetra_GO> node2gnode(numNodes);
+    std::iota(node2gnode.begin(), node2gnode.end(), gnodeStart);
+    const Tpetra_GO indexBase = 0;
+    const auto nodeMap = Teuchos::rcp(new Tpetra_Map(numGNodes, node2gnode, indexBase, comm));
+    const Teuchos::RCP<const Thyra_VectorSpace> nodeVS = Albany::createThyraVectorSpace(nodeMap);
+    const auto nonConstCoordMV = Thyra::createMembers(nodeVS, numDims);
+
+    // Fill coordinate multivector
+    auto coordMVData = Albany::getNonconstLocalData(nonConstCoordMV);
+    Tpetra_GO gnode = 0;
+    for (int k = 0; k < numGNodesPerDir; ++k)
+      for (int j = 0; j < numGNodesPerDir; ++j)
+        for (int i = 0; i < numGNodesPerDir; ++i) {
+          if (std::find(node2gnode.begin(), node2gnode.end(), gnode) != node2gnode.end()) {
+            const int node = gnode - gnodeStart;
+            ALBANY_ASSERT(node >= 0);
+
+            coordMVData[0][node] = i * dx;
+            coordMVData[1][node] = j * dx;
+            coordMVData[2][node] = k * dx;
+          }
+          gnode++;
+        }
+    coordMV = nonConstCoordMV;
+  }
+
+  void init_soln_vs(const int numPDEs)
+  {
+    // Number of local dofs
+    const int numGDofs = numGNodes * numPDEs;
+    const int gdofStart = gnodeStart * numPDEs;
+    numDofs = numNodes * numPDEs;
+
+    // Create solution vector space
+    std::vector<Tpetra_GO> dof2gdof(numDofs);
+    std::iota(dof2gdof.begin(), dof2gdof.end(), gdofStart);
+    const Tpetra_GO indexBase = 0;
+    const auto solnMap = Teuchos::rcp(new Tpetra_Map(numGDofs, dof2gdof, indexBase, comm));
+    solnVS = Albany::createThyraVectorSpace(solnMap);
+  }
+};
+
+struct ParamLists
+{
+  Teuchos::RCP<Teuchos::ParameterList> piroParams, stratParams, mueluParams;
+
+  ParamLists()
+  {
+    piroParams = Teuchos::rcp(new Teuchos::ParameterList("Piro"));
+    piroParams->set<std::string>("Solver Type", "NOX");
+    const auto noxParams = Teuchos::sublist(piroParams, "NOX", false);
+    const auto dirParams = Teuchos::sublist(noxParams, "Direction", false);
+    const auto newtonParams = Teuchos::sublist(dirParams, "Newton", false);
+    const auto stratLinSolvParams = Teuchos::sublist(newtonParams, "Stratimikos Linear Solver", false);
+    stratParams = Teuchos::sublist(stratLinSolvParams, "Stratimikos", false);
+  }
+
+  void init_muelu_params()
+  {
+    stratParams->set<std::string>("Preconditioner Type", "MueLu");
+    const auto precTypesParams = Teuchos::sublist(stratParams, "Preconditioner Types", false);
+    mueluParams = Teuchos::sublist(precTypesParams, "MueLu", false);
+  }
+};
+
+} // namespace
+
+namespace Albany
+{
+
+TEUCHOS_UNIT_TEST(NullSpaceUtils, Constructor)
+{
+  const auto rigidBodyModes = Teuchos::rcp(new RigidBodyModes);
+  TEST_EQUALITY(rigidBodyModes.is_null(), false);
+}
+
+TEUCHOS_UNIT_TEST(NullSpaceUtils, SetCoordinates)
+{
+  // Create cube
+  const int numGNodesPerDir = 4;
+  const double side = 3.0;
+  const auto cube = Cube(numGNodesPerDir, side);
+
+  // Construct rigidBodyModes
+  auto rigidBodyModes = Teuchos::rcp(new RigidBodyModes);
+  const Teuchos::RCP<Thyra_MultiVector> coordMV = cube.coordMV->clone_mv();
+  TEST_THROW(rigidBodyModes->setCoordinates(coordMV), std::logic_error); // params not set
+
+  // Initialize rigid body mode parameters
+  const int numPDEs = 3;
+  const bool computeConstantModes = true;
+  const int physVectorDim = 3;
+  const bool computeRotationModes = true;
+  TEST_NOTHROW(rigidBodyModes->setParameters(numPDEs, computeConstantModes, physVectorDim, computeRotationModes));
+  TEST_THROW(rigidBodyModes->setCoordinates(coordMV), std::logic_error); // piro params not set
+
+  // Initialize piro parameters
+  auto paramLists = ParamLists();
+  const auto piroParams = paramLists.piroParams;
+  TEST_NOTHROW(rigidBodyModes->setPiroPL(piroParams));
+  TEST_THROW(rigidBodyModes->setCoordinates(coordMV), std::logic_error); // muelu params not set
+
+  // Initialize muelu parameters
+  paramLists.init_muelu_params();
+  TEST_NOTHROW(rigidBodyModes->setPiroPL(piroParams));
+  TEST_NOTHROW(rigidBodyModes->setCoordinates(coordMV));
+
+  // Check stored coordinates for muelu
+  const auto mueluParams = paramLists.mueluParams;
+  const auto t_coordMVStored = mueluParams->get<Teuchos::RCP<Tpetra_MultiVector>>("Coordinates");
+  const auto coordMVData = Albany::getLocalData(cube.coordMV);
+  const int numDims = cube.numDims;
+  const int numNodes = cube.numNodes;
+  for (int dim = 0; dim < numDims; ++dim)
+    for (int node = 0; node < numNodes; ++node) {
+      TEST_FLOATING_EQUALITY(t_coordMVStored->getData(dim)[node], coordMVData[dim][node], 1e-12);
+      // printf("rank = %d, dim = %d, node = %d, val = %e\n", cube.comm->getRank(), dim, node, t_coordMVStored->getData(dim)[node]);
+    }
+}
+
+TEUCHOS_UNIT_TEST(NullSpaceUtils, setCoordinatesAndComputeNullspace)
+{
+  // Initialize rigidBodyModes
+  const int numPDEs = 3;
+  const bool computeConstantModes = true;
+  const int physVectorDim = 3;
+  const bool computeRotationModes = true;
+  auto rigidBodyModes = Teuchos::rcp(new RigidBodyModes);
+  rigidBodyModes->setParameters(numPDEs, computeConstantModes, physVectorDim, computeRotationModes);
+
+  // Initialize piro param list with muelu
+  auto paramLists = ParamLists();
+  paramLists.init_muelu_params();
+  const auto piroParams = paramLists.piroParams;
+  rigidBodyModes->setPiroPL(piroParams);
+
+  // Initialize cube
+  const int numGNodesPerDir = 4;
+  const double side = 3.0;
+  auto cube = Cube(numGNodesPerDir, side);
+  const Teuchos::RCP<Thyra_MultiVector> coordMV = cube.coordMV->clone_mv();
+  auto ordering = DiscType::BlockedMono;
+  TEST_THROW(rigidBodyModes->setCoordinatesAndComputeNullspace(coordMV, ordering), std::logic_error); // solnVS not set
+
+  // Initialize solution vector space
+  cube.init_soln_vs(numPDEs);
+  const auto solnVS = cube.solnVS;
+  TEST_THROW(rigidBodyModes->setCoordinatesAndComputeNullspace(coordMV, ordering, solnVS), std::logic_error); // need interleaved ordering
+
+  // Test func
+  ordering = DiscType::Interleaved;
+  TEST_NOTHROW(rigidBodyModes->setCoordinatesAndComputeNullspace(coordMV, ordering, solnVS));
+
+  // Check coordinates after substractCentroid()
+  const auto mueluParams = paramLists.mueluParams;
+  const auto t_coordMVStored = mueluParams->get<Teuchos::RCP<Tpetra_MultiVector>>("Coordinates");
+  const auto coordMVData = Albany::getLocalData(cube.coordMV);
+  const int numDims = cube.numDims;
+  const int numNodes = cube.numNodes;
+  for (int dim = 0; dim < numDims; ++dim)
+    for (int node = 0; node < numNodes; ++node) {
+      TEST_FLOATING_EQUALITY(t_coordMVStored->getData(dim)[node], coordMVData[dim][node] - side/2, 1e-12);
+      // printf("rank = %d, dim = %d, node = %d, val = %e\n", cube.comm->getRank(), dim, node, t_coordMVStored->getData(dim)[node]);
+    }
+
+  // Check nullspace
+  const auto nullspace = mueluParams->get<Teuchos::RCP<Tpetra_MultiVector>>("Nullspace");
+  const int numNSDims = nullspace->getNumVectors(); // numPDEs + numRotations
+  const int numDofs = cube.numDofs;
+  for (int nsdim = 0; nsdim < numPDEs; ++nsdim)
+    for (int dof = 0; dof < numDofs; ++dof) {
+      const double identity = (nsdim == (dof % numPDEs)) ? 1.0 : 0.0;
+      TEST_FLOATING_EQUALITY(nullspace->getData(nsdim)[dof], identity, 1e-12);
+      // printf("rank = %d, nsdim = %d, dof = %d, val = %e\n", cube.comm->getRank(), nsdim, dof, nullspace->getData(nsdim)[dof]);
+    }
+  for (int nsdim = numPDEs; nsdim < numNSDims; ++nsdim)
+    for (int dof = 0; dof < numDofs; ++dof) {
+      const int node = dof / numPDEs;
+      const int pde = dof % numPDEs;
+      double rotation = 0;
+      if (nsdim == numPDEs) {
+        if (pde == 0)
+          rotation = -t_coordMVStored->getData(1)[node];
+        else if (pde == 1)
+          rotation = t_coordMVStored->getData(0)[node];
+      }
+      else if (nsdim == numPDEs+1) {
+        if (pde == 0)
+          rotation = -t_coordMVStored->getData(2)[node];
+        else if (pde == 2)
+          rotation = t_coordMVStored->getData(0)[node];
+      }
+      else if (nsdim == numPDEs+2) {
+        if (pde == 1)
+          rotation = -t_coordMVStored->getData(2)[node];
+        else if (pde == 2)
+          rotation = t_coordMVStored->getData(1)[node];
+      }
+      TEST_FLOATING_EQUALITY(nullspace->getData(nsdim)[dof], rotation, 1e-12);
+      // printf("rank = %d, nsdim = %d, dof = %d, val = %e\n", cube.comm->getRank(), nsdim, dof, nullspace->getData(nsdim)[dof]);
+    }
+}
+
+} // namespace Albany


### PR DESCRIPTION
The coordinates used by ML/MueLu are translated by the centroid (see subtractCentroid()). This function had a bug where the local number of nodes was used instead of the global number of nodes:
https://github.com/SNLComputation/Albany/compare/jewatkins/fix-ml-coords?expand=1#diff-fba75aeba9c71d8c94b90f32551a058c6e45012508a5ab2399a379066f9b0cedR102
It looks like its been incorrect for about 2 years and was changed during @bartgol thyra refactor.
Before: https://github.com/SNLComputation/Albany/blame/7e7871ebbe48533be1817e26d82a94f242b0212c/src/Albany_NullSpaceUtils.cpp#L190
After: https://github.com/SNLComputation/Albany/blame/7912e8626a1080f1c6869a6b1fc676f551b5ac12/src/Albany_NullSpaceUtils.cpp#L205
I added some unit tests so hopefully we'll actually be able to pick up issues next time.

Thanks @rstumin for pointing this out! @mperego Ray mentioned that the effect might be modest: rebalance issues that would effect convergence/performance.

Also I restored the coordinate write feature which will dump in mm format by adding "Write Coordinates to MatrixMarket" to the input under "Discretization".