### PR TITLE
Consistently use PHX::print<Entity>()

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -779,9 +779,9 @@ Application::setDynamicLayoutSizes(Teuchos::RCP<PHX::FieldManager<PHAL::AlbanyTr
     std::string t_identifier = t_dl.identifier();
     std::string sideSetName = t_identifier.substr(0, t_identifier.find("<"));
 
-    TEUCHOS_TEST_FOR_EXCEPTION(first_dim_name == "Side" && sideSetName.empty(), std::logic_error, "Dynamic sizing error: Identifier is that of a sideset but has no sideset name.\n");
+    TEUCHOS_TEST_FOR_EXCEPTION(first_dim_name == PHX::print<Side>() && sideSetName.empty(), std::logic_error, "Dynamic sizing error: Identifier is that of a sideset but has no sideset name.\n");
 
-    if (first_dim_name == "Side" && maxSideSetSizes.find(sideSetName) != maxSideSetSizes.end()) {
+    if (first_dim_name == PHX::print<Side>() && maxSideSetSizes.find(sideSetName) != maxSideSetSizes.end()) {
 
       t_dims[0] = maxSideSetSizes[sideSetName];
 

--- a/src/Albany_StateManager.cpp
+++ b/src/Albany_StateManager.cpp
@@ -502,7 +502,7 @@ Albany::StateManager::registerSideSetStateVariable(
   {
     mfe_type = StateStruct::ElemData;  // One value per element
   } else if (dl->rank() > 1) {
-    if (dl->name(1) == "Dim")
+    if (dl->name(1) == PHX::print<Dim>())
       mfe_type = StateStruct::ElemData;   // One vector/tensor per element
     else if (dl->name(1) == PHX::print<Node>())       // Element node data
       mfe_type = StateStruct::ElemNode;   // One value per side node
@@ -564,7 +564,7 @@ Albany::StateManager::registerSideSetStateVariable(
   }
   stateRef.output              = outputToExodus;
   stateRef.responseIDtoRequire = responseIDtoRequire;
-  stateRef.layered             = (dl->name(dl->rank() - 1) == "LayerDim");
+  stateRef.layered             = (dl->name(dl->rank() - 1) == PHX::print<LayerDim>());
   TEUCHOS_TEST_FOR_EXCEPTION(
       stateRef.layered && (dl->extent(dl->rank() - 1) <= 0),
       std::logic_error,

--- a/src/LandIce/problems/LandIce_ProblemUtils.cpp
+++ b/src/LandIce/problems/LandIce_ProblemUtils.cpp
@@ -11,7 +11,7 @@ extrudeSideLayout (const Teuchos::RCP<PHX::DataLayout>& in, const int numLayers)
 
   std::vector<std::string> names;
   in->names(names);
-  TEUCHOS_TEST_FOR_EXCEPTION(names[0]!="Side", std::runtime_error,
+  TEUCHOS_TEST_FOR_EXCEPTION(names[0]!=PHX::print<Side>(), std::runtime_error,
     "Error! A side layout must begin with <Side,...>.\n");
 
   std::vector<PHX::DataLayout::size_type> dims;
@@ -22,11 +22,11 @@ extrudeSideLayout (const Teuchos::RCP<PHX::DataLayout>& in, const int numLayers)
       out = Teuchos::rcp(new PHX::MDALayout<Side,LayerDim>(dims[0],numLayers));
         break;
     case 2:
-      if (names[1]=="Node") {
+      if (names[1]==PHX::print<Node>()) {
         out = Teuchos::rcp(new PHX::MDALayout<Side,Node,LayerDim>(dims[0],dims[1],numLayers));
-      } else if (names[1]=="Dim") {
+      } else if (names[1]==PHX::print<Dim>()) {
         out = Teuchos::rcp(new PHX::MDALayout<Side,Dim,LayerDim>(dims[0],dims[1],numLayers));
-      } else if (names[1]=="VecDim") {
+      } else if (names[1]==PHX::print<VecDim>()) {
         out = Teuchos::rcp(new PHX::MDALayout<Side,VecDim,LayerDim>(dims[0],dims[1],numLayers));
       } else {
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
@@ -34,11 +34,11 @@ extrudeSideLayout (const Teuchos::RCP<PHX::DataLayout>& in, const int numLayers)
       }
       break;
     case 3:
-      if (names[1]=="Node" && names[2]=="Dim") {
+      if (names[1]==PHX::print<Node>() && names[2]==PHX::print<Dim>()) {
         out = Teuchos::rcp(new PHX::MDALayout<Side,Node,Dim,LayerDim>(dims[0],dims[1],dims[2],numLayers));
-      } else if (names[1]=="Node" && names[2]=="VecDim") {
+      } else if (names[1]==PHX::print<Node>() && names[2]==PHX::print<VecDim>()) {
         out = Teuchos::rcp(new PHX::MDALayout<Side,Node,VecDim,LayerDim>(dims[0],dims[1],dims[2],numLayers));
-      } else if (names[1]=="Dim" && names[2]=="Dim") {
+      } else if (names[1]==PHX::print<Dim>() && names[2]==PHX::print<Dim>()) {
         out = Teuchos::rcp(new PHX::MDALayout<Side,Dim,Dim,LayerDim>(dims[0],dims[1],dims[2],numLayers));
       } else {
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,

--- a/src/PHAL_Dimension.hpp
+++ b/src/PHAL_Dimension.hpp
@@ -73,6 +73,17 @@ struct Dummy : public shards::ArrayDimTag {
 };
 
 namespace PHX {
+  template<> std::string print<Dim>();
+  template<> std::string print<VecDim>();
+  template<> std::string print<LayerDim>();
+  template<> std::string print<QuadPoint>();
+  template<> std::string print<Node>();
+  template<> std::string print<Vertex>();
+  template<> std::string print<Point>();
+  template<> std::string print<Cell>();
+  template<> std::string print<Side>();
+  template<> std::string print<Dummy>();
+
   template<> struct is_extent<Dim> : std::true_type {};
   template<> struct is_extent<LayerDim> : std::true_type {};
   template<> struct is_extent<VecDim> : std::true_type {};

--- a/src/evaluators/state/PHAL_ReadStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_ReadStateField_Def.hpp
@@ -92,13 +92,13 @@ void
 ReadStateField<PHAL::AlbanyTraits::Residual, Traits>::evaluateFields(
     typename Traits::EvalData workset)
 {
-  if (field_type == "Cell") {
+  if (field_type == PHX::print<Cell>()) {
     readElemState(workset);
-  } else if (field_type == "Node") {
+  } else if (field_type == PHX::print<Node>()) {
     readNodalState(workset);
   } else {
     TEUCHOS_TEST_FOR_EXCEPTION(
-        field_type == "Cell" || field_type == "Node",
+        field_type == PHX::print<Cell>() || field_type == PHX::print<Node>(),
         std::runtime_error,
         "Error! Only read cell or node states for now.\n");
   }


### PR DESCRIPTION
This is related to #655

@bartgol For some reason I had to add declarations of the specializations, otherwise PHX::print<Entity>() would not  use the the specializations.