### PR TITLE
Remove default status tests

### DIFF
--- a/src/Albany_SolverFactory.cpp
+++ b/src/Albany_SolverFactory.cpp
@@ -294,20 +294,6 @@ setSolverParamDefaults(Teuchos::ParameterList* appParams,
   Teuchos::ParameterList& lsParams = newtonParams.sublist("Linear Solver");
   lsParams.set("Max Iterations", 43);
   lsParams.set("Tolerance", 1e-4);
-
-  // Sublist for status tests
-  Teuchos::ParameterList& statusParams = noxParams.sublist("Status Tests");
-  statusParams.set("Test Type", "Combo");
-  statusParams.set("Combo Type", "OR");
-  statusParams.set("Number of Tests", 2);
-  Teuchos::ParameterList& normF = statusParams.sublist("Test 0");
-  normF.set("Test Type", "NormF");
-  normF.set("Tolerance", 1.0e-8);
-  normF.set("Norm Type", "Two Norm");
-  normF.set("Scale Type", "Unscaled");
-  Teuchos::ParameterList& maxiters = statusParams.sublist("Test 1");
-  maxiters.set("Test Type", "MaxIters");
-  maxiters.set("Maximum Iterations", 10);
 }
 
 Teuchos::RCP<const Teuchos::ParameterList>

--- a/tests/small/ContinuationHeat1D/input.yaml
+++ b/tests/small/ContinuationHeat1D/input.yaml
@@ -55,6 +55,18 @@ ANONYMOUS:
       Step Size: 
         Initial Step Size: 1.00000000000000006e-01
     NOX: 
+      Status Tests:
+        Test Type: Combo
+        Combo Type: OR
+        Number of Tests: 2
+        Test 0:
+          Test Type: NormF
+          Tolerance: 1.0e-8
+          Norm Type: Two Norm
+          Scale Type: Unscaled
+        Test 1:
+          Test Type: MaxIters
+          Maximum Iterations: 10
       Direction: 
         Method: Newton
         Newton: 

--- a/tests/small/ContinuationHeat1D/inputT.yaml
+++ b/tests/small/ContinuationHeat1D/inputT.yaml
@@ -54,6 +54,18 @@ ANONYMOUS:
       Step Size: 
         Initial Step Size: 1.00000000000000006e-01
     NOX: 
+      Status Tests:
+        Test Type: Combo
+        Combo Type: OR
+        Number of Tests: 2
+        Test 0:
+          Test Type: NormF
+          Tolerance: 1.0e-8
+          Norm Type: Two Norm
+          Scale Type: Unscaled
+        Test 1:
+          Test Type: MaxIters
+          Maximum Iterations: 10
       Direction: 
         Method: Newton
         Newton: 

--- a/tests/small/HeatEigenvalues/input.yaml
+++ b/tests/small/HeatEigenvalues/input.yaml
@@ -58,6 +58,18 @@ ANONYMOUS:
       Step Size: 
         Initial Step Size: 1.00000000000000000e+00
     NOX: 
+      Status Tests:
+        Test Type: Combo
+        Combo Type: OR
+        Number of Tests: 2
+        Test 0:
+          Test Type: NormF
+          Tolerance: 1.0e-8
+          Norm Type: Two Norm
+          Scale Type: Unscaled
+        Test 1:
+          Test Type: MaxIters
+          Maximum Iterations: 10
       Direction: 
         Method: Newton
         Newton: 

--- a/tests/small/HeatEigenvalues/inputT.yaml
+++ b/tests/small/HeatEigenvalues/inputT.yaml
@@ -59,6 +59,18 @@ ANONYMOUS:
       Step Size: 
         Initial Step Size: 1.00000000000000000e+00
     NOX: 
+      Status Tests:
+        Test Type: Combo
+        Combo Type: OR
+        Number of Tests: 2
+        Test 0:
+          Test Type: NormF
+          Tolerance: 1.0e-8
+          Norm Type: Two Norm
+          Scale Type: Unscaled
+        Test 1:
+          Test Type: MaxIters
+          Maximum Iterations: 10
       Direction: 
         Method: Newton
         Newton: 

--- a/tests/small/Helmholtz2D/input.yaml
+++ b/tests/small/Helmholtz2D/input.yaml
@@ -66,6 +66,18 @@ ANONYMOUS:
         Initial Step Size: 2.00000000000000011e-01
         Method: Constant
     NOX:
+      Status Tests:
+        Test Type: Combo
+        Combo Type: OR
+        Number of Tests: 2
+        Test 0:
+          Test Type: NormF
+          Tolerance: 1.0e-8
+          Norm Type: Two Norm
+          Scale Type: Unscaled
+        Test 1:
+          Test Type: MaxIters
+          Maximum Iterations: 10
       Direction:
         Method: Newton
         Newton:

--- a/tests/small/Helmholtz2D/inputT.yaml
+++ b/tests/small/Helmholtz2D/inputT.yaml
@@ -66,6 +66,18 @@ ANONYMOUS:
         Initial Step Size: 2.00000000000000011e-01
         Method: Constant
     NOX:
+      Status Tests:
+        Test Type: Combo
+        Combo Type: OR
+        Number of Tests: 2
+        Test 0:
+          Test Type: NormF
+          Tolerance: 1.0e-8
+          Norm Type: Two Norm
+          Scale Type: Unscaled
+        Test 1:
+          Test Type: MaxIters
+          Maximum Iterations: 10
       Direction:
         Method: Newton
         Newton:

--- a/tests/small/LandIce/FO_GIS/input_create_exo_from_msh.yaml
+++ b/tests/small/LandIce/FO_GIS/input_create_exo_from_msh.yaml
@@ -10,3 +10,12 @@ ANONYMOUS:
     Exodus Output File Name: ./humboldt_2d.exo
     Ascii Input Mesh File Name: ../AsciiMeshes/Humboldt/albany.msh
     Use Serial Mesh: true
+  Piro:
+    NOX:
+      Status Tests:
+        Test Type: NormF
+        Tolerance: 1.0
+      Printing:
+        Output Information: 
+          Details: false
+...

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening.yaml
@@ -275,10 +275,6 @@ ANONYMOUS:
             Norm Type: Two Norm
             Scale Type: Scaled
             Tolerance: 1.00000000000000002e-08
-          Test 1:
-            Test Type: NormWRMS
-            Absolute Tolerance: 1.00000000000000008e-05
-            Relative Tolerance: 1.00000000000000002e-03
         Test 1:
           Test Type: MaxIters
           Maximum Iterations: 50

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_params.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_params.yaml
@@ -302,10 +302,6 @@ ANONYMOUS:
             Norm Type: Two Norm
             Scale Type: Scaled
             Tolerance: 9.99999999999999954e-08
-          Test 1:
-            Test Type: NormWRMS
-            Absolute Tolerance: 1.00000000000000008e-05
-            Relative Tolerance: 1.00000000000000002e-03
         Test 1:
           Test Type: MaxIters
           Maximum Iterations: 25

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_paramsT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_paramsT.yaml
@@ -302,10 +302,6 @@ ANONYMOUS:
             Norm Type: Two Norm
             Scale Type: Scaled
             Tolerance: 9.99999999999999954e-08
-          Test 1:
-            Test Type: NormWRMS
-            Absolute Tolerance: 1.00000000000000008e-05
-            Relative Tolerance: 1.00000000000000002e-03
         Test 1:
           Test Type: MaxIters
           Maximum Iterations: 25

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_populate_meshes.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_populate_meshes.yaml
@@ -67,9 +67,12 @@ ANONYMOUS:
             Vector Dim: 2
             Field Origin: File
             File Name: ../AsciiMeshes/GisUnstructFiles/velocity_RMS.ascii
-  Piro: 
-    NOX: 
-      Printing: 
-        Output Information: 
+  Piro:
+    NOX:
+      Status Tests:
+        Test Type: NormF
+        Tolerance: 1.0
+      Printing:
+        Output Information:
           Details: false
 ...

--- a/tests/small/LandIce/SHMIP/input_bueler_steady.yaml
+++ b/tests/small/LandIce/SHMIP/input_bueler_steady.yaml
@@ -153,10 +153,6 @@ ANONYMOUS:
           Norm Type: Two Norm
           Scale Type: Unscaled
           Tolerance: 1.0e-02
-        Test 2: 
-          Test Type: NormWRMS
-          Absolute Tolerance: 1.0e-04
-          Relative Tolerance: 1.0e-03
       Nonlinear Solver: Line Search Based
       Direction: 
         Method: Newton

--- a/tests/small/LandIce/SHMIP/input_bueler_unsteady.yaml
+++ b/tests/small/LandIce/SHMIP/input_bueler_unsteady.yaml
@@ -173,10 +173,6 @@ ANONYMOUS:
                 Norm Type: Two Norm
                 Scale Type: Unscaled
                 Tolerance: 1.0e-8
-              Test 2: 
-                Test Type: NormWRMS
-                Absolute Tolerance: 1.0e-04
-                Relative Tolerance: 1.0e-03
             Nonlinear Solver: Line Search Based
             Direction: 
               Method: Newton

--- a/tests/small/LandIce/SHMIP/input_hewitt.yaml
+++ b/tests/small/LandIce/SHMIP/input_hewitt.yaml
@@ -159,10 +159,6 @@ ANONYMOUS:
           Norm Type: Two Norm
           Scale Type: Unscaled
           Tolerance: 1.0e-03
-        Test 2: 
-          Test Type: NormWRMS
-          Absolute Tolerance: 1.0e-04
-          Relative Tolerance: 1.0e-03
       Nonlinear Solver: Line Search Based
       Direction: 
         Method: Newton

--- a/tests/small/LandIce/SHMIP/input_suite_A1.yaml
+++ b/tests/small/LandIce/SHMIP/input_suite_A1.yaml
@@ -156,10 +156,6 @@ ANONYMOUS:
           Norm Type: Two Norm
           Scale Type: Unscaled
           Tolerance: 1.0e-02
-        Test 2: 
-          Test Type: NormWRMS
-          Absolute Tolerance: 1.0e-04
-          Relative Tolerance: 1.0e-03
       Nonlinear Solver: Line Search Based
       Direction: 
         Method: Newton

--- a/tests/small/LandIce/SHMIP/input_suite_A2.yaml
+++ b/tests/small/LandIce/SHMIP/input_suite_A2.yaml
@@ -156,10 +156,6 @@ ANONYMOUS:
           Norm Type: Two Norm
           Scale Type: Unscaled
           Tolerance: 1.0e-02
-        Test 2: 
-          Test Type: NormWRMS
-          Absolute Tolerance: 1.0e-04
-          Relative Tolerance: 1.0e-03
       Nonlinear Solver: Line Search Based
       Direction: 
         Method: Newton

--- a/tests/small/LandIce/SHMIP/input_suite_A3.yaml
+++ b/tests/small/LandIce/SHMIP/input_suite_A3.yaml
@@ -156,10 +156,6 @@ ANONYMOUS:
           Norm Type: Two Norm
           Scale Type: Unscaled
           Tolerance: 1.0e-02
-        Test 2: 
-          Test Type: NormWRMS
-          Absolute Tolerance: 1.0e-04
-          Relative Tolerance: 1.0e-03
       Nonlinear Solver: Line Search Based
       Direction: 
         Method: Newton

--- a/tests/small/LandIce/SHMIP/input_suite_A4.yaml
+++ b/tests/small/LandIce/SHMIP/input_suite_A4.yaml
@@ -156,10 +156,6 @@ ANONYMOUS:
           Norm Type: Two Norm
           Scale Type: Unscaled
           Tolerance: 1.0e-02
-        Test 2: 
-          Test Type: NormWRMS
-          Absolute Tolerance: 1.0e-04
-          Relative Tolerance: 1.0e-03
       Nonlinear Solver: Line Search Based
       Direction: 
         Method: Newton

--- a/tests/small/LandIce/SHMIP/input_suite_A5.yaml
+++ b/tests/small/LandIce/SHMIP/input_suite_A5.yaml
@@ -156,10 +156,6 @@ ANONYMOUS:
           Norm Type: Two Norm
           Scale Type: Unscaled
           Tolerance: 1.0e-02
-        Test 2: 
-          Test Type: NormWRMS
-          Absolute Tolerance: 1.0e-04
-          Relative Tolerance: 1.0e-03
       Nonlinear Solver: Line Search Based
       Direction: 
         Method: Newton

--- a/tests/small/Utils/input_populate_mesh.yaml
+++ b/tests/small/Utils/input_populate_mesh.yaml
@@ -36,9 +36,12 @@ ANONYMOUS:
         Field Type: Node Scalar
         Field Origin: File
         Random Value: ['true']
-  Piro: 
-    NOX: 
-      Printing: 
+  Piro:
+    NOX:
+      Status Tests:
+        Test Type: NormF
+        Tolerance: 1.0
+      Printing:
         Output Information: 
           Details: false
 ...

--- a/tests/small/Utils/input_populate_mesh_expr_eval.yaml
+++ b/tests/small/Utils/input_populate_mesh_expr_eval.yaml
@@ -42,9 +42,12 @@ ANONYMOUS:
         Field Origin: File
         Vector Dim: 2
         Field Expression: ['a=1.1', 'b=2.1', 'c=3.1', 'a*x^2+b*y^2+c', 'a*sin(x*b)*cos(y*c)']
-  Piro: 
-    NOX: 
-      Printing: 
+  Piro:
+    NOX:
+      Status Tests:
+        Test Type: NormF
+        Tolerance: 1.0
+      Printing:
         Output Information: 
           Details: false
 ...


### PR DESCRIPTION
NOX requires well formed status tests and the current default status tests causes issues. see #742

@mperego @ikalash This fixes all tests. There were only a few tests which require the default. One notable case is populate mesh. If you have populate mesh input files which don't specify an exit tolerance, NOX will attempt to use some default epetra preconditioner and crash if Tpetra is used as the build type. We may want to look into that issue further. I'm not sure why there's a default preconditioner.