### PR TITLE
Fix the Discretization_Parallel_Unit_Test test on blake-serial-Albany-gcc-no-warn

### DIFF
--- a/tests/unit/disc/UnitTest_BlockedDOFManager.cpp
+++ b/tests/unit/disc/UnitTest_BlockedDOFManager.cpp
@@ -277,6 +277,10 @@ tests are a beginning, "work in progress."
       // panzer::pauseToAttach();
 
       bool useExodus = false;
+
+      if (comm->getSize() > 1)
+         useExodus = true;
+
       bool verbose = false;
 
       RCP<Teuchos::ParameterList> discParams = rcp(new Teuchos::ParameterList);


### PR DESCRIPTION
This PR solves #706 .

The issue occurred while using MPI and the blake-serial-Albany-gcc-no-warn build with the gmsh mesh.
The test is passing fine with the same configuration but with the exodus mesh.