### PR TITLE
fixed race condition in PyAlbany writeMVector function, that was corr…

### DIFF
--- a/PyAlbany/python/Utils.py
+++ b/PyAlbany/python/Utils.py
@@ -128,10 +128,11 @@ def writeMVector(filename, mvector, distributedFile = True, useBinary = True):
             mvectorRank0 = wpa.gatherMVector(mvector, mvector.getMap())
         else:
             mvectorRank0 = mvector
-        if useBinary:     
-            np.save(filename+'.npy', mvectorRank0[:,:])
-        else:
-            np.savetxt(filename+'.txt', mvectorRank0[:,:])
+        if rank == 0:
+            if useBinary:
+                np.save(filename+'.npy', mvectorRank0[:,:])
+            else:
+                np.savetxt(filename+'.txt', mvectorRank0[:,:])
 
 def createTimers(names):
     """@brief Creates Teuchos timers."""


### PR DESCRIPTION
The writeMVector function had a race condition when a parallel job tried to write a non-distributedFile, as each MPI process attempted to write to the same file. Not all MPI processes need to write to `filename+'.npy'` or `filename+'.txt'` as after gathering the multivector the only MPI process which has the global vector data is the root process.