### PR TITLE
Several QOL changes

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -18,6 +18,7 @@
 
 #include "Teuchos_TimeMonitor.hpp"
 
+#include <stdexcept>
 #include <string>
 #include "Albany_DataTypes.hpp"
 
@@ -170,6 +171,15 @@ Application::initialSetUp(const RCP<Teuchos::ParameterList>& params)
   // Initialize Phalanx postRegistration setup
   phxSetup = Teuchos::rcp(new PHAL::Setup());
   phxSetup->init_problem_params(problemParams);
+
+  // If memoization is active, set workset size to -1 (otherwise memoization won't work)
+  if (phxSetup->memoizer_active()) {
+    int worksetSize = discParams->get("Workset Size", -1);
+    TEUCHOS_TEST_FOR_EXCEPTION(worksetSize != -1, std::logic_error,
+        "Input error: Memoization is active but Workset Size is not set to -1!\n" <<
+        "             A single workset is needed to active memoization.\n")
+    discParams->set("Workset Size", -1);
+  }
 
   // Set in Albany_AbstractProblem constructor or in siblings
   num_time_deriv = problemParams->get<int>("Number Of Time Derivatives");

--- a/src/Albany_ObserverImpl.hpp
+++ b/src/Albany_ObserverImpl.hpp
@@ -34,11 +34,11 @@ public:
       const Teuchos::Ptr<const Thyra_MultiVector>& nonOverlappedSolution_dxdp) override;
 
   void parameterChanged(
-      const std::string& param);
+      const std::string& param) override;
 
-  void parametersChanged();
+  void parametersChanged() override;
   
-  void observeResponse(int iter);
+  void observeResponse(int iter) override;
 };
 
 } // namespace Albany

--- a/src/Albany_SolverFactory.cpp
+++ b/src/Albany_SolverFactory.cpp
@@ -383,6 +383,7 @@ SolverFactory::getValidDebugParameters() const
   validPL->set<int>("Write Solution to Standard Output", 0, "Residual Number to Dump to Standard Output");
   validPL->set<bool>("Analyze Memory", false, "Flag to Analyze Memory");
   validPL->set<bool>("Report Timers", true, "Whether to report timers at the end of execution");
+  validPL->set<bool>("Report MPI Info", false, "Whether to report MPI processor name and rank");
   return validPL; 
 }
 

--- a/src/Albany_Utils.cpp
+++ b/src/Albany_Utils.cpp
@@ -57,6 +57,29 @@ PrintHeader(std::ostream& os)
   os << R"(** Albany cuda compiler --- Cuda )" << KOKKOS_COMPILER_CUDA_VERSION << std::endl;
 #endif
 
+  // Print fad types
+#if defined(ALBANY_FAD_TYPE_SFAD)
+  os << R"(** Albany FadType --------- SFad)" << ALBANY_SFAD_SIZE << std::endl;
+#elif defined(ALBANY_FAD_TYPE_SLFAD)
+  os << R"(** Albany FadType --------- SLFad)" << ALBANY_SLFAD_SIZE << std::endl;
+#else
+  os << R"(** Albany FadType --------- DFad)" << std::endl;
+#endif
+#if defined(ALBANY_TAN_FAD_TYPE_SFAD)
+  os << R"(** Albany TanFadType ------ SFad)" << ALBANY_TAN_SFAD_SIZE << std::endl;
+#elif defined(ALBANY_TAN_FAD_TYPE_SLFAD)
+  os << R"(** Albany TanFadType ------ SLFad)" << ALBANY_TAN_SLFAD_SIZE << std::endl;
+#else
+  os << R"(** Albany TanFadType ------ DFad)" << std::endl;
+#endif
+#if defined(ALBANY_HES_VEC_FAD_TYPE_SFAD)
+  os << R"(** Albany HessianVecFad  -- SFad)" << ALBANY_HES_VEC_SFAD_SIZE << std::endl;
+#elif defined(ALBANY_HES_VEC_FAD_TYPE_SLFAD)
+  os << R"(** Albany HessianVecFad  -- SLFad)" << ALBANY_HES_VEC_SLFAD_SIZE << std::endl;
+#else
+  os << R"(** Albany HessianVecFad  -- DFad)" << std::endl;
+#endif
+
   // Print start time
   time_t rawtime;
   time(&rawtime);
@@ -65,6 +88,21 @@ PrintHeader(std::ostream& os)
   strftime(buffer, 80, "%F at %T", timeinfo);
   os << R"(** Simulation start time -- )" << buffer << std::endl;
   os << R"(***************************************************************)" << std::endl;
+}
+
+void
+PrintMPIInfo(std::ostream& os)
+{
+  const auto comm = Albany::getDefaultComm();
+  const auto rank = comm->getRank();
+  const auto size = comm->getSize();
+  int nameLen;
+  char procName[MPI_MAX_PROCESSOR_NAME];
+  ::MPI_Get_processor_name(procName, &nameLen);
+  std::ostringstream oss;
+  oss << "Rank " << rank << " of " << size << " exists on processor " << procName << std::endl;
+  os << oss.str() << std::flush;
+  comm->barrier();
 }
 
 int

--- a/src/Albany_Utils.hpp
+++ b/src/Albany_Utils.hpp
@@ -10,6 +10,7 @@
 // Get Albany configuration macros
 #include "Albany_config.h"
 
+#include <ostream>
 #include <sstream>
 
 #include "Albany_CommUtils.hpp"
@@ -24,6 +25,10 @@ namespace Albany {
 //! Print ascii art and version information
 void
 PrintHeader(std::ostream& os);
+
+//! Print MPI processor name and rank
+void
+PrintMPIInfo(std::ostream& os);
 
 //! Helper function to calculate the number of parameters in a problem
 int

--- a/src/Main_Analysis.cpp
+++ b/src/Main_Analysis.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[]) {
   int status=0; // 0 = pass, failures are incremented
   bool success = true;
 
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv, nullptr);
 
   Kokkos::initialize(argc, argv);
 
@@ -58,6 +58,9 @@ int main(int argc, char *argv[]) {
     Teuchos::ParameterList &debugParams =
         slvrfctry.getParameters()->sublist("Debug Output", true);
     reportTimers = debugParams.get<bool>("Report Timers", true);
+
+    const bool reportMPIInfo = debugParams.get<bool>("Report MPI Info", false);
+    if (reportMPIInfo) Albany::PrintMPIInfo(std::cout);
 
     const auto& bt = slvrfctry.getParameters()->get("Build Type","Tpetra");
     if (bt=="Tpetra") {
@@ -100,7 +103,7 @@ int main(int argc, char *argv[]) {
   TEUCHOS_STANDARD_CATCH_STATEMENTS(true, std::cerr, success);
   if (!success) status+=10000;
 
-  stackedTimer->stop("Albany Total Time");
+  stackedTimer->stopBaseTimer();
   if (reportTimers) {
     Teuchos::StackedTimer::OutputOptions options;
     options.output_fraction = true;

--- a/src/Main_Solve.cpp
+++ b/src/Main_Solve.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
   int status = 0;  // 0 = pass, failures are incremented
   bool success = true;
 
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv, nullptr);
   Kokkos::initialize(argc, argv);
 
 #if defined(ALBANY_FLUSH_DENORMALS)
@@ -108,6 +108,9 @@ int main(int argc, char *argv[])
     Teuchos::ParameterList &debugParams =
         slvrfctry.getParameters()->sublist("Debug Output", true);
     reportTimers = debugParams.get<bool>("Report Timers", true);
+
+    const bool reportMPIInfo = debugParams.get<bool>("Report MPI Info", false);
+    if (reportMPIInfo) Albany::PrintMPIInfo(std::cout);
 
     auto const& bt = slvrfctry.getParameters()->get<std::string>("Build Type","NONE");
 
@@ -354,7 +357,7 @@ int main(int argc, char *argv[])
   TEUCHOS_STANDARD_CATCH_STATEMENTS(true, std::cerr, success);
   if (!success) status += 10000;
 
-  stackedTimer->stop("Albany Total Time");
+  stackedTimer->stopBaseTimer();
   if (reportTimers) {
     Teuchos::StackedTimer::OutputOptions options;
     options.output_fraction = true;

--- a/src/disc/Albany_DiscretizationFactory.cpp
+++ b/src/disc/Albany_DiscretizationFactory.cpp
@@ -113,7 +113,7 @@ DiscretizationFactory::createMeshStruct(Teuchos::RCP<Teuchos::ParameterList> dis
         }
 
         // Set basal workset size
-        int extruded_ws_size = disc_params->get("Workset Size", 50);
+        int extruded_ws_size = disc_params->get("Workset Size", -1);
         if (extruded_ws_size == -1) {
           basal_params->set("Workset Size", -1);
         } else if (!basal_params->isParameter("Workset Size")) {

--- a/src/disc/stk/Albany_ExtrudedSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_ExtrudedSTKMeshStruct.cpp
@@ -180,7 +180,7 @@ Albany::ExtrudedSTKMeshStruct::ExtrudedSTKMeshStruct(const Teuchos::RCP<Teuchos:
 
   int cub = params->get("Cubature Degree", 3);
   int basalWorksetSize = basalMeshSpec->worksetSize;
-  int worksetSizeMax = params->get<int>("Workset Size", DEFAULT_WORKSET_SIZE);
+  int worksetSizeMax = params->get<int>("Workset Size");
   int numElemsInColumn = numLayers*((ElemShape==Tetrahedron) ? 3 : 1);
   int ebSizeMaxEstimate = basalWorksetSize * numElemsInColumn; // This is ebSizeMax when basalWorksetSize is max
   int worksetSize = this->computeWorksetSize(worksetSizeMax, ebSizeMaxEstimate);

--- a/src/disc/stk/Albany_IossSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_IossSTKMeshStruct.cpp
@@ -205,7 +205,7 @@ Albany::IossSTKMeshStruct::IossSTKMeshStruct(
     TEUCHOS_TEST_FOR_EXCEPTION (true, Teuchos::Exceptions::InvalidParameterValue,
                                 "Invalid Cubature Rule: " << cub_rule_string << "; valid options are GAUSS, GAUSS_RADAU_LEFT, GAUSS_RADAU_RIGHT, and GAUSS_LOBATTO");
 
-  int worksetSizeMax = params->get<int>("Workset Size", DEFAULT_WORKSET_SIZE);
+  int worksetSizeMax = params->get<int>("Workset Size", -1);
 
   // Get number of elements per element block using Ioss for use
   // in calculating an upper bound on the worksetSize.

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_unstructT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_unstructT.yaml
@@ -4,6 +4,7 @@ ANONYMOUS:
   Build Type: Tpetra
   Debug Output:
     Write Solution to MatrixMarket: 0
+    Report MPI Info: true
   Problem:
     Phalanx Graph Visualization Detail: 0
     Solution Method: Continuation


### PR DESCRIPTION
This adds some QOL changes based on a discussion with @mperego 
1. Force a single workset when using memoization (throw if trying to use multiple)
   - This is needed because memoization only works for a single workset.

2. Suppress MPI info, add option to print "Report MPI Info"
   - I was getting tired of seeing each rank dump the processor name in all simulations (particularly for the large ones I just did) so I added it as a debug option (off by default). I could turn it on by default if others prefer seeing it. Basically this:
```
Teuchos::GlobalMPISession::GlobalMPISession(): started processor with name ecw00108 and rank 0!
```
now looks like this (but now we can turn it on/off):
```
Rank 0 of 30 exists on processor ecw00108
```

3. Dump fad types and size at start of simulation
    - Example (it can be modified):
```
...
** Albany cxx compiler ---- Clang 10.0.0
** Albany FadType --------- SFad12
** Albany TanFadType ------ SLFad30
** Albany HessianVecFad  -- SFad12
** Simulation start time -- 2021-08-09 at 20:09:23
...
```

4. Change timer so that sims exit more cleanly
    - I noticed that if something fails during setup, the timer segfaults so this should fix it

5. Set default workset size in Extruded and Ioss to -1 (single workset)
    - this should always be more efficient anyways. The main difference will be: if you run out-of-memory, it's probably because of this so you have to manually specify a workset size in the input file to reduce the memory allocation.

@mperego @ikalash @bartgol @kliegeois @mcarlson801 