### PR TITLE
Modifications related to Hessian dot Product capabilities 

### DIFF
--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -865,35 +865,37 @@ Thyra_OutArgs ModelEvaluator::createOutArgsImpl() const
 
   for (int i = 0; i < n_g; ++i) {
     // Default value for response:
-    bool dADHessVec_g, reconstructHpp;
+    bool dADHessVec_g, supportHpp;
 
     if(hessParams.isSublist(Albany::strint("Response", i))) {
       dADHessVec_g = hessParams.sublist(Albany::strint("Response", i)).isParameter("Use AD for Hessian-vector products (default)") ?
         hessParams.sublist(Albany::strint("Response", i)).get<bool>("Use AD for Hessian-vector products (default)") : dADHessVec;
-      reconstructHpp = hessParams.sublist(Albany::strint("Response", i)).isParameter("Reconstruct H_pp") ?
-        hessParams.sublist(Albany::strint("Response", i)).get<bool>("Reconstruct H_pp") : false;
+      supportHpp = hessParams.sublist(Albany::strint("Response", i)).isParameter("Reconstruct H_pp") ?
+        hessParams.sublist(Albany::strint("Response", i)).get<bool>("Reconstruct H_pp") : true;
     }
     else {
       dADHessVec_g = dADHessVec;
-      reconstructHpp = false;
+      supportHpp = true;
     }
     
     auto& analysisParams = appParams->sublist("Piro").sublist("Analysis");
     if(analysisParams.isSublist("ROL")) {
-      bool reconstructHppROL = reconstructHpp = analysisParams.sublist("ROL").get("Hessian Dot Product", false);
+      bool reconstructHppROL = false;
+      if(analysisParams.sublist("ROL").isSublist("Matrix Based Dot Product"))
+        reconstructHppROL =
+            (analysisParams.sublist("ROL").sublist("Matrix Based Dot Product").get<std::string>("Matrix Type") == "Hessian Of Response");
+
       TEUCHOS_TEST_FOR_EXCEPTION(
-          reconstructHpp!=reconstructHppROL,
+          (supportHpp == false) && (reconstructHppROL == true),
           Teuchos::Exceptions::InvalidParameter,
           std::endl
               << "Error!  Albany::ModelEvaluator::createOutArgsImpl():  "
-              << "The Hessian reconstruction options are not consistent: " << reconstructHpp << " != "
-              << reconstructHppROL
+              << "The construction of H_pp is requested but not supported"
               << ". Please set the Option in the Hessian and ROL sublists consistently."
               << std::endl);
-    }
 
     TEUCHOS_TEST_FOR_EXCEPTION(
-        reconstructHpp && (num_param_vecs>0),
+        reconstructHppROL && (num_param_vecs>0),
         Teuchos::Exceptions::InvalidParameter,
         std::endl
             << "Error!  Albany::ModelEvaluator::createOutArgsImpl():  "
@@ -903,6 +905,8 @@ Thyra_OutArgs ModelEvaluator::createOutArgsImpl() const
             << "If at least one parameter is a scalar parameter or a parameter vector, "
             << "the Hessian reconstruction option must be disabled."
             << std::endl);
+
+    }
 
     aDHessVec_g[0][0] = dADHessVec_g;
 
@@ -1028,7 +1032,7 @@ Thyra_OutArgs ModelEvaluator::createOutArgsImpl() const
         i,
         j1,
         j1,
-        reconstructHpp);
+        supportHpp);
       for (int j2 = 0; j2 < num_params; j2++) {
         result.setSupports(
           Thyra_ModelEvaluator::OUT_ARG_hess_vec_prod_g_pp,

--- a/tests/small/LandIce/Enthalpy/input_enthalpy_humboldt.yaml
+++ b/tests/small/LandIce/Enthalpy/input_enthalpy_humboldt.yaml
@@ -195,7 +195,6 @@ ANONYMOUS:
         Step Method: "Trust Region"
 
         Full Space: false
-        Hessian Dot Product: false
         Use NOX Solver: true
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
@@ -171,7 +171,6 @@ ANONYMOUS:
         Full Space: false
         Use NOX Solver: false
 
-        Hessian Dot Product: false
         ROL Options:
           General:
             Variable Objective Function: false

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
@@ -15,7 +15,7 @@ ANONYMOUS:
       Type: LandIce
       Num Equations: 2
     Response Functions:
-      Number Of Responses: 1
+      Number Of Responses: 2
       Response 0:
         Type: Sum Of Responses
         Number Of Responses: 2
@@ -24,6 +24,23 @@ ANONYMOUS:
           Asinh Scaling: 1.00000000000000000e+01
           Name: Surface Velocity Mismatch
           Regularization Coefficient: 0.0
+        Response 1:
+          Scaling: 5.88239999999999978e-06
+          Name: Squared L2 Difference Side Source PST Target MST
+          Source Field Name: basal_friction_gradient_basalside
+          Side Set Name: basalside
+          Field Rank: Gradient
+          Target Value: 0.0
+      Response 1:
+        Type: Sum Of Responses
+        Number Of Responses: 2
+        Response 0:
+          Scaling: 5.88239999999999978e-06
+          Name: Squared L2 Difference Side Source PST Target MST
+          Source Field Name: basal_friction_basalside
+          Side Set Name: basalside
+          Field Rank: Scalar
+          Target Value: 0.0
         Response 1:
           Scaling: 5.88239999999999978e-06
           Name: Squared L2 Difference Side Source PST Target MST
@@ -158,6 +175,7 @@ ANONYMOUS:
   Piro:
     Sensitivity Method: Adjoint
     Analysis:
+      Output Final Parameters: false
       Analysis Package: ROL
       ROL:
         Check Gradient: false
@@ -174,28 +192,36 @@ ANONYMOUS:
         Full Space: false
         Use NOX Solver: false
 
-        Hessian Dot Product: true
-        Remove Mean Of The Right-hand Side: true
-        Hessian Diagonal Inverse:
-          Block solver type 0: Belos
-          Block 0:
-            Linear Solver Type: Belos
-            Linear Solver Types:
-              Belos:
-                Solver Type: Pseudo Block GMRES
-                Solver Types:
-                  Pseudo Block GMRES:
-                    Maximum Iterations: 1000
-                    Convergence Tolerance: 1e-4
-                    Num Blocks: 1000
-                    Output Frequency: 200
-                    Verbosity: 33
-                VerboseObject:
-                  Verbosity Level: medium
-            Preconditioner Type: Ifpack2
-            Preconditioner Types:
-              Ifpack2:
-                Prec Type: ILUT
+        Matrix Based Dot Product: 
+          Matrix Type: Hessian Of Response
+          Matrix Types:
+            Hessian Of Response:
+              Response Index: 1
+              Remove Mean Of The Right-hand Side: false
+              Block Diagonal Solver:
+                Block 0:
+                  Linear Solver Type: Belos
+                  Linear Solver Types:
+                    Belos:
+                      Solver Type: Block GMRES
+                      Solver Types:
+                        Block GMRES:
+                          Maximum Iterations: 200
+                          Convergence Tolerance: 1e-7
+                          Num Blocks: 200
+                          Output Frequency: 20
+                          Output Style: 1
+                          Verbosity: 33
+                      VerboseObject:
+                        Verbosity Level: medium
+                  Preconditioner Type: Ifpack2
+                  Preconditioner Types:
+                    Ifpack2:
+                      Overlap: 0
+                      Prec Type: Amesos2
+                      Ifpack2 Settings: 
+                        Amesos2: {}
+                        Amesos2 solver name: klu
         ROL Options:
           General:
             Variable Objective Function: false
@@ -379,9 +405,12 @@ ANONYMOUS:
       Solver Options:
         Status Test Check Type: Minimal
   Regression For Response 0:
+    Test Value: 1.13523015029099994e+02
+    Relative Tolerance: 1.00000000000000004e-04
     Absolute Tolerance: 1.00000000000000004e-04
     Sensitivity For Parameter 0:
       Test Value: 4.53304824162499997e+00
-    Test Value: 1.13523015029099994e+02
-    Relative Tolerance: 1.00000000000000004e-04
+    Number of Piro Analysis Comparisons: 1
+    Piro Analysis Test Two Norm: true
+    Piro Analysis Test Values: [78.4624]
 ...

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
@@ -171,7 +171,6 @@ ANONYMOUS:
         bound_eps: 1.00000000000000005e-01
 
         Full Space: false
-        Hessian Dot Product: false
         Use NOX Solver: false
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
@@ -182,7 +182,6 @@ ANONYMOUS:
         bound_eps: 1.00000000000000005e-01
 
         Full Space: false
-        Hessian Dot Product: false
         Use NOX Solver: true
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
@@ -13,7 +13,7 @@ ANONYMOUS:
     Basal Side Name: basalside
     Surface Side Name: upperside
     Response Functions:
-      Number Of Responses: 1
+      Number Of Responses: 2
       Response 0:
         Regularization Coefficient Stiffening: 1.5e+00
         Asinh Scaling: 1.0e+01
@@ -21,6 +21,23 @@ ANONYMOUS:
         Scaling Coefficient: 5.8824e-07
         Type: Scalar Response
         Name: Surface Velocity Mismatch
+      Response 1:
+        Type: Sum Of Responses
+        Number Of Responses: 2
+        Response 0:
+          Regularization Coefficient Stiffening: 1.5e+00
+          Asinh Scaling: 1.0e+01
+          Regularization Coefficient: 1.0e+00
+          Scaling Coefficient: 5.8824e-07
+          Type: Scalar Response
+          Name: Surface Velocity Mismatch
+        Response 1:
+          Scaling: 5.8824e-06
+          Name: Squared L2 Difference Side Source PST Target MST
+          Source Field Name: basal_friction_basalside
+          Side Set Name: basalside
+          Field Rank: Scalar
+          Target Value: 0.0
     Dirichlet BCs: {}
     Neumann BCs: {}
     LandIce BCs:
@@ -167,27 +184,78 @@ ANONYMOUS:
   Piro:
     Sensitivity Method: Adjoint
     Analysis:
+      Output Final Parameters: false
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 2
         Check Gradient: true
-        Gradient Tolerance: 1.00000000000000004e-04
-        Step Tolerance: 1.00000000000000004e-04
-        Max Iterations: 1
         Print Output: true
         Parameter Initial Guess Type: Uniform Vector
-        Uniform Parameter Guess: 0.00000000000000000e+00
-        Min And Max Of Random Parameter Guess: [1.00000000000000000e+00, 2.00000000000000000e+00]
+        Uniform Parameter Guess: 0.0e+00
+        Min And Max Of Random Parameter Guess: [1.0e+00, 2.0e+00]
         Bound Constrained: true
-        bound_eps: 1.00000000000000005e-01
 
         Full Space: false
         Use NOX Solver: true
+        Step Method: Line Search
 
+        Matrix Based Dot Product: 
+          Matrix Type: Hessian Of Response
+          Matrix Types:
+            Hessian Of Response:
+              Response Index: 1
+              Remove Mean Of The Right-hand Side: false
+              Block Diagonal Solver:
+                Block 0:
+                  Linear Solver Type: Belos
+                  Linear Solver Types:
+                    Belos:
+                      Solver Type: Block GMRES
+                      Solver Types:
+                        Block GMRES:
+                          Maximum Iterations: 200
+                          Convergence Tolerance: 1e-7
+                          Num Blocks: 200
+                          Output Frequency: 20
+                          Output Style: 1
+                          Verbosity: 33
+                      VerboseObject:
+                        Verbosity Level: medium
+                  Preconditioner Type: Ifpack2
+                  Preconditioner Types:
+                    Ifpack2:
+                      Overlap: 0
+                      Prec Type: Amesos2
+                      Ifpack2 Settings: 
+                        Amesos2: {}
+                        Amesos2 solver name: klu
+                Block 1:
+                  Linear Solver Type: Belos
+                  Linear Solver Types:
+                    Belos:
+                      Solver Type: Block GMRES
+                      Solver Types:
+                        Block GMRES:
+                          Maximum Iterations: 200
+                          Convergence Tolerance: 1e-7
+                          Num Blocks: 200
+                          Output Frequency: 20
+                          Output Style: 1
+                          Verbosity: 33
+                      VerboseObject:
+                        Verbosity Level: medium
+                  Preconditioner Type: Ifpack2
+                  Preconditioner Types:
+                    Ifpack2:
+                      Overlap: 0
+                      Prec Type: Amesos2
+                      Ifpack2 Settings: 
+                        Amesos2: {}
+                        Amesos2 solver name: klu
         ROL Options:
           General:
             Variable Objective Function: false
-            Scale for Epsilon Active Sets: 1.00000000000000000e+00
+            Scale for Epsilon Active Sets: 1.0e+00
             Inexact Objective Function: false
             Inexact Gradient: false
             Inexact Hessian-Times-A-Vector: false
@@ -200,15 +268,15 @@ ANONYMOUS:
               Barzilai-Borwein Type: 1
             Krylov:
               Type: Conjugate Gradients
-              Absolute Tolerance: 1.00000000000000004e-04
-              Relative Tolerance: 1.00000000000000002e-02
+              Absolute Tolerance: 1.0e-04
+              Relative Tolerance: 1.0e-02
               Iteration Limit: 100
           Step:
             Line Search:
               Function Evaluation Limit: 60
-              Sufficient Decrease Tolerance: 9.99999999999999945e-21
-              Initial Step Size: 1.00000000000000000e+00
-              User Defined Initial Step Size: false
+              Sufficient Decrease Tolerance: 1.0e-20
+              Initial Step Size: 1.0e-1
+              User Defined Initial Step Size: true
               Accept Linesearch Minimizer: false
               Accept Last Alpha: false
               Descent Method:
@@ -247,10 +315,21 @@ ANONYMOUS:
                   Tolerance Scaling: 1.00000000000000005e-01
                   Relative Tolerance: 2.00000000000000000e+00
           Status Test:
-            Gradient Tolerance: 1.00000000000000003e-10
-            Constraint Tolerance: 1.00000000000000003e-10
-            Step Tolerance: 9.99999999999999998e-15
+            Gradient Tolerance: 1.0e-10
+            Constraint Tolerance: 1.0e-10
+            Step Tolerance: 1.0e-15
             Iteration Limit: 1
+          SimOpt:
+            Solve:
+              Absolute Residual Tolerance: 1.0e-5
+              Relative Residual Tolerance: 1.0e-7
+              Iteration Limit: 20
+              Sufficient Decrease Tolerance: 1.e-4
+              Step Tolerance: 1.e-8
+              Backtracking Factor: 0.5
+              Output Iteration History: true
+              Zero Initial Guess: false
+              Solver Type: 0
     LOCA:
       Bifurcation: {}
       Constraints: {}
@@ -277,15 +356,11 @@ ANONYMOUS:
           Test 0:
             Test Type: NormF
             Norm Type: Two Norm
-            Scale Type: Scaled
-            Tolerance: 1.00000000000000002e-08
-          Test 1:
-            Test Type: NormWRMS
-            Absolute Tolerance: 1.00000000000000008e-05
-            Relative Tolerance: 1.00000000000000002e-03
+            Scale Type: Unscaled
+            Tolerance: 1.0e-02
         Test 1:
           Test Type: MaxIters
-          Maximum Iterations: 50
+          Maximum Iterations: 20
       Direction:
         Method: Newton
         Newton:
@@ -312,12 +387,13 @@ ANONYMOUS:
                   Solver Type: Block GMRES
                   Solver Types:
                     Block GMRES:
-                      Convergence Tolerance: 9.99999999999999954e-08
-                      Output Frequency: 10
+                      Convergence Tolerance: 1.0e-07
+                      Output Frequency: 20
                       Output Style: 1
-                      Maximum Iterations: 100
+                      Verbosity: 33
+                      Maximum Iterations: 200
                       Block Size: 1
-                      Num Blocks: 50
+                      Num Blocks: 200
                       Flexible Gmres: false
               Preconditioner Type: Ifpack2
               Preconditioner Types:
@@ -372,10 +448,14 @@ ANONYMOUS:
           Stepper Parameters: true
       Solver Options:
         Status Test Check Type: Minimal
+
   Regression For Response 0:
+    Test Value: 6.14131581607e+01
+    Relative Tolerance: 1.0e-05
     Absolute Tolerance: 1.0e-05
     Sensitivity For Parameter 0:
       Test Value: 1.06024176845e+00
-    Test Value: 6.14131581607e+01
-    Relative Tolerance: 1.0e-05
+    Number of Piro Analysis Comparisons: 1
+    Piro Analysis Test Two Norm: true
+    Piro Analysis Test Values: [107.726]
 ...

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening_memT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening_memT.yaml
@@ -183,7 +183,6 @@ ANONYMOUS:
         bound_eps: 1.00000000000000005e-01
 
         Full Space: false
-        Hessian Dot Product: false
         Use NOX Solver: false
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch.yaml
@@ -257,7 +257,6 @@ ANONYMOUS:
         Step Method: "Trust Region"
 
         Full Space: false
-        Hessian Dot Product: true
         Use NOX Solver: true
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch_effect_press.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch_effect_press.yaml
@@ -262,7 +262,6 @@ ANONYMOUS:
         Step Method: "Trust Region"
 
         Full Space: false
-        Hessian Dot Product: true
         Use NOX Solver: true
 
         ROL Options:

--- a/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch_power_law.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch_power_law.yaml
@@ -256,7 +256,6 @@ ANONYMOUS:
         Step Method: "Trust Region"
 
         Full Space: false
-        Hessian Dot Product: true
         Use NOX Solver: true
 
         ROL Options:

--- a/tests/small/LandIce/FO_Thermo/humboldt_analysis.yaml
+++ b/tests/small/LandIce/FO_Thermo/humboldt_analysis.yaml
@@ -57,6 +57,7 @@ ANONYMOUS:
         Use AD for Hessian-vector products (default): true
       Response 0:
         Use AD for Hessian-vector products (default): true
+        Reconstruct H_pp: true
       Write Hessian MatrixMarket: true
     LandIce Viscosity: 
       Extract Strain Rate Sq: true
@@ -265,30 +266,36 @@ ANONYMOUS:
         Full Space: false
         Use NOX Solver: true        
         
-        Hessian Dot Product: true
-        Remove Mean Of The Right-hand Side: true
-        Hessian Diagonal Inverse:
-          Block solver type 0: Belos
-          Block 0:
-            Linear Solver Type: Belos
-            Linear Solver Types:
-              Belos:
-                Solver Type: Pseudo Block GMRES
-                Solver Types:
-                  Pseudo Block GMRES:
-                    Maximum Iterations: 1
-                    Convergence Tolerance: 1e+8
-                    Num Blocks: 1000
-                    Output Frequency: 200
-                    Verbosity: 33
-                VerboseObject:
-                  Verbosity Level: medium
-            Preconditioner Type: Ifpack2
-            Preconditioner Types:
-              Ifpack2:
-                Prec Type: ilut
-                Ifpack2 Settings:
-                  "fact: ilut level-of-fill": 1.0
+        Matrix Based Dot Product: 
+          Matrix Type: Hessian Of Response
+          Matrix Types:
+            Hessian Of Response:
+              Response Index: 0
+              Remove Mean Of The Right-hand Side: false
+              Block Diagonal Solver:
+                Block 0:
+                  Linear Solver Type: Belos
+                  Linear Solver Types:
+                    Belos:
+                      Solver Type: Block GMRES
+                      Solver Types:
+                        Block GMRES:
+                          Maximum Iterations: 200
+                          Convergence Tolerance: 1e-7
+                          Num Blocks: 200
+                          Output Frequency: 20
+                          Output Style: 1
+                          Verbosity: 33
+                      VerboseObject:
+                        Verbosity Level: medium
+                  Preconditioner Type: Ifpack2
+                  Preconditioner Types:
+                    Ifpack2:
+                      Overlap: 0
+                      Prec Type: Amesos2
+                      Ifpack2 Settings: 
+                        Amesos2: {}
+                        Amesos2 solver name: klu
 
         ROL Options: 
         # ===========  SIMOPT SOLVER PARAMETER SUBLIST  =========== 

--- a/tests/small/LandIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
+++ b/tests/small/LandIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
@@ -296,7 +296,6 @@ ANONYMOUS:
         Step Method: "Trust Region"
 
         Full Space: false
-        Hessian Dot Product: true
         Use NOX Solver: true
 
         ROL Options:

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param.yaml
@@ -64,7 +64,6 @@ ANONYMOUS:
         bound_eps: 1.00000000000000006e-01
 
         Full Space: false
-        Hessian Dot Product: true
         Use NOX Solver: false
         
         ROL Options: 

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_paramT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_paramT.yaml
@@ -35,6 +35,9 @@ ANONYMOUS:
           Scaling: 1.49999999999999994e-01
           Source Field Name: ThermalConductivity
           Target Value: 0.0
+    Hessian:
+      Response 0:
+        Reconstruct H_pp: true
   Discretization: 
     1D Elements: 40
     2D Elements: 40
@@ -65,10 +68,39 @@ ANONYMOUS:
         bound_eps: 1.0e-01
         Max Iterations: 10
        
-
         Full Space: false
-        Hessian Dot Product: true
         Use NOX Solver: true
+        
+        Matrix Based Dot Product: 
+          Matrix Type: Hessian Of Response
+          Matrix Types:
+            Hessian Of Response:
+              Response Index: 0
+              Remove Mean Of The Right-hand Side: false
+              Block Diagonal Solver:
+                Block 0:
+                  Linear Solver Type: Belos
+                  Linear Solver Types:
+                    Belos:
+                      Solver Type: Block GMRES
+                      Solver Types:
+                        Block GMRES:
+                          Maximum Iterations: 200
+                          Convergence Tolerance: 1e-7
+                          Num Blocks: 200
+                          Output Frequency: 20
+                          Output Style: 1
+                          Verbosity: 33
+                      VerboseObject:
+                        Verbosity Level: medium
+                  Preconditioner Type: Ifpack2
+                  Preconditioner Types:
+                    Ifpack2:
+                      Overlap: 0
+                      Prec Type: Amesos2
+                      Ifpack2 Settings: 
+                        Amesos2: {}
+                        Amesos2 solver name: klu
  
 
 

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restart.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restart.yaml
@@ -65,9 +65,8 @@ ANONYMOUS:
         bound_eps: 1.00000000000000006e-01
 
         Full Space: false
-        Hessian Dot Product: true
         Use NOX Solver: false
-        
+
         ROL Options: 
           General: 
             Variable Objective Function: false

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restartT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restartT.yaml
@@ -65,7 +65,6 @@ ANONYMOUS:
         bound_eps: 1.00000000000000006e-01
 
         Full Space: false
-        Hessian Dot Product: true
         Use NOX Solver: true
         
         ROL Options: 

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_paramT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_paramT.yaml
@@ -60,8 +60,10 @@ ANONYMOUS:
         Bound Constrained: true
 
         Full Space: false
-        Hessian Dot Product: false
         Use NOX Solver: true        
+        
+        Matrix Based Dot Product: 
+          Matrix Type: Identity
         
         Step Method: "Line Search"
         bound_eps: 1.0e-01

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_params.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_params.yaml
@@ -71,7 +71,6 @@ ANONYMOUS:
         Bound Constrained: true
 
         Full Space: false
-        Hessian Dot Product: false
         Use NOX Solver: false
         
         Step Method: "Line Search"

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
@@ -74,7 +74,6 @@ ANONYMOUS:
         Bound Constrained: true
 
         Full Space: false
-        Hessian Dot Product: false
         Use NOX Solver: true
         
         Step Method: "Line Search"

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_paramT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_paramT.yaml
@@ -88,7 +88,6 @@ ANONYMOUS:
        
 
         Full Space: false
-        Hessian Dot Product: false
         Use NOX Solver: true
  
 


### PR DESCRIPTION
Modified ModelEvaluator and tests to comply with the new syntax for defining the Hessian Dot Product (https://github.com/trilinos/Trilinos/pull/9501).