### PR TITLE
Fix PyAlbany stackedTimers when more than 1 problem is used

### DIFF
--- a/PyAlbany/src/Albany_Interface.cpp
+++ b/PyAlbany/src/Albany_Interface.cpp
@@ -434,6 +434,8 @@ Teuchos::RCP<PyTrilinosMultiVector> PyProblem::getReducedHessian(const int g_ind
 
 void PyProblem::performSolve()
 {
+    if (Teuchos::TimeMonitor::getStackedTimer() != stackedTimer)
+        Teuchos::TimeMonitor::setStackedTimer(stackedTimer);
     stackedTimer->start("Albany: performSolve");
 
     Teuchos::ParameterList &solveParams =
@@ -450,6 +452,8 @@ void PyProblem::performSolve()
 
 void PyProblem::performAnalysis()
 {
+    if (Teuchos::TimeMonitor::getStackedTimer() != stackedTimer)
+        Teuchos::TimeMonitor::setStackedTimer(stackedTimer);
     stackedTimer->start("Albany: performAnalysis");
 
     Teuchos::RCP<Albany::ObserverImpl> observer = Teuchos::rcp(new Albany::ObserverImpl(albanyApp));

--- a/PyAlbany/tests/small/SteadyHeat/steadyHeat.py
+++ b/PyAlbany/tests/small/SteadyHeat/steadyHeat.py
@@ -43,8 +43,11 @@ class TestSteadyHeat(unittest.TestCase):
         hessian = problem.getReducedHessian(0, 0)
 
         stackedTimer = problem.getStackedTimer()
-        setup_time = stackedTimer.accumulatedTime("Albany: Setup Time")
+        setup_time = stackedTimer.accumulatedTime("PyAlbany: Setup Time")
         print("setup_time = " + str(setup_time))
+
+        setup_time_2 = stackedTimer.findBaseTimer("PyAlbany Total Time@PyAlbany: Setup Time").accumulatedTime()
+        setup_time_fix_node_sharing = stackedTimer.findBaseTimer("PyAlbany Total Time@PyAlbany: Setup Time@Albany Setup: fix_node_sharing").accumulatedTime()
 
         g_target = 3.23754626955999991e-01
         norm_target = 8.94463776843999921e-03
@@ -67,6 +70,8 @@ class TestSteadyHeat(unittest.TestCase):
             self.assertTrue(np.abs(g_data[0]-g_target) < tol)
             self.assertTrue(np.abs(norm-norm_target) < tol)
             self.assertTrue(setup_time > 0.)
+            self.assertTrue(setup_time == setup_time_2)
+            self.assertTrue(setup_time_fix_node_sharing > 0.)
             for i in range(0,n_directions):
                 self.assertTrue(np.abs(hessian_norms[i]-h_target[i]) < tol)
 

--- a/PyAlbany/tests/small/SteadyHeat/steadyHeat_stateMap.py
+++ b/PyAlbany/tests/small/SteadyHeat/steadyHeat_stateMap.py
@@ -39,7 +39,7 @@ class TestSteadyHeat(unittest.TestCase):
         
 
         stackedTimer = problem.getStackedTimer()
-        setup_time = stackedTimer.accumulatedTime("Albany: Setup Time")
+        setup_time = stackedTimer.accumulatedTime("PyAlbany: Setup Time")
         print("setup_time = " + str(setup_time))
         tol = 1.e-8
         self.assertTrue(np.linalg.norm(state_ref[0, :] - state[0,:]) < tol)


### PR DESCRIPTION
It has been observed that when more than one PyAlbany problem is created, the stackedTimer can be printed correctly only for the last created problem.

This PR fixes this issue; the stackedTimer can be correctly printed for all the created PyAlbany problems.

The tests passed correctly on Blake.