### PR TITLE
Add warning if SFad size is larger than derivative dimension

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -1566,14 +1566,6 @@ Application::computeGlobalJacobianImpl(
     workset.Jac = jac;
     loadWorksetJacobianInfo(workset, alpha, beta, omega);
 
-    // fill Jacobian derivative dimensions:
-    for (int ps = 0; ps < fm.size(); ps++) {
-      (workset.Jacobian_deriv_dims)
-          .push_back(
-              PHAL::getDerivativeDimensions<EvalT>(
-                  this, ps, explicit_scheme));
-    }
-
 #ifdef ALBANY_KOKKOS_UNDER_DEVELOPMENT
     if (!workset.f.is_null()) {
       workset.f_kokkos = getNonconstDeviceData(workset.f);
@@ -1994,13 +1986,6 @@ Application::computeGlobalTangent(
       if (nfm != Teuchos::null)
         deref_nfm(nfm, wsPhysIndex, ws)
             ->evaluateFields<EvalT>(workset);
-    }
-
-    // fill Tangent derivative dimensions
-    for (int ps = 0; ps < fm.size(); ps++) {
-      (workset.Tangent_deriv_dims)
-          .push_back(PHAL::getDerivativeDimensions<EvalT>(
-              this, ps));
     }
   }
 

--- a/src/PHAL_Workset.hpp
+++ b/src/PHAL_Workset.hpp
@@ -143,9 +143,6 @@ struct Workset
   bool                                              transpose_dist_param_deriv;
   Teuchos::ArrayRCP<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double>>> local_Vp;
 
-  std::vector<PHX::index_size_type> Jacobian_deriv_dims;
-  std::vector<PHX::index_size_type> Tangent_deriv_dims;
-
   Albany::WorksetConn                           wsElNodeEqID;
   Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>      wsElNodeID;
   Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>> wsCoords;


### PR DESCRIPTION
 @mperego @ikalash @kliegeois This adds a warning if SFad size is set to something larger than what is required to store the derivative components. This capability is not tested and there's been issues with it in the past (see `LinComprNS_1D_standingWave` as an example). There may be some issue with how xdot is gathered and then used in local assembly for this specific example but there might be other issues.

I also removed some unnecessary calls to getDerivativeDimensions() because they're not used and would pollute runs with warnings.